### PR TITLE
Improve GCOV runconfig comments

### DIFF
--- a/python/packages/nisar/workflows/runconfig.py
+++ b/python/packages/nisar/workflows/runconfig.py
@@ -184,7 +184,8 @@ class RunConfig:
         # otherwise, check contents of freq_pols
         for freq in freq_pols.keys():
             if freq not in slc.frequencies:
-                err_str = f"Frequency {freq} invalid; not found in source frequencies."
+                err_str = (f'Requested frequency {freq} not found in input'
+                           ' product.')
                 error_channel.log(err_str)
                 raise ValueError(err_str)
 
@@ -199,7 +200,8 @@ class RunConfig:
             # check if user provided polarizations match RSLC ones
             for usr_pol in freq_pols[freq]:
                 if usr_pol not in rslc_pols:
-                    err_str = f"{usr_pol} invalid; not found in source polarizations."
+                    err_str = (f'Requested polarization {usr_pol}'
+                               ' not found in input product.')
                     error_channel.log(err_str)
                     raise ValueError(err_str)
 

--- a/share/nisar/defaults/gcov.yaml
+++ b/share/nisar/defaults/gcov.yaml
@@ -52,6 +52,7 @@ runconfig:
             # strategy works well for accessing files stored on the cloud by
             # reducing the number of high-latency REST API calls needed to read
             # datasets and their metadata.
+            # Options: "fsm", "page", "aggregate", and "none"
             fs_strategy: page
 
             # HDF5 file space page size.  Only relevant when fs_strategy="page".
@@ -68,6 +69,7 @@ runconfig:
                 compression_enabled: True
 
                 # Compression type. 'none' for no compression
+                # Options: "gzip", "lzf", and "szip"
                 compression_type: gzip
 
                 # Compression level
@@ -122,12 +124,30 @@ runconfig:
                 mantissa_nbits:
 
         primary_executable:
+            # Product type ("GCOV")
             product_type: GCOV
+
+            # Product version
             product_version: 0.1.0
+
+            # Product Digital Object Identifier (DOI). If not provided,
+            # the corresponding metadata field will be set to "(NOT SPECIFIED)".
             product_doi:
+
+            # Composite release ID (CRID). If not provided, the corresponding
+            # metadata field will be set to b'A10000'.
             composite_release_id:
+
+            # Processing center. If not provided, the corresponding metadata
+            # field will be set to "Undefined".
             processing_type:
+
+            # Processing center. If not provided, the corresponding metadata
+            # field will be set to "(NOT SPECIFIED)".
             processing_center:
+
+            # Processing center. If not provided, the metadata field 
+            # `granuleId` will be set to "(NOT SPECIFIED)".
             partial_granule_id:
 
         debug_level_group:
@@ -205,6 +225,7 @@ runconfig:
                range_looks:   1
 
             # Radiometric Terrain Correction (RTC) options
+            # Only relevant if `apply_rtc` is enabled in the `geocode` group
             rtc:
                 # Output type (defines the terrain radiometry convention for
                 # the output). Choices:
@@ -233,16 +254,16 @@ runconfig:
                 dem_upsampling: 2
 
                 # RTC area beta mode. Options:
-                # 'auto' - Default value is defined by the RTC algorithm that is being
-                #     executed, i.e., 'pixel_area' for 'algorithm_type' equal to
-                #     'bilinear_distribution' and 'projection_angle' for
-                #     'algorithm_type' equal to 'area_projection'
                 #  'pixel_area' - Estimate the beta surface reference area `A_beta`
                 #     using the pixel area, which is the product of the range spacing
                 #     by the azimuth spacing (computed using the ground velocity)
                 #  'projection_angle' - estimate the beta surface reference area `A_beta`
                 #     using the projection angle method:
                 #     `A_beta = A_sigma * cos(projection_angle)`
+                # 'auto' - Default value is defined by the RTC algorithm that is being
+                #     executed, i.e., 'pixel_area' for 'algorithm_type' equal to
+                #     'bilinear_distribution' and 'projection_angle' for
+                #     'algorithm_type' equal to 'area_projection'
                 area_beta_mode: auto
 
             # Mechanism to specify output posting and DEM
@@ -254,6 +275,7 @@ runconfig:
                 algorithm_type: area_projection
 
                 # Apply radiometric terrain correction
+                # If `False`, the entire `rtc` group is ignored.
                 apply_rtc: True
 
                 # NOT YET IMPLEMENTED (it is expected that the RSLC product already
@@ -359,7 +381,9 @@ runconfig:
                 # increase memory usage and runtime.
                 upsample_radargrid: False
 
-                # Same as input DEM if not provided.
+                # EPSG code of the output product, including GCOV terms
+                # and all metadata LUTs (excluding radar grid cubes)
+                # Defaults to the DEM EPSG code, if not provided.
                 output_epsg:
 
                 # Pixel spacing in the units of the output EPSG coordinate
@@ -380,10 +404,18 @@ runconfig:
                         x_posting:
                         y_posting:
 
-                # To control output grid in same units as output EPSG
+                # Snap-to-grid interval along the Y-direction, in same units as
+                # output EPSG `output_epsg`.
+                # This parameter aligns the output grid in the Y-direction such
+                # that its origin and spacing are rounded to the nearest
+                # multiple of `y_snap`.
                 y_snap:
 
-                # To control output grid in same units as output EPSG
+                # Snap-to-grid interval along the X-direction, in same units as
+                # output EPSG `output_epsg`.
+                # This parameter aligns the output grid in the X-direction such
+                # that its origin and spacing are rounded to the nearest
+                # multiple of `x_snap`.
                 x_snap:
 
                 # Coordinates of the top-left pixel corner,
@@ -396,8 +428,10 @@ runconfig:
                     x_abs:
 
                 # Coordinates of the bottom-right pixel corner in the
-                # output EPSG coordinate system,  before grid snapping
-                # and before adjusting to ensure alignment with pixel spacing.
+                # output EPSG coordinate system.
+                # These coordinates will be adjusted based on
+                # the provided top-left coordinate, to ensure
+                # alignment with grid snapping and pixel spacing.
                 bottom_right:
                     y_abs:
                     x_abs:
@@ -408,27 +442,44 @@ runconfig:
                 # Maximum block size in MB per thread
                 max_block_size:
 
+            # Group to define parameters for radar grid cubes.
+            # Radar grid cubes describe the radar geometry in the form of
+            # 3D data cubes. The representation as data cubes,
+            # rather than two-dimensional arrays, is used to reduce storage
+            # requirements for NISAR L2 products. This is possible because
+            # radar geometry values vary slowly in space and can be accurately
+            # captured using a low-resolution three-dimensional grid
             radar_grid_cubes:
 
-                # List of metadata cube heights, in meters
+                # List of heights (in meters) above the WGS84 ellipsoid
+                # representing metadata cube layers along the Z-direction.
                 heights:
 
