### PR TITLE
Add option to compute the ground-track velocity using rdr2geo (radar grid cubes)

### DIFF
--- a/cxx/isce3/geometry/metadataCubes.cpp
+++ b/cxx/isce3/geometry/metadataCubes.cpp
@@ -288,7 +288,8 @@ void makeRadarGridCubes(const isce3::product::RadarGridParameters& radar_grid,
         isce3::io::Raster* elevation_angle_raster,
         isce3::io::Raster* ground_track_velocity_raster,
         const double threshold_geo2rdr, const int numiter_geo2rdr,
-        const double delta_range, bool flag_set_output_rasters_geolocation)
+        const double delta_range, bool flag_set_output_rasters_geolocation,
+        const bool flag_ground_velocity_from_rdr2geo)
 {
 
     pyre::journal::info_t info("isce.geometry.makeRadarGridCubes");
@@ -337,6 +338,29 @@ void makeRadarGridCubes(const isce3::product::RadarGridParameters& radar_grid,
                 getNanArray<float>(elevation_angle_raster, geogrid);
         auto ground_track_velocity_array =
                 getNanArray<double>(ground_track_velocity_raster, geogrid);
+
+        /*
+        The function `isce3::geometry::writeVectorDerivedCubes()` computes
+        ground-track velocity using a theoretical expression. It determines
+        whether to perform this computation based on the output ground-track
+        velocity raster being `nullptr` or not.
+
+        If the `flag_ground_velocity_from_rdr2geo` flag is enabled, we intend
+        to compute the ground-track velocity using the rdr2geo method
+        instead of the theoretical formula. In this case, the ground-track
+        velocity raster passed to `writeVectorDerivedCubes()` should be
+        `nullptr`.
+
+        On the other hand, if `flag_ground_velocity_from_rdr2geo` is disabled,
+        we want the theoretical method to be used, so the output ground-track
+        velocity raster should be set to `ground_track_velocity_raster`.
+        */
+        isce3::io::Raster* ground_track_velocity_theoretical_raster = nullptr;
+
+        if (!flag_ground_velocity_from_rdr2geo) {
+            ground_track_velocity_theoretical_raster = ground_track_velocity_raster;
+        }
+        isce3::geometry::DEMInterpolator dem_interpolator(height, geogrid.epsg());
 
         for (int i = 0; i < geogrid.length(); ++i) {
             double pos_y = geogrid.startY() + (0.5 + i) * geogrid.spacingY();
@@ -402,6 +426,96 @@ void makeRadarGridCubes(const isce3::product::RadarGridParameters& radar_grid,
                     continue;
                 }
 
+                // Ground-track velocity using rdr2geo
+                if (ground_track_velocity_raster != nullptr &&
+                        flag_ground_velocity_from_rdr2geo) {
+
+                        /*
+                        Get target position (target_llh) considering grid Doppler
+                        */
+                        double fd = grid_doppler.eval(azimuth_time, slant_range);
+                        
+                        Vec3 target_llh_before, target_llh_after;
+                        target_llh_before[2] = height;
+                        target_llh_after[2] = height;
+
+                        /*
+                        Compute ground-track velocity using finite differences
+                        where dt is the pulse-repetition interval (PRI), inverse
+                        of the pulse-repetition frequency (PRF)
+                        */
+                        double dt = 1.0 / radar_grid.prf();
+                        double azimuth_time_before = azimuth_time - dt / 2.0;
+                        double azimuth_time_after = azimuth_time + dt / 2.0;
+
+                        auto converged_before =
+                                rdr2geo(azimuth_time_before, slant_range, fd, orbit, ellipsoid,
+                                        dem_interpolator, target_llh_before,
+                                        radar_grid.wavelength(),
+                                        radar_grid.lookSide(), threshold_geo2rdr,
+                                        numiter_geo2rdr, delta_range);
+
+                        auto converged_after =
+                                rdr2geo(azimuth_time_after, slant_range, fd, orbit, ellipsoid,
+                                        dem_interpolator, target_llh_after,
+                                        radar_grid.wavelength(),
+                                        radar_grid.lookSide(), threshold_geo2rdr,
+                                        numiter_geo2rdr, delta_range);
+
+                        /*
+                        Since we already have the central point, we need at least one extra point
+                        that converged to a solution
+                        */
+                        if (converged_before || converged_after) {
+                            /*
+                            If the previous point didn't converge, replace it by the central point
+                            */
+                            if (!converged_before) {
+                                dt = dt / 2.0;
+                                target_llh_before = target_llh;
+                            }
+
+                            /*
+                            Otherwise, if the next point didn't converge, replace it by the central
+                            point
+                            */
+                            else if (!converged_after && converged_before) {
+                                dt = dt / 2.0;
+                                target_llh_after = target_llh;
+                            }
+
+                            /*
+                            We compute the distance between `target_xyz_after` and
+                            `target_xyz_before` and divide it by the associated time interval.
+                            This distance does not consider the Earth's curvature
+                            which should be in the order of 3mm for a 1km distance.
+                            */
+                            const isce3::core::Vec3 target_xyz_before = \
+                                ellipsoid.lonLatToXyz(target_llh_before);
+                            const isce3::core::Vec3 target_xyz_after = \
+                                ellipsoid.lonLatToXyz(target_llh_after);
+
+                            // derivative X wrt az. time
+                            double dx_dt = (target_xyz_after[0] - target_xyz_before[0]) / dt;
+
+                            // derivative Y wrt az. time
+                            double dy_dt = (target_xyz_after[1] - target_xyz_before[1]) / dt;
+
+
+                            // derivative Z wrt az. time
+                            double dz_dt = (target_xyz_after[2] - target_xyz_before[2]) / dt;
+
+                            ground_track_velocity_array(i, j) = std::sqrt(std::pow(dx_dt, 2) +
+                                                                          std::pow(dy_dt, 2) +
+                                                                          std::pow(dz_dt, 2));
+
+                        }
+                        else {
+                            ground_track_velocity_array(i, j) = std::numeric_limits<double>::quiet_NaN();
+                        }
+
+                }
+
                 isce3::geometry::writeVectorDerivedCubes(i, j,
                         native_azimuth_time, target_llh, orbit, ellipsoid,
                         incidence_angle_raster, incidence_angle_array,
@@ -413,7 +527,7 @@ void makeRadarGridCubes(const isce3::product::RadarGridParameters& radar_grid,
                         along_track_unit_vector_y_array, 
                         elevation_angle_raster,
                         elevation_angle_array,
-                        ground_track_velocity_raster,
+                        ground_track_velocity_theoretical_raster,
                         ground_track_velocity_array,
                         local_incidence_angle_raster,
                         local_incidence_angle_array,

--- a/cxx/isce3/geometry/metadataCubes.h
+++ b/cxx/isce3/geometry/metadataCubes.h
@@ -141,10 +141,11 @@ void writeVectorDerivedCubes(const int array_pos_i,
  * derivative of doppler
  * @param[in]  flag_set_output_rasters_geolocation Set output rasters'
  * geotransform and spatial reference
- * @param[in] flag_ground_velocity_from_rdr2geo Compute ground-track
- * velocity based on estimated distance between two points on ground
- * along the azimuth direction (`rdr2geo` method), instead of applying a
- * theoretical expression
+ * @param[in] flag_ground_velocity_from_rdr2geo When true, compute ground-track
+ * velocity using a finite-difference approximation between grid locations in
+ * the azimuth direction (`rdr2geo` method). In this case, the azimuth spacing
+ * of the grid affects the accuracy of the approximation. When false, use a
+ * closed-form expression for a geocentric spherical surface model instead.
  */
 void makeRadarGridCubes(const isce3::product::RadarGridParameters& radar_grid,
         const isce3::product::GeoGridParameters& geogrid,

--- a/cxx/isce3/geometry/metadataCubes.h
+++ b/cxx/isce3/geometry/metadataCubes.h
@@ -141,6 +141,10 @@ void writeVectorDerivedCubes(const int array_pos_i,
  * derivative of doppler
  * @param[in]  flag_set_output_rasters_geolocation Set output rasters'
  * geotransform and spatial reference
+ * @param[in] flag_ground_velocity_from_rdr2geo Compute ground-track
+ * velocity based on estimated distance between two points on ground
+ * along the azimuth direction (`rdr2geo` method), instead of applying a
+ * theoretical expression
  */
 void makeRadarGridCubes(const isce3::product::RadarGridParameters& radar_grid,
         const isce3::product::GeoGridParameters& geogrid,
@@ -158,7 +162,8 @@ void makeRadarGridCubes(const isce3::product::RadarGridParameters& radar_grid,
         isce3::io::Raster* ground_track_velocity_raster = nullptr,
         const double threshold_geo2rdr = 1e-8, const int numiter_geo2rdr = 100,
         const double delta_range = 1e-8,
-        bool flag_set_output_rasters_geolocation = false);
+        bool flag_set_output_rasters_geolocation = false,
+        const bool flag_ground_velocity_from_rdr2geo = true);
 
 /** Make metadata geolocation grid cubes
  *

--- a/python/extensions/pybind_isce3/geometry/metadataCubes.cpp
+++ b/python/extensions/pybind_isce3/geometry/metadataCubes.cpp
@@ -30,6 +30,7 @@ void addbinding_metadata_cubes(py::module & m)
             py::arg("numiter_geo2rdr") = defaults.maxiter,
             py::arg("delta_range") = defaults.delta_range,
             py::arg("flag_set_output_rasters_geolocation") = false,
+            py::arg("flag_ground_velocity_from_rdr2geo") = true,
             R"(Make metadata radar grid cubes
 
                Metadata radar grid cubes describe the radar geometry
@@ -96,8 +97,12 @@ void addbinding_metadata_cubes(py::module & m)
                     Step size used for computing derivative of doppler
                 flag_set_output_rasters_geolocation : bool
                     Set output rasters' geotransform and spatial reference
-
-)");
+                flag_ground_velocity_from_rdr2geo, bool, optional
+                    Compute ground-track velocity based on estimated distance
+                    between two points on ground along the azimuth direction
+                    (`rdr2geo` method), instead of applying a theoretical
+                    expression
+                    )");
 
     m.def("make_geolocation_cubes", &isce3::geometry::makeGeolocationGridCubes,
             py::arg("radar_grid"), py::arg("heights"), py::arg("orbit"),

--- a/python/extensions/pybind_isce3/geometry/metadataCubes.cpp
+++ b/python/extensions/pybind_isce3/geometry/metadataCubes.cpp
@@ -98,10 +98,12 @@ void addbinding_metadata_cubes(py::module & m)
                 flag_set_output_rasters_geolocation : bool
                     Set output rasters' geotransform and spatial reference
                 flag_ground_velocity_from_rdr2geo, bool, optional
-                    Compute ground-track velocity based on estimated distance
-                    between two points on ground along the azimuth direction
-                    (`rdr2geo` method), instead of applying a theoretical
-                    expression
+                    When True, compute ground-track velocity using a
+                    finite-difference approximation between grid locations in
+                    the azimuth direction (`rdr2geo` method). In this case, the
+                    azimuth spacing of the grid affects the accuracy of the
+                    approximation. When False, use a closed-form expression for
+                    a geocentric spherical surface model instead.
                     )");
 
     m.def("make_geolocation_cubes", &isce3::geometry::makeGeolocationGridCubes,

--- a/tests/cxx/isce3/geometry/metadata_cubes/metadata_cubes.cpp
+++ b/tests/cxx/isce3/geometry/metadata_cubes/metadata_cubes.cpp
@@ -425,6 +425,7 @@ TEST(radarGridCubeTest, testRadarGridCube)
                                                   epsg);
 
         bool flag_set_output_rasters_geolocation = true;
+        bool flag_ground_velocity_from_rdr2geo = false;
 
         // Make cubes
         std::cout << "calling makeRadarGridCubes() with geogrid EPSG:" << epsg
@@ -437,7 +438,8 @@ TEST(radarGridCubeTest, testRadarGridCube)
                 &along_track_unit_vector_y_raster, &elevation_angle_raster,
                 &ground_track_velocity_raster,
                 threshold_geo2rdr, numiter_geo2rdr, delta_range,
-                flag_set_output_rasters_geolocation);
+                flag_set_output_rasters_geolocation,
+                flag_ground_velocity_from_rdr2geo);
 
         // 1. Check geotransform and EPSG
         std::vector<isce3::io::Raster> raster_vector = {


### PR DESCRIPTION
This PR adds option to compute the ground velocity using `rdr2geo` for radar grid cubes (L2 products) in addition to the current method that uses a theoretical formula. The new method is added to the function `makeRadarGridCubes()` selected through the flag `flag_ground_velocity_from_rdr2geo`. Since the new method is believed to be more accurate, this PR also makes the `rdr2geo` the default method for computing the ground-track velocity for radar grid cubes.