### PR TITLE
Compute the along-track unit vector along the ground track without the vertical component

### DIFF
--- a/cxx/isce3/geogrid/getRadarGrid.h
+++ b/cxx/isce3/geogrid/getRadarGrid.h
@@ -15,6 +15,9 @@ namespace isce3 { namespace geogrid {
  * 
  * The target-to-sensor line-of-sight (LOS) and along-track unit vectors are
  * referenced to ENU coordinates computed wrt targets.
+ * 
+ * The along-track unit vectors X and Y are computed at the target location
+ * in ENU coordinates, without the vertical component
  *
  * @param[in]  lookside                    Look side
  * @param[in]  wavelength                  Wavelength

--- a/cxx/isce3/geometry/getGeolocationGrid.h
+++ b/cxx/isce3/geometry/getGeolocationGrid.h
@@ -13,6 +13,10 @@ namespace isce3 { namespace geometry {
  *
  * The target-to-sensor line-of-sight (LOS) and along-track unit vectors are
  * referenced to ENU coordinates computed wrt targets.
+ * 
+ * The along-track unit vectors X and Y are computed at the target location
+ * in ENU coordinates, without the vertical component
+ 
  *
  * @param[in]  dem_raster                  DEM raster
  * @param[in]  radar_grid                  Radar grid

--- a/cxx/isce3/geometry/metadataCubes.cpp
+++ b/cxx/isce3/geometry/metadataCubes.cpp
@@ -258,17 +258,24 @@ void writeVectorDerivedCubes(const int array_pos_i,
     }
 
     // Compute velocity vector (ENU)
-    const isce3::core::Vec3 along_track_unit_vector =
-            xyz2enu.dot(vel_xyz).normalized();
+    const isce3::core::Vec3 along_track_vector =
+            xyz2enu.dot(vel_xyz);
+    const double horizontal_norm = std::sqrt(
+        std::pow(along_track_vector[0], 2) +
+        std::pow(along_track_vector[1], 2));
 
-    // Along-track unit vector X
+    /// Along-track unit vector X along the ground track without the vertical
+    // component
     if (along_track_unit_vector_x_raster != nullptr) {
-        along_track_unit_vector_x_array(i, j) = along_track_unit_vector[0];
+        along_track_unit_vector_x_array(i, j) =
+            along_track_vector[0] / horizontal_norm;
     }
 
-    // Along-track unit vector Y
+    // Along-track unit vector Y along the ground track without the vertical
+    // component
     if (along_track_unit_vector_y_raster != nullptr) {
-        along_track_unit_vector_y_array(i, j) = along_track_unit_vector[1];
+        along_track_unit_vector_y_array(i, j) =
+            along_track_vector[1] / horizontal_norm;
     }
 
 }

--- a/cxx/isce3/geometry/metadataCubes.h
+++ b/cxx/isce3/geometry/metadataCubes.h
@@ -110,6 +110,9 @@ void writeVectorDerivedCubes(const int array_pos_i,
  * 
  * The line-of-sight (LOS) and along-track unit vectors are referenced to
  * ENU coordinates computed wrt targets.
+ * 
+ * The along-track unit vectors X and Y are computed at the target location
+ * in ENU coordinates, without the vertical component
  *
  * @param[in]  radar_grid                  Radar grid
  * @param[in]  geogrid                     Geogrid to be
@@ -185,6 +188,9 @@ void makeRadarGridCubes(const isce3::product::RadarGridParameters& radar_grid,
  * 
  * The line-of-sight (LOS) and along-track unit vectors are referenced to
  * ENU coordinates computed wrt targets.
+ *
+ * The along-track unit vectors X and Y are computed at the target location
+ * in ENU coordinates, without the vertical component
  *
  * @param[in]  radar_grid                Cube radar grid
  * @param[in]  heights                   Cube heights

--- a/python/extensions/pybind_isce3/geogrid/getRadarGrid.cpp
+++ b/python/extensions/pybind_isce3/geogrid/getRadarGrid.cpp
@@ -40,6 +40,9 @@ void addbinding_get_radar_grid(pybind11::module& m)
              The target-to-sensor line-of-sight (LOS) and along-track unit
              vectors are referenced to ENU coordinates computed wrt targets.
 
+             The along-track unit vectors X and Y are computed at the target location
+             in ENU coordinates, without the vertical component
+
              Parameters
              ----------
              lookside : isce3.core.LookSide

--- a/python/extensions/pybind_isce3/geometry/getGeolocationGrid.cpp
+++ b/python/extensions/pybind_isce3/geometry/getGeolocationGrid.cpp
@@ -36,6 +36,9 @@ void addbinding_get_geolocation_grid(pybind11::module& m)
             The target-to-sensor line-of-sight (LOS) and along-track unit vectors are
             referenced to ENU coordinates computed wrt targets.
 
+            The along-track unit vectors X and Y are computed at the target location
+            in ENU coordinates, without the vertical component
+
         Parameters
         ----------
               dem_raster : isce3.io.Raster


### PR DESCRIPTION
This PR updates the computation of the `alongTrackUnitVectorX` and `alongTrackUnitVectorY` in the metadata cubes module by removing its vertical component.

Currently, the X and Y components of alongTrackUnitVector describe the platform's horizontal velocity in ENU computed at at the target but are derived from a 3D velocity vector that includes the vertical component. However, according to the NISAR product specifications, these fields are defined as "unit vector along ground track," which implies a horizontal-only direction. This PR aligns the code implementation with the intended definition.