-                # Same as the geocode group output_EPSG if not provided
+                # Output EPSG code for the radar grid cubes
+                # Defaults to `output_epsg` in the `geocode` group
                 output_epsg:
 
                 # Spacing between pixels, in same units as output EPSG.
-                # If not provided, spacing values will be taken from geocode group
-                # parameters.
                 # All postings/spacings must be > 0.
                 # ISCE3 output rasters always have North-up West-left orientation
+                # If not provided, coarser spacing values will be inferred
+                # based on the `output_epsg` and the DEM
                 output_posting:
                     x_posting:
                     y_posting:
 
-                # To control output grid in same units as output EPSG
+                # Snap-to-grid interval along the Y-direction, in same units as
+                # output EPSG `output_epsg`.
+                # This parameter aligns the output grid in the Y-direction such
+                # that its origin and spacing are rounded to the nearest
+                # multiple of `y_snap`.
                 y_snap:
 
-                # To control output grid in same units as output EPSG
+                # Snap-to-grid interval along the X-direction, in same units as
+                # output EPSG `output_epsg`.
+                # This parameter aligns the output grid in the X-direction such
+                # that its origin and spacing are rounded to the nearest
+                # multiple of `x_snap`.
                 x_snap:
 
                 # Coordinates of the top-left pixel corner,
@@ -441,8 +492,10 @@ runconfig:
                     x_abs:
 
                 # Coordinates of the bottom-right pixel corner in the
-                # output EPSG coordinate system,  before grid snapping
-                # and before adjusting to ensure alignment with pixel spacing.
+                # output EPSG coordinate system.
+                # These coordinates will be adjusted based on
+                # the provided top-left coordinate, to ensure
+                # alignment with grid snapping and pixel spacing.
                 bottom_right:
                     y_abs:
                     x_abs:
@@ -451,6 +504,9 @@ runconfig:
 
                 # Spacing between pixels, in same units as output EPSG.
                 # All postings/spacings must be > 0.
+                # ISCE3 output rasters always have North-up West-left orientation
+                # If not provided, coarser spacing values will be inferred
+                # based on the `output_epsg` and the DEM
                 output_posting:
                     x_posting:
                     y_posting:
@@ -459,6 +515,9 @@ runconfig:
 
                 # Spacing between pixels, in same units as output EPSG.
                 # All postings/spacings must be > 0.
+                # ISCE3 output rasters always have North-up West-left orientation
+                # If not provided, coarser spacing values will be inferred
+                # based on the `output_epsg` and the DEM
                 output_posting:
                     x_posting:
                     y_posting:
@@ -470,6 +529,7 @@ runconfig:
                 maxiter: 50
 
             # DEM interpolation method
+            # Options: "sinc", "bilinear", "bicubic", "nearest", and "biquintic"
             dem_interpolation_method: biquintic
 
             noise_correction:
@@ -483,12 +543,7 @@ runconfig:
         # to populate the output product's metadata
         ceos_analysis_ready_data:
 
-            # Data access for the source data (URL or DOI)
-            source_data_access:
-
-            # Data access for the output product (URL or DOI)
-            product_data_access:
-
+            # NOT YET IMPLEMENTED
             # Data access for the static layers product associated with the output product (URL or DOI)
             static_layers_data_access:
 

--- a/share/nisar/defaults/gcov.yaml
+++ b/share/nisar/defaults/gcov.yaml
@@ -250,7 +250,7 @@ runconfig:
                 # or inaccurate outputs.
                 rtc_min_value_db:
 
-                # RTC DEM upsampling
+                # RTC DEM upsampling factor
                 dem_upsampling: 2
 
                 # RTC area beta mode. Options:

--- a/share/nisar/defaults/gcov.yaml
+++ b/share/nisar/defaults/gcov.yaml
@@ -6,7 +6,7 @@ runconfig:
             pge_name: GCOV_L_PGE
 
         input_file_group:
-            # REQUIRED - One NISAR L1B RSLC formatted HDF5 file
+            # REQUIRED - One NISAR L1 RSLC formatted HDF5 file
             input_file_path:
 
             # REQUIRED for QA. NOT REQUIRED if only running Product SAS.
@@ -20,7 +20,8 @@ runconfig:
             # REQUIRED - Digital elevation model
             dem_file:
 
-            # OPTIONAL - Digital elevation model file description, optional
+            # Description of the digital elevation model (DEM) file  
+            # to be included in the output product metadata
             dem_file_description:
 
             # External orbit file
@@ -37,8 +38,7 @@ runconfig:
             # Directory where SAS can write temporary data
             scratch_path: .
 
-            # SAS writes output product to the following file. PGE may rename.
-            # NOTE: For R2 will need to handle mixed-mode case with multiple outputs of RSLC workflow.
+            # Output file in the HDF5 format
             sas_output_file: gcov.h5
 
             # REQUIRED for QA. NOT REQUIRED if only running Product SAS.
@@ -46,7 +46,6 @@ runconfig:
             # Defaults to './qa'
             qa_output_dir: ./qa
 
-        # Output options
         output:
 
             # HDF5 file space management strategy.  In our tests, the "page"
@@ -62,7 +61,7 @@ runconfig:
 
             # Output options for GCOV terms (e.g., HHHH, HVHV, VVVV)
             output_gcov_terms:
-                # PLACEHOLDER - Output format
+                # NOT YET IMPLEMENTED - Output format
                 format: HDF5
 
                 # Enable/disable compression of output raster
@@ -93,7 +92,7 @@ runconfig:
 
             # Output options for secondary layers (e.g., number of looks, RTC ANF)
             output_secondary_layers:
-                # PLACEHOLDER - Output format
+                # NOT YET IMPLEMENTED - Output format
                 format: HDF5
 
                 # Enable/disable compression of output raster
@@ -132,21 +131,23 @@ runconfig:
             partial_granule_id:
 
         debug_level_group:
+            # NOT YET IMPLEMENTED
             debug_switch: false
 
-        # TODO OPTIONAL - To setup type of worker
+        # NOT YET IMPLEMENTED - To setup type of worker
         worker:
-            # OPTIONAL - To prevent downloading DEM / other data automatically. Default True
+            # NOT YET IMPLEMENTED - To prevent downloading DEM / other data
+            # automatically. Default True
             internet_access: False
 
-            # OPTIONAL - To explicitly use GPU capability if available. Default False
+            # NOT YET IMPLEMENTED -  To explicitly use GPU capability if available. Default False
             gpu_enabled: False
 
-            # Index of the GPU to use for processing, optional. Defaults to the
+            # NOT YET IMPLEMENTED - Index of the GPU to use for processing. Defaults to the
             # first available CUDA device. Ignored if *gpu_enabled* is False.
             gpu_id: 0
 
-        #adt section - isce3 + pyre workflow
+        # Processing options
         processing:
             input_subset:
                 # Frequencies and polarizations to process
@@ -166,54 +167,66 @@ runconfig:
                 #         A: [HH, HV]  # process only polarizations HH and HV from frequency A
                 #         B:           # process all polarizations from frequency B
                 #
