### PR TITLE
Patch `cheby_equi_ripple_filter` for SciPy v1.16.0

### DIFF
--- a/python/packages/isce3/signal/fir_filter_func.py
+++ b/python/packages/isce3/signal/fir_filter_func.py
@@ -78,8 +78,8 @@ def cheby_equi_ripple_filter(samprate, bandwidth, rolloff=1.2, ripple=0.1,
     # get LPF coeffs
     coeffs = spsg.remez(len_flt, 0.5 / samprate
                         * np.array([0, bandwidth, fstop, samprate]),
-                        np.array([1.0, 0.0]),
-                        weight=np.array([1, weight_fact]),
+                        [1.0, 0.0],
+                        weight=[1, weight_fact],
                         fs=1, type='bandpass', maxiter=50)
 
     # up/down conversion

--- a/tests/python/packages/isce3/signal/fir_filter_func.py
+++ b/tests/python/packages/isce3/signal/fir_filter_func.py
@@ -245,6 +245,9 @@ def test_bandpass(width, fc):
                                       transition_width=tw, force_odd_len=odd)
     # compute frequency response over entire unit circle
     f, H = sig.freqz(h, fs=1.0, whole=True)
+    # Workaround for scipy=1.16.0
+    # (see https://github.com/isce-framework/isce3/pull/49#issuecomment-3025125318).
+    f = f.real
     a, b = transition_region(width, tw)
     # should have unit gain in passband with ripple < -att
     mask_pass = wrapped_distance(f - fc) < a


### PR DESCRIPTION
Closes #47

SciPy 1.16.0 was released recently with [this update](https://github.com/scipy/scipy/commit/f45ba7bd311ee60c5c2f74c272cd3cd6c1dece86) that seems to break the `scipy.signal.remez()` function when the `weight` argument is not `None`. This seems to be causing CI failures for us.

Let's exclude this SciPy version from the environment spec.