### PR TITLE
Compute bounding polygon for a geocoded grid (MCR #90132)

### DIFF
--- a/python/packages/isce3/geometry/__init__.py
+++ b/python/packages/isce3/geometry/__init__.py
@@ -1,5 +1,6 @@
 from isce3.ext.isce3.geometry import *
 from .rdr2rdr import rdr2rdr
+from .bounding_polygon import make_geo_grid_bounding_polygon
 from .bounding_radar_grid import get_bounding_radar_grid
 from .compute_incidence import (compute_incidence_angle,
                                 get_near_and_far_range_incidence_angles)

--- a/python/packages/isce3/geometry/bounding_polygon.py
+++ b/python/packages/isce3/geometry/bounding_polygon.py
@@ -1,12 +1,124 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 
 import numpy as np
+import shapely
+from numpy.typing import ArrayLike
 from osgeo import ogr
 
 import isce3
 from isce3.geometry import DEMInterpolator
+
+Point2D = tuple[float, float]
+Point3D = tuple[float, float, float]
+
+
+def wrap_to_interval(val: float, lower: float, upper: float) -> float:
+    """
+    Wrap a value to the range [lower, upper) using modular arithmetic.
+
+    Parameters
+    ----------
+    val : float
+        Value to wrap.
+    lower : float
+        Lower endpoint of the interval (inclusive).
+    upper : float
+        Upper endpoint of the interval (exclusive). Must be > `lower`.
+
+    Returns
+    -------
+    float
+        Wrapped value in the range [lower, upper).
+    """
+    if not (upper > lower):
+        raise ValueError(f"{upper=} must be greater than {lower=}")
+
+    # Python's `%` (modulo) operator computes the remainder with the same sign as the
+    # right-hand side operand, so the result of the modulo operation below is in the
+    # range [0, b-a), where b is the upper endpoint and a is the lower endpoint. Then,
+    # if we add a, the result will be in the range [a, b). See
+    # https://docs.python.org/3/reference/expressions.html#binary-arithmetic-operations.
+    return (val - lower) % (upper - lower) + lower
+
+
+def unwrap_degrees(angles: ArrayLike) -> np.ndarray:
+    """
+    Unwrap a sequence of angles in degrees.
+
+    Unwraps the input angles such that the absolute differences between adjacent
+    elements are never greater than 180 degrees by adding a multiple of 360 degrees to
+    each element.
+
+    Parameters
+    ----------
+    angles : array_like
+        The input sequence of angles, in degrees.
+
+    Returns
+    -------
+    numpy.ndarray
+        The unwrapped angles, in degrees.
+    """
+    # `numpy.unwrap` doesn't correctly unwrap inputs in degrees prior to NumPy 1.21.0.
+    # See https://github.com/numpy/numpy/pull/16987.
+    # ISCE3 currently supports NumPy >=1.20.
+    return np.rad2deg(np.unwrap(np.deg2rad(angles)))
+
+
+def unwrap_longitudes(llhs: Iterable[Point3D]) -> Iterator[Point3D]:
+    """
+    Unwrap longitude coordinates of a sequence of LLH points.
+
+    Parameters
+    ----------
+    llhs : iterable of (float, float, float)
+        An ordered series of (longitude, latitude, height) triplets, with longitudes
+        specified in degrees.
+
+    Returns
+    -------
+    iterator of (float, float, float)
+        An iterator over the input sequence with longitude values unwrapped. The order
+        of the points is preserved.
+    """
+    lons, lats, heights = map(list, zip(*llhs))
+    return zip(unwrap_degrees(lons), lats, heights)
+
+
+def create_ogr_polygon(
+    exterior_vertices: Iterable[Point2D] | Iterable[Point3D],
+) -> ogr.Geometry:
+    """
+    Create a polygon with the specified exterior vertices as an OGR Geometry object.
+
+    Parameters
+    ----------
+    exterior_vertices : iterable of (float, float) or iterable of (float, float, float)
+        The vertices of the exterior boundary of the polygon. An ordered series of 2D or
+        3D points. The final point should not be identical to the first -- the boundary
+        ring will be automatically closed.
+
+    Returns
+    -------
+    osgeo.ogr.Geometry
+        The output polygon.
+    """
+    # Create the exterior ring of the polygon.
+    ring = ogr.Geometry(ogr.wkbLinearRing)
+    for vertex in exterior_vertices:
+        ring.AddPoint(*vertex)
+
+    # Ensure the ring is closed by appending the first vertex to the end of the list of
+    # points in the ring.
+    ring.CloseRings()
+
+    # Create the output polygon object.
+    polygon = ogr.Geometry(ogr.wkbPolygon)
+    polygon.AddGeometry(ring)
+
+    return polygon
 
 
 def make_geo_grid_bounding_polygon(
@@ -19,16 +131,17 @@ def make_geo_grid_bounding_polygon(
     Get the perimeter of a geocoded grid as an LLH polygon.
 
     Construct a polygon whose corners consist of (longitude, latitude, height) points
-    sampled along the perimeter of `geo_grid`. The polygon has counterclockwise
-    orientation (in the native coordinates of `geo_grid`), starting from the upper-left
-    corner of the grid.
+    sampled along the perimeter of `geo_grid`.
+
+    The polygon is convex with counterclockwise winding order on the ellipsoid. The
+    first boundary vertex is the upper-left corner of the grid. The polygon is closed
+    (i.e. the first and last point in the boundary are the same).
 
     In the resulting polygon, longitude and latitude coordinates are in degrees and
-    height is in meters above the reference ellipsoid of the digital elevation model
-    (DEM).
-
-    The polygon is closed (i.e. the first and last point in the polygon perimeter ring
-    are the same).
+    height is in meters above the reference ellipsoid of the input digital elevation
+    model (DEM). Longitude values are in the range [-180, 180], except that they may
+    extend outside this range in the case where `geo_grid` spans the antimeridian.
+    Latitude values are in the range [-90, 90].
 
     Parameters
     ----------
@@ -58,6 +171,32 @@ def make_geo_grid_bounding_polygon(
     # `geo_grid`.
     proj = isce3.core.make_projection(geo_grid.epsg)
 
+    # Convert an (x, y) point in projected coordinates to an LLH point on the DEM
+    # surface.
+    def xy_to_llh(x: float, y: float) -> Point3D:
+        # Transform from projected coordinates to geodetic coordinates.
+        # XXX: `ProjectionBase.inverse()` doesn't necessarily guarantee that the
+        # resulting longitude is in [-pi, pi] or that the resulting latitude is in
+        # [-pi/2, pi/2].
+        lon_rad, lat_rad, _ = proj.inverse((x, y, 0.0))
+        lon_rad = wrap_to_interval(lon_rad, lower=-np.pi, upper=np.pi)
+        if not (-0.5 * np.pi <= lat_rad <= 0.5 * np.pi):
+            raise ValueError(
+                "geo_grid latitude coordinates must be within the interval"
+                f" [-pi/2, pi/2], got latitude={lat_rad} (radians)"
+            )
+
+        # Interpolate the DEM height. In general, the DEM grid may be in a different
+        # coordinate system than the input (x, y) points, so use `interpolate_lonlat()`,
+        # which internally converts (lon, lat) points to the native DEM coordinates,
+        # instead of `interpolate_xy()`.
+        height = dem.interpolate_lonlat(lon_rad, lat_rad)
+
+        # Convert to degrees.
+        lon_deg, lat_deg = np.rad2deg((lon_rad, lat_rad))
+
+        return lon_deg, lat_deg, height
+
     # The transformation from projected coordinates to LLH coordinates is not affine in
     # general, so it's not sufficient to just use the four corners of `geo_grid` as the
     # corners of the bounding polygon -- we need to ensure that the entire perimeter of
@@ -67,7 +206,7 @@ def make_geo_grid_bounding_polygon(
 
     # Yield (x, y) points sampled uniformly along the perimeter of `geo_grid` in native
     # coordinates, in counterclockwise order, starting from the upper-left corner.
-    def boundary_pts() -> Iterator[tuple[float, float]]:
+    def boundary_pts() -> Iterator[Point2D]:
         # Get x & y coordinates uniformly sampled along the extents of the `geo_grid`.
         xcoords = np.linspace(geo_grid.start_x, geo_grid.end_x, num=pts_per_edge)
         ycoords = np.linspace(geo_grid.start_y, geo_grid.end_y, num=pts_per_edge)
@@ -92,20 +231,31 @@ def make_geo_grid_bounding_polygon(
         for x in xcoords[1:-1][::-1]:
             yield x, y0
 
-    # Create a ring of LLH points sampled along the perimeter of `geo_grid`.
-    ring = ogr.Geometry(ogr.wkbLinearRing)
-    for x, y in boundary_pts():
-        lon_rad, lat_rad, _ = proj.inverse((x, y, 0.0))
-        height = dem.interpolate_lonlat(lon_rad, lat_rad)
-        lon_deg, lat_deg = np.rad2deg((lon_rad, lat_rad))
-        ring.AddPoint(lon_deg, lat_deg, height)
+    # Get points sampled along the perimeter of `geo_grid` in LLH coordinates. Unwrap
+    # longitude values to handle antimeridian crossings.
+    perimeter_points_llh = (xy_to_llh(x, y) for (x, y) in boundary_pts())
+    perimeter_points_llh = list(unwrap_longitudes(perimeter_points_llh))
 
-    # Ensure the ring is closed by appending the first point to the end of the list of
-    # points in the ring.
-    ring.CloseRings()
+    # Construct a `LinearRing` from the perimeter points so we can ensure that the
+    # output polygon is simple (i.e. not self-intersecting) and has the correct winding
+    # order.
+    ring = shapely.LinearRing(perimeter_points_llh)
 
-    # Create the output polygon object.
-    polygon = ogr.Geometry(ogr.wkbPolygon)
-    polygon.AddGeometry(ring)
+    # Check that the exterior of the polygon is a valid LinearRing (that is, it does not
+    # cross or touch itself). This could happen, for example, if `geo_grid` extends
+    # beyond +/-90 degrees latitude, which might result in a self-intersecting shape on
+    # the ellipsoid (see
+    # https://github.com/isce-framework/isce3/pull/35#discussion_r2178276599).
+    if not ring.is_valid:
+        raise RuntimeError("polygon boundary is invalid")
 
-    return polygon
+    # Ensure that the polygon has counterclockwise (CCW) winding order on the ellipsoid.
+    # Reverse the order of points along the exterior boundary if necessary. This could
+    # happen, for example, if the geo grid orientation is not north-up/west-left, or if
+    # the projection doesn't preserve the north-south ordering and east-west ordering of
+    # the points.
+    if not ring.is_ccw:
+        perimeter_points_llh = perimeter_points_llh[::-1]
+        assert shapely.LinearRing(perimeter_points_llh).is_ccw
+
+    return create_ogr_polygon(perimeter_points_llh)

--- a/python/packages/isce3/geometry/bounding_polygon.py
+++ b/python/packages/isce3/geometry/bounding_polygon.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import numpy as np
+from osgeo import ogr
+
+import isce3
+from isce3.geometry import DEMInterpolator
+
+
+def make_geo_grid_bounding_polygon(
+    geo_grid: isce3.product.GeoGridParameters,
+    dem: DEMInterpolator = DEMInterpolator(),
+    *,
+    pts_per_edge: int = 11,
+) -> ogr.Geometry:
+    """
+    Get the perimeter of a geocoded grid as an LLH polygon.
+
+    Construct a polygon whose corners consist of (longitude, latitude, height) points
+    sampled along the perimeter of `geo_grid`. The polygon has counterclockwise
+    orientation (in the native coordinates of `geo_grid`), starting from the upper-left
+    corner of the grid.
+
+    In the resulting polygon, longitude and latitude coordinates are in degrees and
+    height is in meters above the reference ellipsoid of the digital elevation model
+    (DEM).
+
+    The polygon is closed (i.e. the first and last point in the polygon perimeter ring
+    are the same).
+
+    Parameters
+    ----------
+    geo_grid : isce3.product.GeoGridParameters
+        The input geocoded coordinate grid.
+    dem : isce3.geometry.DEMInterpolator, optional
+        A DEM spanning the input grid. Need not be in the same coordinate reference
+        system as `geo_grid`. Defaults to a zero-height DEM w.r.t the WGS 84 ellipsoid.
+    pts_per_edge : int, optional
+        The number of perimeter points to sample along each edge of the input
+        `geo_grid`. Must be >= 2. Defaults to 11.
+
+    Returns
+    -------
+    osgeo.ogr.Geometry
+        A polygon bounding the input geocoded grid, in geodetic coordinates.
+
+    See Also
+    --------
+    get_dem_boundary_polygon
+    get_geo_perimeter_wkt
+    """
+    if pts_per_edge < 2:
+        raise ValueError(f"{pts_per_edge = }, must be >= 2")
+
+    # Get a 'projection' object that represents the native spatial reference system of
+    # `geo_grid`.
+    proj = isce3.core.make_projection(geo_grid.epsg)
+
+    # The transformation from projected coordinates to LLH coordinates is not affine in
+    # general, so it's not sufficient to just use the four corners of `geo_grid` as the
+    # corners of the bounding polygon -- we need to ensure that the entire perimeter of
+    # `geo_grid` is contained within the polygon. As a concession to computational
+    # feasibility, we'll sample a finite number of points along each edge of `geo_grid`
+    # to form the perimeter of the output polygon.
+
+    # Yield (x, y) points sampled uniformly along the perimeter of `geo_grid` in native
+    # coordinates, in counterclockwise order, starting from the upper-left corner.
+    def boundary_pts() -> Iterator[tuple[float, float]]:
+        # Get x & y coordinates uniformly sampled along the extents of the `geo_grid`.
+        xcoords = np.linspace(geo_grid.start_x, geo_grid.end_x, num=pts_per_edge)
+        ycoords = np.linspace(geo_grid.start_y, geo_grid.end_y, num=pts_per_edge)
+
+        # Left edge from top to bottom (including both endpoints).
+        x0 = xcoords[0]
+        for y in ycoords:
+            yield x0, y
+
+        # Bottom edge from left to right (excluding the left endpoint).
+        y1 = ycoords[-1]
+        for x in xcoords[1:]:
+            yield x, y1
+
+        # Right edge from bottom to top (excluding the bottom endpoint).
+        x1 = xcoords[-1]
+        for y in ycoords[:-1][::-1]:
+            yield x1, y
+
+        # Top edge from right to left (excluding both endpoints).
+        y0 = ycoords[0]
+        for x in xcoords[1:-1][::-1]:
+            yield x, y0
+
+    # Create a ring of LLH points sampled along the perimeter of `geo_grid`.
+    ring = ogr.Geometry(ogr.wkbLinearRing)
+    for x, y in boundary_pts():
+        lon_rad, lat_rad, _ = proj.inverse((x, y, 0.0))
+        height = dem.interpolate_lonlat(lon_rad, lat_rad)
+        lon_deg, lat_deg = np.rad2deg((lon_rad, lat_rad))
+        ring.AddPoint(lon_deg, lat_deg, height)
+
+    # Ensure the ring is closed by appending the first point to the end of the list of
+    # points in the ring.
+    ring.CloseRings()
+
+    # Create the output polygon object.
+    polygon = ogr.Geometry(ogr.wkbPolygon)
+    polygon.AddGeometry(ring)
+
+    return polygon

--- a/tests/python/packages/CMakeLists.txt
+++ b/tests/python/packages/CMakeLists.txt
@@ -13,6 +13,7 @@ isce3/core/resample_block_generators.py
 isce3/focus/valid_regions.py
 isce3/focus/notch.py
 isce3/geocode/geocode_slc.py
+isce3/geometry/bounding_polygon.py
 isce3/geometry/bounding_radar_grid.py
 isce3/geometry/polygons.py
 isce3/image/resample_slc.py

--- a/tests/python/packages/isce3/geometry/bounding_polygon.py
+++ b/tests/python/packages/isce3/geometry/bounding_polygon.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import itertools
+import os
+from collections.abc import Iterator
+
+import numpy as np
+import pytest
+import shapely
+
+import isce3
+import iscetest
+from isce3.geometry import DEMInterpolator
+from isce3.io import Raster
+from isce3.product import GeoGridParameters
+
+
+def south_pole_dem() -> Raster:
+    dem_raster_path = os.path.join(iscetest.data, "dem_south_pole.tif")
+    return Raster(dem_raster_path)
+
+
+def winnipeg_dem() -> Raster:
+    dem_raster_path = os.path.join(iscetest.data, "winnipeg_dem.tif")
+    return Raster(dem_raster_path)
+
+
+def get_raster_grid(raster: isce3.io.Raster) -> GeoGridParameters:
+    """
+    Get the sample coordinate grid of the input raster.
+
+    Parameters
+    ----------
+    raster : isce3.io.Raster
+        The input raster.
+
+    Returns
+    -------
+    isce3.product.GeoGridParameters
+        The coordinate grid that the raster was sampled on.
+    """
+    return GeoGridParameters(
+        start_x=raster.x0,
+        start_y=raster.y0,
+        spacing_x=raster.dx,
+        spacing_y=raster.dy,
+        width=raster.width,
+        length=raster.length,
+        epsg=raster.get_epsg(),
+    )
+
+
+def get_xy_coords(geo_grid: GeoGridParameters) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Get the set of x and y coordinates of the input geocoded grid.
+
+    Parameters
+    ----------
+    geo_grid : isce3.product.GeoGridParameters
+        The input geocoded coordinate grid.
+
+    Returns
+    -------
+    x_coords, y_coords : numpy.ndarray
+        The x and y coordinates of the grid.
+    """
+    x_start = geo_grid.start_x
+    y_start = geo_grid.start_y
+    x_spacing = geo_grid.spacing_x
+    y_spacing = geo_grid.spacing_y
+
+    x_coords = x_start + (0.5 * x_spacing) + x_spacing * np.arange(geo_grid.width)
+    y_coords = y_start + (0.5 * y_spacing) + y_spacing * np.arange(geo_grid.length)
+
+    return x_coords, y_coords
+
+
+def iter_geo_grid_llh_points(
+    geo_grid: GeoGridParameters,
+    dem: DEMInterpolator,
+    *,
+    step: int = 1,
+) -> Iterator[shapely.Point]:
+    """
+    Iterate over points within a geocoded grid in LLH coordinates.
+
+    Parameters
+    ----------
+    geo_grid : isce3.product.GeoGridParameters
+        The input geocoded coordinate grid.
+    dem : isce3.geometry.DEMInterpolator
+        A DEM spanning the input grid.
+    step : int, optional
+        The stride between consecutive elements. Defaults to 1.
+
+    Yields
+    ------
+    shapely.Point
+        A point within the grid, in geodetic coordinates (longitude, latitude, height).
+        Longitude and latitude coordinates are specified in degrees. Height is in meters
+        w.r.t the vertical datum of the input `dem`.
+    """
+    x_coords, y_coords = get_xy_coords(geo_grid)
+    proj = isce3.core.make_projection(geo_grid.epsg)
+    xy_points = itertools.product(x_coords, y_coords)
+    for x, y in itertools.islice(xy_points, None, None, step):
+        height = dem.interpolate_xy(x, y)
+        lon_rad, lat_rad, _ = proj.inverse((x, y, 0.0))
+        lon_deg, lat_deg = np.rad2deg((lon_rad, lat_rad))
+        yield shapely.Point(lon_deg, lat_deg, height)
+
+
+class TestMakeGeoGridBoundingPolygon:
+    @pytest.mark.parametrize("dem_raster", [south_pole_dem(), winnipeg_dem()])
+    def test_contains_geo_grid(self, dem_raster: Raster):
+        geo_grid = get_raster_grid(dem_raster)
+        dem = DEMInterpolator(dem_raster)
+
+        ogr_polygon = isce3.geometry.make_geo_grid_bounding_polygon(
+            geo_grid,
+            dem,
+            pts_per_edge=101,
+        )
+        polygon = shapely.wkt.loads(ogr_polygon.ExportToWkt())
+
+        # Iterate over every 10th point in `geo_grid` in LLH coordinates.
+        llh_points = iter_geo_grid_llh_points(geo_grid, dem, step=10)
+
+        assert all(polygon.contains(llh) for llh in llh_points)
+
+    @pytest.mark.parametrize("dem_raster", [south_pole_dem(), winnipeg_dem()])
+    def test_counter_clockwise(self, dem_raster: Raster):
+        geo_grid = get_raster_grid(dem_raster)
+        dem = DEMInterpolator(dem_raster)
+
+        ogr_polygon = isce3.geometry.make_geo_grid_bounding_polygon(geo_grid, dem)
+        polygon = shapely.wkt.loads(ogr_polygon.ExportToWkt())
+
+        assert shapely.is_ccw(polygon.boundary)
+
+    @pytest.mark.parametrize("pts_per_edge", [2, 11])
+    def test_num_points(self, pts_per_edge: int):
+        dem_raster = south_pole_dem()
+        geo_grid = get_raster_grid(dem_raster)
+        dem = DEMInterpolator(dem_raster)
+
+        ogr_polygon = isce3.geometry.make_geo_grid_bounding_polygon(
+            geo_grid,
+            dem,
+            pts_per_edge=pts_per_edge,
+        )
+        polygon = shapely.wkt.loads(ogr_polygon.ExportToWkt())
+
+        n = len(polygon.exterior.coords)
+        assert n == (4 * pts_per_edge - 3)
+
+    def test_bad_pts_per_edge(self):
+        dem_raster = south_pole_dem()
+        geo_grid = get_raster_grid(dem_raster)
+        dem = DEMInterpolator(dem_raster)
+
+        with pytest.raises(ValueError, match="^pts_per_edge = 1, must be >= 2$"):
+            isce3.geometry.make_geo_grid_bounding_polygon(
+                geo_grid,
+                dem,
+                pts_per_edge=1,
+            )

--- a/tests/python/packages/isce3/geometry/bounding_polygon.py
+++ b/tests/python/packages/isce3/geometry/bounding_polygon.py
@@ -11,18 +11,17 @@ import shapely
 import isce3
 import iscetest
 from isce3.geometry import DEMInterpolator
+from isce3.geometry.bounding_polygon import wrap_to_interval
 from isce3.io import Raster
 from isce3.product import GeoGridParameters
 
 
-def south_pole_dem() -> Raster:
-    dem_raster_path = os.path.join(iscetest.data, "dem_south_pole.tif")
-    return Raster(dem_raster_path)
-
-
-def winnipeg_dem() -> Raster:
-    dem_raster_path = os.path.join(iscetest.data, "winnipeg_dem.tif")
-    return Raster(dem_raster_path)
+def test_wrap_to_interval():
+    assert np.isclose(wrap_to_interval(-181.0, lower=-180.0, upper=180.0), 179.0)
+    assert np.isclose(wrap_to_interval(2 * np.pi, lower=-np.pi, upper=np.pi), 0.0)
+    assert np.isclose(wrap_to_interval(np.pi / 2, lower=-np.pi, upper=np.pi), np.pi / 2)
+    assert np.isclose(wrap_to_interval(0.0, lower=1.0, upper=10.0), 9.0)
+    assert np.isclose(wrap_to_interval(11.0, lower=1.0, upper=10.0), 2.0)
 
 
 def get_raster_grid(raster: isce3.io.Raster) -> GeoGridParameters:
@@ -48,6 +47,55 @@ def get_raster_grid(raster: isce3.io.Raster) -> GeoGridParameters:
         length=raster.length,
         epsg=raster.get_epsg(),
     )
+
+
+def winnipeg() -> tuple[GeoGridParameters, DEMInterpolator]:
+    dem_raster_path = os.path.join(iscetest.data, "winnipeg_dem.tif")
+    dem_raster = Raster(dem_raster_path)
+    geo_grid = get_raster_grid(dem_raster)
+    dem = DEMInterpolator(dem_raster)
+    return geo_grid, dem
+
+
+def south_pole() -> tuple[GeoGridParameters, DEMInterpolator]:
+    dem_raster_path = os.path.join(iscetest.data, "dem_south_pole.tif")
+    dem_raster = Raster(dem_raster_path)
+    geo_grid = get_raster_grid(dem_raster)
+    dem = DEMInterpolator(dem_raster)
+    return geo_grid, dem
+
+
+def antimeridian() -> tuple[GeoGridParameters, DEMInterpolator]:
+    # A geodetic coordinate grid that spans the antimeridian and the equator.
+    geo_grid = GeoGridParameters(
+        start_x=179.0,
+        start_y=1.0,
+        spacing_x=0.01,
+        spacing_y=-0.01,
+        width=201,
+        length=201,
+        epsg=4326,
+    )
+    dem = DEMInterpolator()
+    return geo_grid, dem
+
+
+def north_down() -> tuple[GeoGridParameters, DEMInterpolator]:
+    # A UTM coordinate grid with the Y axis flipped relative to the usual
+    # north-up/west-left orientation. A counterclockwise ring in pixel coordinates on
+    # the grid will be clockwise in map coordinates.
+    geo_grid = GeoGridParameters(
+        start_x=0.0,
+        start_y=0.0,
+        spacing_x=10.0,
+        spacing_y=-10.0,
+        width=1001,
+        length=1001,
+        epsg=32611,
+    )
+    geo_grid.spacing_y = 10.0  # Eww, gross!
+    dem = DEMInterpolator()
+    return geo_grid, dem
 
 
 def get_xy_coords(geo_grid: GeoGridParameters) -> tuple[np.ndarray, np.ndarray]:
@@ -111,11 +159,10 @@ def iter_geo_grid_llh_points(
 
 
 class TestMakeGeoGridBoundingPolygon:
-    @pytest.mark.parametrize("dem_raster", [south_pole_dem(), winnipeg_dem()])
-    def test_contains_geo_grid(self, dem_raster: Raster):
-        geo_grid = get_raster_grid(dem_raster)
-        dem = DEMInterpolator(dem_raster)
-
+    @pytest.mark.parametrize(
+        "geo_grid,dem", [winnipeg(), south_pole(), antimeridian(), north_down()]
+    )
+    def test_contains_geo_grid(self, geo_grid: GeoGridParameters, dem: DEMInterpolator):
         ogr_polygon = isce3.geometry.make_geo_grid_bounding_polygon(
             geo_grid,
             dem,
@@ -128,21 +175,39 @@ class TestMakeGeoGridBoundingPolygon:
 
         assert all(polygon.contains(llh) for llh in llh_points)
 
-    @pytest.mark.parametrize("dem_raster", [south_pole_dem(), winnipeg_dem()])
-    def test_counter_clockwise(self, dem_raster: Raster):
-        geo_grid = get_raster_grid(dem_raster)
-        dem = DEMInterpolator(dem_raster)
-
+    @pytest.mark.parametrize(
+        "geo_grid,dem", [winnipeg(), south_pole(), antimeridian(), north_down()]
+    )
+    def test_counter_clockwise(self, geo_grid: GeoGridParameters, dem: DEMInterpolator):
         ogr_polygon = isce3.geometry.make_geo_grid_bounding_polygon(geo_grid, dem)
         polygon = shapely.wkt.loads(ogr_polygon.ExportToWkt())
-
         assert shapely.is_ccw(polygon.boundary)
+
+    def test_latitude_overflow(self):
+        # A geodetic grid with latitude coordinates extending past -90 degrees. The
+        # bounding polygon of such a grid is self-intersecting (see
+        # https://github.com/isce-framework/isce3/pull/35#discussion_r2178276599).
+        geo_grid = isce3.product.GeoGridParameters(
+            start_x=-118.0,
+            start_y=-88.0,
+            spacing_x=1.0,
+            spacing_y=-1.0,
+            width=10,
+            length=5,
+            epsg=4326,
+        )
+        dem = DEMInterpolator()
+
+        match = (
+            "^geo_grid latitude coordinates must be within the interval"
+            r" \[-pi/2, pi/2\]"
+        )
+        with pytest.raises(ValueError, match=match):
+            isce3.geometry.make_geo_grid_bounding_polygon(geo_grid, dem)
 
     @pytest.mark.parametrize("pts_per_edge", [2, 11])
     def test_num_points(self, pts_per_edge: int):
-        dem_raster = south_pole_dem()
-        geo_grid = get_raster_grid(dem_raster)
-        dem = DEMInterpolator(dem_raster)
+        geo_grid, dem = winnipeg()
 
         ogr_polygon = isce3.geometry.make_geo_grid_bounding_polygon(
             geo_grid,
@@ -155,10 +220,7 @@ class TestMakeGeoGridBoundingPolygon:
         assert n == (4 * pts_per_edge - 3)
 
     def test_bad_pts_per_edge(self):
-        dem_raster = south_pole_dem()
-        geo_grid = get_raster_grid(dem_raster)
-        dem = DEMInterpolator(dem_raster)
-
+        geo_grid, dem = winnipeg()
         with pytest.raises(ValueError, match="^pts_per_edge = 1, must be >= 2$"):
             isce3.geometry.make_geo_grid_bounding_polygon(
                 geo_grid,

--- a/tests/python/packages/isce3/geometry/bounding_polygon.py
+++ b/tests/python/packages/isce3/geometry/bounding_polygon.py
@@ -50,6 +50,7 @@ def get_raster_grid(raster: isce3.io.Raster) -> GeoGridParameters:
 
 
 def winnipeg() -> tuple[GeoGridParameters, DEMInterpolator]:
+    # A DEM raster in geodetic coordinates (EPSG:4326).
     dem_raster_path = os.path.join(iscetest.data, "winnipeg_dem.tif")
     dem_raster = Raster(dem_raster_path)
     geo_grid = get_raster_grid(dem_raster)
@@ -57,7 +58,9 @@ def winnipeg() -> tuple[GeoGridParameters, DEMInterpolator]:
     return geo_grid, dem
 
 
-def south_pole() -> tuple[GeoGridParameters, DEMInterpolator]:
+def antarctica() -> tuple[GeoGridParameters, DEMInterpolator]:
+    # A DEM raster in Antarctic Polar Stereographic coordinates (EPSG:3031).
+    # Note: it does not contain the pole.
     dem_raster_path = os.path.join(iscetest.data, "dem_south_pole.tif")
     dem_raster = Raster(dem_raster_path)
     geo_grid = get_raster_grid(dem_raster)
@@ -160,7 +163,7 @@ def iter_geo_grid_llh_points(
 
 class TestMakeGeoGridBoundingPolygon:
     @pytest.mark.parametrize(
-        "geo_grid,dem", [winnipeg(), south_pole(), antimeridian(), north_down()]
+        "geo_grid,dem", [winnipeg(), antarctica(), antimeridian(), north_down()]
     )
     def test_contains_geo_grid(self, geo_grid: GeoGridParameters, dem: DEMInterpolator):
         ogr_polygon = isce3.geometry.make_geo_grid_bounding_polygon(
@@ -176,7 +179,7 @@ class TestMakeGeoGridBoundingPolygon:
         assert all(polygon.contains(llh) for llh in llh_points)
 
     @pytest.mark.parametrize(
-        "geo_grid,dem", [winnipeg(), south_pole(), antimeridian(), north_down()]
+        "geo_grid,dem", [winnipeg(), antarctica(), antimeridian(), north_down()]
     )
     def test_counter_clockwise(self, geo_grid: GeoGridParameters, dem: DEMInterpolator):
         ogr_polygon = isce3.geometry.make_geo_grid_bounding_polygon(geo_grid, dem)


### PR DESCRIPTION
Adds a function `make_geo_grid_bounding_polygon()` that returns a polygon in geodetic coordinates that approximately encloses an input `GeoGridParameters` object. The result is an `osgeo.ogr.Geometry` object with counterclockwise orientation.

This is useful for the NISAR Static Layers product. Unlike other L2 products whose bounding polygon represents only the footprint of the swath inside the output geo grid, the bounding polygon should span the entire geo grid for Static Layers.