-                #
                 list_of_frequencies:
 
-                # OPTIONAL - If we want full covariance instead of diagonals only. Default False
+                # Flag indicating whether the output GCOV product should include
+                # off-diagonal covariance elements. If False, only the diagonal
+                # elements are included.
                 fullcovariance:   False
 
-                # Perform polarimetric symmetrization. It's only applicable
-                # for quad-polarimetric datasets (i.e. datasets that include
-                # HV and VH), otherwise, the flag is ignored.
-                # If enabled, the output product's "HV" dataset will contain symmetrized
-                # HV/VH data and the "VH" dataset will be omitted from the output.
+                # Flag indicating whether polarimetric symmetrization should be
+                # applied to datasets that include both HV and VH polarimetric
+                # channels. If enabled, the output product's "HV" dataset will
+                # contain symmetrized HV/VH data and the "VH" dataset will be
+                # omitted from the output. If the input data does not contain
+                # HV and VH channels, then the "symmetrize_cross_pol_channels"
+                # flag will be ignored by the workflow.
                 symmetrize_cross_pol_channels:  True
 
-            # TODO OPTIONAL - Only checked when internet access is available
+            # NOT YET IMPLEMENTED - Only checked when internet access is available
             dem_download:
-                # OPTIONAL - s3 bucket / curl URL / local file
+                # NOT YET IMPLEMENTED - s3 bucket / curl URL / local file
                 source:
                 top_left:
+                    # NOT YET IMPLEMENTED - Top-left X coordinate
                     x:
+                    # NOT YET IMPLEMENTED - Top-left Y coordinate
                     y:
                 bottom_right:
+                    # NOT YET IMPLEMENTED - Bottom-right X coordinate
                     x:
+                    # NOT YET IMPLEMENTED - Bottom-right Y coordinate
                     y:
 
-            # OPTIONAL - if amplitude data needs to be mulitlooked before GCOV generation
             pre_process:
+                # NOT YET IMPLEMENTED - Number of looks in azimuth
                azimuth_looks: 1
+                # NOT YET IMPLEMENTED - Number of looks in range
                range_looks:   1
 
-            # OPTIONAL - to control behavior of RTC module
-            # (only applicable if geocode.apply_rtc is True)
+            # Radiometric Terrain Correction (RTC) options
             rtc:
-                # OPTIONAL - Choices:
+                # Output type (defines the terrain radiometry convention for
+                # the output). Choices:
                 # "gamma0" (default)
                 # "sigma0"
                 output_type: gamma0
 
-                # OPTIONAL - Choices:
-                # "bilinear_distribution" (default)
-                # "area_projection"
+                # RTC algorithm type. Choices:
+                # "bilinear_distribution"
+                # "area_projection" (default)
                 algorithm_type: area_projection
 
-                # OPTIONAL - Choices:
+                # Input terrain radiometry convention. Choices:
                 # "beta0" (default)
                 # "sigma0"
                 input_terrain_radiometry: beta0
 
-                # OPTIONAL - Minimum RTC area factor in dB
+                # Minimum RTC area factor (in dB). Specifies the lowest
+                # allowable denominator (in dB) for dividing GCOV samples.
+                # If not set, no minimum is enforced, which may lead
+                # to divisions by very small values and result in infinite
+                # or inaccurate outputs.
                 rtc_min_value_db:
 
                 # RTC DEM upsampling
@@ -232,7 +245,7 @@ runconfig:
                 #     `A_beta = A_sigma * cos(projection_angle)`
                 area_beta_mode: auto
 
-            # OPTIONAL - Mechanism to specify output posting and DEM
+            # Mechanism to specify output posting and DEM
             geocode:
 
                 # Geocoding algorithm type. Choices "area_projection"
@@ -243,13 +256,13 @@ runconfig:
                 # Apply radiometric terrain correction
                 apply_rtc: True
 
-                # PLACEHOLDER (it is expected that the RSLC product already
+                # NOT YET IMPLEMENTED (it is expected that the RSLC product already
                 # incorporates static tropospheric delay corrections --
                 # no additional correction is currently applied)
                 # Apply dry tropospheric delay correction
                 apply_dry_tropospheric_delay_correction: False
 
-                # PLACEHOLDER (it is expected that the RSLC product already
+                # NOT YET IMPLEMENTED (it is expected that the RSLC product already
                 # incorporates static tropospheric delay corrections --
                 # no additional correction is currently applied)
                 # Apply wet tropospheric delay correction
@@ -268,13 +281,28 @@ runconfig:
                 # Apply RSLC metadata valid-samples sub-swath masking
                 apply_valid_samples_sub_swath_masking: False
 
-                # Apply shadow masking
-                apply_shadow_masking: True
+                # NOT YET IMPLEMENTED - Apply shadow masking
+                apply_shadow_masking: False
 
-                # Memory mode. Choices: "single_block", "geogrid", "geogrid_and_radargrid", and "auto" (default)
+                # Memory mode
+                # Enumeration specifying memory management strategies for
+                # geocoding operations. These modes determine how input data
+                # is loaded and processed in memory, allowing trade-offs
+                # between performance and memory usage depending on system
+                # resources. Choices:
+                # - "auto": Automatically selects the optimal memory mode
+                # based on the module's defaults.
+                # - "single_block": Disables block processing by loading
+                # and processing the entire dataset at once.
+                # - "geogrid": Enables block-wise processing over the geogrid;
+                # the full SLC is loaded once and reused for each geogrid
+                # block.
+                # - "geogrid_and_radargrid": Enables full block-wise
+                # processing over both geogrid and radar grid; the SLC is
+                # loaded in segments per geogrid block.
                 memory_mode: auto
 
-                # OPTIONAL - Processing upsampling factor applied to input geogrid
+                # Processing upsampling factor applied to input geogrid
                 geogrid_upsampling: 1
 
                 # Save the number of looks used to compute GCOV
@@ -293,44 +321,57 @@ runconfig:
                 # Save the mask layer
                 save_mask: True
 
-                # PLACEHOLDER - Save interpolated DEM used to compute GCOV
+                # NOT YET IMPLEMENTED - Save interpolated DEM used to compute GCOV
                 save_dem: False
 
-                # PLACEHOLDER - Save the layover shadow mask
+                # NOT YET IMPLEMENTED - Save the layover shadow mask
                 save_layover_shadow_mask: False
 
-                # PLACEHOLDER - Save the incidence angle
+                # NOT YET IMPLEMENTED - Save the incidence angle
                 save_incidence_angle: False
 
-                # PLACEHOLDER - Save the local-incidence angle
+                # NOT YET IMPLEMENTED - Save the local-incidence angle
                 save_local_inc_angle: False
 
-                # PLACEHOLDER - Save the projection angle
+                # NOT YET IMPLEMENTED - Save the projection angle
                 save_projection_angle: False
 
-                # PLACEHOLDER - Save the range slope angle
+                # NOT YET IMPLEMENTED - Save the range slope angle
                 save_range_slope: False
 
-                # OPTIONAL - Absolute radiometric correction
+                # Absolute radiometric calibration factor (in power or
+                # intensity units). This factor is applied to the output
+                # pixels. If the output is complex-valued,
+                # the square root of this factor is applied instead.
                 abs_rad_cal: 1
 
-                # OPTIONAL - Clip values above threshold
+                # Clip values above the threshold. If empty, no max. value
+                # clipping occurs.
                 clip_max:
 
-                # OPTIONAL - Clip values below threshold
+                # Clip values below the threshold. If empty, no min. value
+                # clipping occurs.
                 clip_min:
 
-                # OPTIONAL - Double sampling of the radar-grid
-                # input sampling in the range direction
+                # Doubles the sampling rate of the input RSLC in the range
+                # direction to reduce aliasing during covariance
+                # multiplication. Note: Enabling this may significantly
+                # increase memory usage and runtime.
                 upsample_radargrid: False
 
-                # OPTIONAL - Same as input DEM if not provided.
+                # Same as input DEM if not provided.
                 output_epsg:
 
-                # OPTIONAL - Spacing between pixels, in same units as output EPSG.
-                # If not provided, spacing values will be taken from provided DEM.
-                # All postings/spacings must be > 0.
-                # ISCE3 output rasters always have North-up West-left orientation
+                # Pixel spacing in the units of the output EPSG coordinate
+                # system (output_epsg).
+                # 
+                # If not specified and `output_epsg` differs from the DEM’s EPSG:
+                #   - Defaults to 0.00017966305682390427 degrees for geographic
+                # coordinate systems.
+                #   - Defaults to 20 meters for projected coordinate systems.
+                #
+                # If not specified and `output_epsg` matches the DEM’s EPSG,
+                # spacing will be taken from the input DEM.
                 output_posting:
                     A:
                         x_posting:
@@ -339,20 +380,24 @@ runconfig:
                         x_posting:
                         y_posting:
 
-                # OPTIONAL - To control output grid in same units as output EPSG
+                # To control output grid in same units as output EPSG
                 y_snap:
 
-                # OPTIONAL - To control output grid in same units as output EPSG
+                # To control output grid in same units as output EPSG
                 x_snap:
 
-                # OPTIONAL - Can control with absolute values or with snap values
+                # Coordinates of the top-left pixel corner,
+                # expressed in the output EPSG's coordinate
+                # system, prior to grid snapping.
                 top_left:
-                    # OPTIONAL - Set top-left y in same units as output EPSG
+                    # Set top-left y in same units as output EPSG
                     y_abs:
-                    # OPTIONAL - Set top-left x in same units as output EPSG
+                    # Set top-left x in same units as output EPSG
                     x_abs:
 
-                # OPTIONAL - Can control with absolute values or with snap values
+                # Coordinates of the bottom-right pixel corner in the
+                # output EPSG coordinate system,  before grid snapping
+                # and before adjusting to ensure alignment with pixel spacing.
                 bottom_right:
                     y_abs:
                     x_abs:
@@ -365,13 +410,13 @@ runconfig:
 
             radar_grid_cubes:
 
-                # List of heights in meters
+                # List of metadata cube heights, in meters
                 heights:
 
-                # OPTIONAL - Same as the geocode group output_epsg if not provided
+                # Same as the geocode group output_EPSG if not provided
                 output_epsg:
 
-                # OPTIONAL - Spacing between pixels, in same units as output EPSG.
+                # Spacing between pixels, in same units as output EPSG.
                 # If not provided, spacing values will be taken from geocode group
                 # parameters.
                 # All postings/spacings must be > 0.
@@ -380,27 +425,31 @@ runconfig:
                     x_posting:
                     y_posting:
 
-                # OPTIONAL - To control output grid in same units as output EPSG
+                # To control output grid in same units as output EPSG
                 y_snap:
 
-                # OPTIONAL - To control output grid in same units as output EPSG
+                # To control output grid in same units as output EPSG
                 x_snap:
 
-                # OPTIONAL - Can control with absolute values or with snap values
+                # Coordinates of the top-left pixel corner,
+                # expressed in the output EPSG's coordinate
+                # system, prior to grid snapping.
                 top_left:
-                    # OPTIONAL - Set top-left y in same units as output EPSG
+                    # Set top-left y in same units as output EPSG
                     y_abs:
-                    # OPTIONAL - Set top-left x in same units as output EPSG
+                    # Set top-left x in same units as output EPSG
                     x_abs:
 
-                # OPTIONAL - Can control with absolute values or with snap values
+                # Coordinates of the bottom-right pixel corner in the
+                # output EPSG coordinate system,  before grid snapping
+                # and before adjusting to ensure alignment with pixel spacing.
                 bottom_right:
                     y_abs:
                     x_abs:
 
             calibration_information:
 
-                # OPTIONAL - Spacing between pixels, in same units as output EPSG.
+                # Spacing between pixels, in same units as output EPSG.
                 # All postings/spacings must be > 0.
                 output_posting:
                     x_posting:
@@ -408,27 +457,29 @@ runconfig:
 
             processing_information:
 
-                # OPTIONAL - Spacing between pixels, in same units as output EPSG.
+                # Spacing between pixels, in same units as output EPSG.
                 # All postings/spacings must be > 0.
                 output_posting:
                     x_posting:
                     y_posting:
 
             geo2rdr:
+                # Convergence threshold for geo2rdr algorithm
                 threshold: 1.0e-7
+                # Maximum number of iterations
                 maxiter: 50
 
+            # DEM interpolation method
             dem_interpolation_method: biquintic
 
-            # OPTIONAL
             noise_correction:
                 # Enable/disable noise correction
                 apply_correction: False
 
-                # PLACEHOLDER
+                # NOT YET IMPLEMENTED
                 correction_type:
 
-        # OPTIONAL - Group containing CEOS Analysis Ready Data (CARD) parameters
+        # Group containing CEOS Analysis Ready Data (CARD) parameters
         # to populate the output product's metadata
         ceos_analysis_ready_data:
 

--- a/share/nisar/defaults/gslc.yaml
+++ b/share/nisar/defaults/gslc.yaml
@@ -327,12 +327,7 @@ runconfig:
         # to populate the output product's metadata
         ceos_analysis_ready_data:
 
-            # Data access for the source data (URL or DOI)
-            source_data_access:
-
-            # Data access for the output product (URL or DOI)
-            product_data_access:
-
+            # NOT YET IMPLEMENTED
             # Data access for the static layers product associated with the output product (URL or DOI)
             static_layers_data_access:
 

--- a/share/nisar/schemas/gcov.yaml
+++ b/share/nisar/schemas/gcov.yaml
@@ -32,8 +32,16 @@ runconfig:
             tec_file: str(required=False)
 
         product_path_group:
-            # Directory where PGE will place results Irrelevant to SAS.
+            # Directory where PGE will place results. Irrelevant to SAS.
             product_path: str(required=False)
+
+            # Product counter. Irrelevant to SAS.
+            # The product counter is used to version data products generated
+            # multiple times from the same SDS venue deployed. The counter
+            # starts with `001` and increments for subsequent generation of
+            # the same granule of any particular product type.
+            # This versioning is valid within an SDS venue.
+            # It is reset to `001` upon deployment of a new CRID.
             product_counter: int(min=1, max=999, required=False)
 
             # Directory where SAS can write temporary data
@@ -308,8 +316,7 @@ pre_process_options:
     range_looks: int(min=1, required=False)
 
 rtc_options:
-    # Output type (defines the terrain radiometry convention for
-    # the output)
+    # Output type (defines the terrain radiometry convention for the output
     output_type: enum('gamma0', 'sigma0', required=False)
 
     # RTC algorithm type
@@ -325,7 +332,7 @@ rtc_options:
     # or inaccurate outputs.
     rtc_min_value_db: num(required=False)
 
-    # RTC DEM upsampling
+    # RTC DEM upsampling factor
     dem_upsampling: int(min=1, required=False)
 
     # RTC area beta mode. Options:
@@ -440,7 +447,7 @@ geocode_options:
     # clipping occurs.
     clip_max: num(required=False)
 
-     # Clip values below the threshold. If empty, no min. value
+    # Clip values below the threshold. If empty, no min. value
     # clipping occurs.
     clip_min: num(required=False)
 

--- a/share/nisar/schemas/gcov.yaml
+++ b/share/nisar/schemas/gcov.yaml
@@ -33,11 +33,11 @@ runconfig:
 
         product_path_group:
             # Directory where PGE will place results Irrelevant to SAS.
-            product_path: str()
+            product_path: str(required=False)
             product_counter: int(min=1, max=999, required=False)
 
             # Directory where SAS can write temporary data
-            scratch_path: str()
+            scratch_path: str(required=False)
 
             # Output file in the HDF5 format
             sas_output_file: str()
@@ -78,6 +78,7 @@ runconfig:
             pre_process: include('pre_process_options', required=False)
 
             # Radiometric Terrain Correction (RTC) options
+            # Only relevant if `apply_rtc` is enabled in the `geocode` group
             rtc: include('rtc_options', required=False)
 
             # Geocode options: (e.g. output posting)
@@ -157,31 +158,43 @@ list_of_frequencies_options:
     B: any(list(str(min=2, max=2), min=1, max=4), str(min=2, max=2), null(), required=False)
 
 radar_grid_cubes_options:
+    # Group to define parameters for radar grid cubes.
+    # Radar grid cubes describe the radar geometry in the form of
+    # 3D data cubes. The representation as data cubes,
+    # rather than two-dimensional arrays, is used to reduce storage
+    # requirements for NISAR L2 products. This is possible because
+    # radar geometry values vary slowly in space and can be accurately
+    # captured using a low-resolution three-dimensional grid
 
-    # List of metadata cube heights, in meters
+    # List of heights (in meters) above the WGS84 ellipsoid
+    # representing metadata cube layers along the Z-direction.
     heights: list(num(), required=False)
 
-    # Same as input DEM if not provided.
+    # Output EPSG code for the radar grid cubes
+    # Defaults to `output_epsg` in the `geocode` group
     output_epsg: int(min=1024, max=32767, required=False)
 
-    # Pixel spacing in the units of the output EPSG coordinate system
-    # (output_epsg).
-    # 
-    # If not specified and `output_epsg` differs from the DEM’s EPSG:
-    #   - Defaults to 0.00017966305682390427 degrees for geographic
-    # coordinate systems.
-    #   - Defaults to 20 meters for projected coordinate systems.
-    #
-    # If not specified and `output_epsg` matches the DEM’s EPSG,
-    # spacing will be taken from the input DEM.
+    # Spacing between pixels, in same units as output EPSG.
+    # All postings/spacings must be > 0.
+    # ISCE3 output rasters always have North-up West-left orientation
+    # If not provided, coarser spacing values will be inferred
+    # based on the `output_epsg` and the DEM
     output_posting:
         x_posting: num(min=0, required=False)
         y_posting: num(min=0, required=False)
 
-    # To control output grid in same units as output EPSG
+    # Snap-to-grid interval along the X-direction, in same units as
+    # output EPSG `output_epsg`.
+    # This parameter aligns the output grid in the X-direction such
+    # that its origin and spacing are rounded to the nearest
+    # multiple of `x_snap`.
     x_snap: num(min=0, required=False)
 
-    # To control output grid in same units as output EPSG
+    # Snap-to-grid interval along the Y-direction, in same units as
+    # output EPSG `output_epsg`.
+    # This parameter aligns the output grid in the Y-direction such
+    # that its origin and spacing are rounded to the nearest
+    # multiple of `y_snap`.
     y_snap: num(min=0, required=False)
 
     # Coordinates of the top-left pixel corner,
@@ -195,8 +208,10 @@ radar_grid_cubes_options:
         x_abs: num(required=False)
 
     # Coordinates of the bottom-right pixel corner in the
-    # output EPSG coordinate system,  before grid snapping
-    # and before adjusting to ensure alignment with pixel spacing.
+    # output EPSG coordinate system.
+    # These coordinates will be adjusted based on
+    # the provided top-left coordinate, to ensure
+    # alignment with grid snapping and pixel spacing.
     bottom_right:
         # Set bottom-right y in same units as output EPSG
         y_abs: num(required=False)
@@ -206,14 +221,22 @@ radar_grid_cubes_options:
 
 calibration_information_options:
 
-    # Output posting in same units as output EPSG.
+    # Spacing between pixels, in same units as output EPSG.
+    # All postings/spacings must be > 0.
+    # ISCE3 output rasters always have North-up West-left orientation
+    # If not provided, coarser spacing values will be inferred
+    # based on the `output_epsg` and the DEM
     output_posting:
         x_posting: num(min=0, required=False)
         y_posting: num(min=0, required=False)
 
 processing_information_options:
 
-    # Output posting in same units as output EPSG.
+    # Spacing between pixels, in same units as output EPSG.
+    # All postings/spacings must be > 0.
+    # ISCE3 output rasters always have North-up West-left orientation
+    # If not provided, coarser spacing values will be inferred
+    # based on the `output_epsg` and the DEM
     output_posting:
         x_posting: num(min=0, required=False)
         y_posting: num(min=0, required=False)
@@ -306,16 +329,16 @@ rtc_options:
     dem_upsampling: int(min=1, required=False)
 
     # RTC area beta mode. Options:
-    # 'auto' - Default value is defined by the RTC algorithm that is being
-    #     executed, i.e., 'pixel_area' for 'algorithm_type' equal to
-    #     'bilinear_distribution' and 'projection_angle' for
-    #     'algorithm_type' equal to 'area_projection'
     #  'pixel_area' - Estimate the beta surface reference area `A_beta`
     #     using the pixel area, which is the product of the range spacing
     #     by the azimuth spacing (computed using the ground velocity)
     #  'projection_angle' - estimate the beta surface reference area `A_beta`
     #     using the projection angle method:
     #     `A_beta = A_sigma * cos(projection_angle)`
+    # 'auto' - Default value is defined by the RTC algorithm that is being
+    #     executed, i.e., 'pixel_area' for 'algorithm_type' equal to
+    #     'bilinear_distribution' and 'projection_angle' for
+    #     'algorithm_type' equal to 'area_projection'
     area_beta_mode: enum('auto', 'pixel_area', 'projection_angle', required=False)
 
 geocode_options:
@@ -325,6 +348,7 @@ geocode_options:
     algorithm_type: enum('area_projection', 'sinc', 'bilinear', 'bicubic', 'nearest', 'biquintic', required=False)
 
     # Apply radiometric terrain correction
+    # If `False`, the entire `rtc` group is ignored.
     apply_rtc: bool(required=False)
 
     # NOT YET IMPLEMENTED (it is expected that the RSLC product already
@@ -425,11 +449,21 @@ geocode_options:
     # Note: Enabling this may significantly increase memory usage and runtime.
     upsample_radargrid: bool(required=False)
 
-    # Same as input DEM if not provided.
+    # EPSG code of the output product, including GCOV terms
+    # and all metadata LUTs (excluding radar grid cubes)
+    # Defaults to the DEM EPSG code, if not provided.
     output_epsg: int(min=1024, max=32767, required=False)
 
-    # Output posting in same units as output EPSG.
-    # If not provided, spacing values will be taken from provided DEM.
+    # Pixel spacing in the units of the output EPSG coordinate
+    # system (output_epsg).
+    # 
+    # If not specified and `output_epsg` differs from the DEM’s EPSG:
+    #   - Defaults to 0.00017966305682390427 degrees for geographic
+    # coordinate systems.
+    #   - Defaults to 20 meters for projected coordinate systems.
+    #
+    # If not specified and `output_epsg` matches the DEM’s EPSG,
+    # spacing will be taken from the input DEM.
     output_posting:
         A:
             x_posting: num(min=0, required=False)
@@ -438,10 +472,18 @@ geocode_options:
             x_posting: num(min=0, required=False)
             y_posting: num(min=0, required=False)
 
-    # To control output grid in same units as output EPSG
+    # Snap-to-grid interval along the X-direction, in same units as
+    # output EPSG `output_epsg`.
+    # This parameter aligns the output grid in the X-direction such
+    # that its origin and spacing are rounded to the nearest
+    # multiple of `x_snap`.
     x_snap: num(min=0, required=False)
 
-    # To control output grid in same units as output EPSG
+    # Snap-to-grid interval along the Y-direction, in same units as
+    # output EPSG `output_epsg`.
+    # This parameter aligns the output grid in the Y-direction such
+    # that its origin and spacing are rounded to the nearest
+    # multiple of `y_snap`.
     y_snap: num(min=0, required=False)
 
     # Coordinates of the top-left pixel corner,
@@ -455,8 +497,10 @@ geocode_options:
         x_abs: num(required=False)
 
     # Coordinates of the bottom-right pixel corner in the
-    # output EPSG coordinate system,  before grid snapping
-    # and before adjusting to ensure alignment with pixel spacing.
+    # output EPSG coordinate system.
+    # These coordinates will be adjusted based on
+    # the provided top-left coordinate, to ensure
+    # alignment with grid snapping and pixel spacing.
     bottom_right:
         # Set bottom-right y in same units as output EPSG
         y_abs: num(required=False)
@@ -464,20 +508,25 @@ geocode_options:
         # Set bottom-right x in same units as output EPSG
         x_abs: num(required=False)
 
-    # Minimum block size in MB per thread
+    # Minimum block size per thread, in megabytes (MB).
+    # Used by the GeocodeCov (geocoding) module to determine the
+    # geogrid block allocation.
+    # It defines the smallest memory block required to process a geogrid
+    # block, accounting for the data type and the number
+    # of bands (polarizations) to process.
     min_block_size: num(min=0, required=False)
 
-    # Maximum block size in MB per thread
+    # Maximum block size per thread, in megabytes (MB).
+    # Used by the GeocodeCov (geocoding) module to limit the
+    # geogrid block allocation.
+    # It defines the upper memory limit to process a geogrid
+    # block, considering the data type and the number of bands
+    # (polarizations) to process.
     max_block_size: num(min=0, required=False)
 
 ceos_analysis_ready_data_options:
 
-    # Data access for the source data (URL or DOI)
-    source_data_access: str(required=False)
-
-    # Data access for the output product (URL or DOI)
-    product_data_access: str(required=False)
-
+    # NOT YET IMPLEMENTED
     # Data access for the static layers product associated with the output
     # product (URL or DOI)
     static_layers_data_access: str(required=False)

--- a/share/nisar/schemas/gcov.yaml
+++ b/share/nisar/schemas/gcov.yaml
@@ -6,7 +6,7 @@ runconfig:
             pge_name: enum('GCOV_L_PGE')
 
         input_file_group:
-            # REQUIRED - One NISAR L1B RSLC formatted HDF5 file
+            # REQUIRED - One NISAR L1 RSLC formatted HDF5 file
             input_file_path: str()
 
             # REQUIRED for QA. NOT REQUIRED if only running Product SAS.
@@ -20,7 +20,8 @@ runconfig:
             # REQUIRED - Digital elevation model
             dem_file: str()
 
-            # OPTIONAL - Digital elevation model file description, optional
+            # Description of the digital elevation model (DEM) file  
+            # to be included in the output product metadata
             dem_file_description: str(required=False)
 
             # External orbit file
@@ -31,16 +32,14 @@ runconfig:
             tec_file: str(required=False)
 
         product_path_group:
-            # Directory where PGE will place results
+            # Directory where PGE will place results Irrelevant to SAS.
             product_path: str()
             product_counter: int(min=1, max=999, required=False)
 
             # Directory where SAS can write temporary data
             scratch_path: str()
 
-            # Intermediate file name. SAS writes output product to the following file.
-            # After the SAS completes, the PGE wrapper renames the product file
-            # according to proper file naming conventions.
+            # Output file in the HDF5 format
             sas_output_file: str()
 
             # REQUIRED for QA. NOT REQUIRED if only running Product SAS.
@@ -64,20 +63,21 @@ runconfig:
             partial_granule_id: str(required=False)
 
         debug_level_group:
+            # NOT YET IMPLEMENTED
             debug_switch: bool()
 
-        #adt section - isce3 + pyre workflow
+        # Processing options
         processing:
             # Mechanism to select frequencies and polarizations
             input_subset: include('input_subset_options', required=False)
 
-            # DEM download options: checked only if internet access is available
+            # NOT YET IMPLEMENTED - DEM download options: checked only if internet access is available
             dem_download: include('dem_download_options', required=False)
 
-            # Pre-processing (before geocoding) options
+            # Pre-processing options
             pre_process: include('pre_process_options', required=False)
 
-            # Radiometric Terrain Correction (RTC)
+            # Radiometric Terrain Correction (RTC) options
             rtc: include('rtc_options', required=False)
 
             # Geocode options: (e.g. output posting)
@@ -92,8 +92,10 @@ runconfig:
             # Processing information options
             processing_information: include('processing_information_options', required=False)
 
+            # geo2rdr options
             geo2rdr: include('geo2rdr_options', required=False)
 
+            # DEM interpolation method
             dem_interpolation_method: enum('sinc', 'bilinear', 'bicubic', 'nearest', 'biquintic', required=False)
 
             # Noise correction options
@@ -118,29 +120,60 @@ input_subset_options:
     # List of frequencies to process. Default empty representing all
     list_of_frequencies: include('list_of_frequencies_options', required=False)
 
-    # Compute cross-elements (True) or diagonals only (False). Default: False
+    # Flag indicating whether the output GCOV product should include
+    # off-diagonal covariance elements. If False, only the diagonal
+    # elements are included.
     fullcovariance: bool(required=False)
 
-    # Perform polarimetric symmetrization. It's only applicable
-    # for quad-polarimetric datasets (i.e. datasets that include
-    # HV and VH), otherwise, the flag is ignored.
+    # Flag indicating whether polarimetric symmetrization should be
+    # applied to datasets that include both HV and VH polarimetric
+    # channels. If enabled, the output product's "HV" dataset will
+    # contain symmetrized HV/VH data and the "VH" dataset will be
+    # omitted from the output. If the input data does not contain HV
+    # and VH channels, then the "symmetrize_cross_pol_channels" flag
+    # will be ignored by the workflow.
+
     symmetrize_cross_pol_channels:  bool(required=False)
 
 list_of_frequencies_options:
-    # List of polarization channels to process. Default empty representing all
+    # Frequencies and polarizations to process
+    # Keys for frequency A and B followed by a list of polarizations to process:
+    #     {frequency}: [polarizations]
+    #
+    # - If the entire field is left empty, all available frequencies will be processed.
+    # - Otherwise, only frequencies listed (i.e, 'A' and/or 'B') will be processed.
+    # - If the [polarizations] list is empty, all available polarizations
+    # for given frequency will be processed
+    #
+    # Example 1:
+    #     list_of_frequencies:  # (empty) process all polarizations from all
+    #                           # available frequencies
+    # Example 2:
+    #     list_of_frequencies:
+    #         A: [HH, HV]  # process only polarizations HH and HV from frequency A
+    #         B:           # process all polarizations from frequency B
+    #
     A: any(list(str(min=2, max=2), min=1, max=4), str(min=2, max=2), null(), required=False)
     B: any(list(str(min=2, max=2), min=1, max=4), str(min=2, max=2), null(), required=False)
 
 radar_grid_cubes_options:
 
-    # List of heights in meters
+    # List of metadata cube heights, in meters
     heights: list(num(), required=False)
 
     # Same as input DEM if not provided.
     output_epsg: int(min=1024, max=32767, required=False)
 
-    # Output posting in same units as output EPSG.
-    # If not provided, spacing values will be taken from provided DEM.
+    # Pixel spacing in the units of the output EPSG coordinate system
+    # (output_epsg).
+    # 
+    # If not specified and `output_epsg` differs from the DEM’s EPSG:
+    #   - Defaults to 0.00017966305682390427 degrees for geographic
+    # coordinate systems.
+    #   - Defaults to 20 meters for projected coordinate systems.
+    #
+    # If not specified and `output_epsg` matches the DEM’s EPSG,
+    # spacing will be taken from the input DEM.
     output_posting:
         x_posting: num(min=0, required=False)
         y_posting: num(min=0, required=False)
@@ -151,6 +184,9 @@ radar_grid_cubes_options:
     # To control output grid in same units as output EPSG
     y_snap: num(min=0, required=False)
 
+    # Coordinates of the top-left pixel corner,
+    # expressed in the output EPSG's coordinate
+    # system, prior to grid snapping.
     top_left:
         # Set top-left y in same units as output EPSG
         y_abs: num(required=False)
@@ -158,6 +194,9 @@ radar_grid_cubes_options:
         # Set top-left x in same units as output EPSG
         x_abs: num(required=False)
 
+    # Coordinates of the bottom-right pixel corner in the
+    # output EPSG coordinate system,  before grid snapping
+    # and before adjusting to ensure alignment with pixel spacing.
     bottom_right:
         # Set bottom-right y in same units as output EPSG
         y_abs: num(required=False)
@@ -224,37 +263,43 @@ log_nfo:
     write_mode: enum('a', 'w', required=False)
 
 dem_download_options:
-    # s3 bucket / curl URL / local file
+    # NOT YET IMPLEMENTED - s3 bucket / curl URL / local file
     source: str(required=False)
     top_left:
-            # Top-left X coordinate
+            # NOT YET IMPLEMENTED - Top-left X coordinate
             x: num(required=False)
-            # Top-left Y coordinate
+            # NOT YET IMPLEMENTED - Top-left Y coordinate
             y: num(required=False)
 
     bottom_right:
-            # Bottom-right X coordinate
+            # NOT YET IMPLEMENTED - Bottom-right X coordinate
             x: num(required=False)
-            # Bottom-right Y coordinate
+            # NOT YET IMPLEMENTED - Bottom-right Y coordinate
             y: num(required=False)
 
 pre_process_options:
-    # PLACEHOLDER Number of looks in azimuth
+    # NOT YET IMPLEMENTED - Number of looks in azimuth
     azimuth_looks: int(min=1, required=False)
 
-    # PLACEHOLDER Number of looks in slant range
+    # NOT YET IMPLEMENTED - Number of looks in slant range
     range_looks: int(min=1, required=False)
 
 rtc_options:
-    # RTC output type: empty value to turn off the RTC
-    # The output_type defaults to "gamma0" if the key is absent
+    # Output type (defines the terrain radiometry convention for
+    # the output)
     output_type: enum('gamma0', 'sigma0', required=False)
 
+    # RTC algorithm type
     algorithm_type: enum('area_projection', 'bilinear_distribution', required=False)
 
+    # Input terrain radiometry convention
     input_terrain_radiometry: enum('beta0', 'sigma0', required=False)
 
-    # Minimum RTC area factor in dB
+    # Minimum RTC area factor (in dB). Specifies the lowest
+    # allowable denominator (in dB) for dividing GCOV samples.
+    # If not set, no minimum is enforced, which may lead
+    # to divisions by very small values and result in infinite
+    # or inaccurate outputs.
     rtc_min_value_db: num(required=False)
 
     # RTC DEM upsampling
@@ -282,13 +327,13 @@ geocode_options:
     # Apply radiometric terrain correction
     apply_rtc: bool(required=False)
 
-    # PLACEHOLDER (it is expected that the RSLC product already
+    # NOT YET IMPLEMENTED (it is expected that the RSLC product already
     # incorporates static tropospheric delay corrections --
     # no additional correction is currently applied)
     # Apply dry tropospheric delay correction
     apply_dry_tropospheric_delay_correction: bool(required=False)
 
-    # PLACEHOLDER (it is expected that the RSLC product already
+    # NOT YET IMPLEMENTED (it is expected that the RSLC product already
     # incorporates static tropospheric delay corrections --
     # no additional correction is currently applied)
     # Apply wet tropospheric delay correction
@@ -307,10 +352,23 @@ geocode_options:
     # Apply RSLC metadata valid-samples sub-swath masking
     apply_valid_samples_sub_swath_masking: bool(required=False)
 
-    # Apply shadow masking
+    # NOT YET IMPLEMENTED - Apply shadow masking
     apply_shadow_masking: bool(required=False)
 
     # Memory mode
+    # Enumeration specifying memory management strategies for geocoding
+    # operations. These modes determine how input data is loaded and
+    # processed in memory, allowing trade-offs between performance and
+    # memory usage depending on system resources.
+    # Choices:
+    # - "auto": Automatically selects the optimal memory mode based on
+    # the module's defaults.
+    # - "single_block": Disables block processing by loading and processing
+    # the entire dataset at once.
+    # - "geogrid": Enables block-wise processing over the geogrid; the full
+    # SLC is loaded once and reused for each geogrid block.
+    # - "geogrid_and_radargrid": Enables full block-wise processing over
+    # both geogrid and radar grid; the SLC is loaded in segments per geogrid block.
     memory_mode: enum('auto', 'single_block', 'geogrid', 'geogrid_and_radargrid', required=False)
 
     # Processing upsampling factor on top of the input geogrid
@@ -330,35 +388,41 @@ geocode_options:
     # Save the mask layer
     save_mask: bool(required=False)
 
-    # PLACEHOLDER - Save interpolated DEM used to compute GCOV
+    # NOT YET IMPLEMENTED - Save interpolated DEM used to compute GCOV
     save_dem: bool(required=False)
 
-    # PLACEHOLDER - Save the layover shadow mask
+    # NOT YET IMPLEMENTED - Save the layover shadow mask
     save_layover_shadow_mask: bool(required=False)
 
-    # PLACEHOLDER - Save the incidence angle
+    # NOT YET IMPLEMENTED - Save the incidence angle
     save_incidence_angle: bool(required=False)
 
-    # PLACEHOLDER - Save the local-incidence angle
+    # NOT YET IMPLEMENTED - Save the local-incidence angle
     save_local_inc_angle: bool(required=False)
 
-    # PLACEHOLDER - Save the projection angle
+    # NOT YET IMPLEMENTED - Save the projection angle
     save_projection_angle: bool(required=False)
 
-    # PLACEHOLDER - Save the range slope angle
+    # NOT YET IMPLEMENTED - Save the range slope angle
     save_range_slope: bool(required=False)
 
-    # Absolute radiometric correction factor
+    # Absolute radiometric calibration factor (in power or
+    # intensity units). This factor is applied to the output
+    # pixels. If the output is complex-valued,
+    # the square root of this factor is applied instead.
     abs_rad_cal: num(required=False)
 
-    # Clip values above threshold
+    # Clip values above the threshold. If empty, no max. value
+    # clipping occurs.
     clip_max: num(required=False)
 
-    # Clip values below threshold
+     # Clip values below the threshold. If empty, no min. value
+    # clipping occurs.
     clip_min: num(required=False)
 
-    # Double sampling of the radar-grid
-    # input sampling in the range direction
+    # Doubles the sampling rate of the input RSLC in the range direction
+    # to reduce aliasing during covariance multiplication.
+    # Note: Enabling this may significantly increase memory usage and runtime.
     upsample_radargrid: bool(required=False)
 
     # Same as input DEM if not provided.
@@ -380,6 +444,9 @@ geocode_options:
     # To control output grid in same units as output EPSG
     y_snap: num(min=0, required=False)
 
+    # Coordinates of the top-left pixel corner,
+    # expressed in the output EPSG's coordinate
+    # system, prior to grid snapping.
     top_left:
         # Set top-left y in same units as output EPSG
         y_abs: num(required=False)
@@ -387,6 +454,9 @@ geocode_options:
         # Set top-left x in same units as output EPSG
         x_abs: num(required=False)
 
+    # Coordinates of the bottom-right pixel corner in the
+    # output EPSG coordinate system,  before grid snapping
+    # and before adjusting to ensure alignment with pixel spacing.
     bottom_right:
         # Set bottom-right y in same units as output EPSG
         y_abs: num(required=False)
@@ -424,17 +494,17 @@ noise_correction_options:
     # Enable/disable noise correction
     apply_correction: bool(required=False)
 
-    # PLACEHOLDER
+    # NOT YET IMPLEMENTED
     correction_type: str(required=False)
 
 worker_options:
-    # Enable/disable internet connection (e.g. to download DEM)
+    # NOT YET IMPLEMENTED - Enable/disable internet connection (e.g. to download DEM)
     internet_access: bool(required=False)
 
-    # To explicitly use GPU capability if available. Default False
+    # NOT YET IMPLEMENTED - To explicitly use GPU capability if available. Default False
     gpu_enabled: bool(required=False)
 
-    # Index of the GPU to use for processing, optional. Defaults to the
+    # NOT YET IMPLEMENTED - Index of the GPU to use for processing. Defaults to the
     # first available CUDA device. Ignored if *gpu_enabled* is False.
     gpu_id: int(min=0, required=False)
 
@@ -458,7 +528,7 @@ output_options:
 
 output_dataset_options:
 
-    # Output file format
+    # NOT YET IMPLEMENTED - Output file format
     format: enum('HDF5', 'GTiff', 'ENVI', required=False)
 
     # Enable/disable compression of output raster

--- a/share/nisar/schemas/gslc.yaml
+++ b/share/nisar/schemas/gslc.yaml
@@ -302,12 +302,7 @@ geocode_options:
 
 ceos_analysis_ready_data_options:
 
-    # Data access for the source data (URL or DOI)
-    source_data_access: str(required=False)
-
-    # Data access for the output product (URL or DOI)
-    product_data_access: str(required=False)
-
+    # NOT YET IMPLEMENTED
     # Data access for the static layers product associated with the output product (URL or DOI)
     static_layers_data_access: str(required=False)
 


### PR DESCRIPTION
This PR Improves the comments in GCOV schema and default runconfigs:
- Add `NOT YET IMPLEMENTED` to the parameters that are not used;
- Remove all mentions to optional arguments, as everything that is not marked as `REQUIRED` is considered optional;
- Improve description of parameters;
- Harmonize descriptions between GCOV schema and default runconfig.