### PR TITLE
Update attribute `grid_mapping_name` from unicode to byte string

### DIFF
--- a/python/packages/nisar/workflows/h5_prep.py
+++ b/python/packages/nisar/workflows/h5_prep.py
@@ -797,7 +797,7 @@ def set_get_geo_info(hdf5_obj, root_ds, geo_grid, z_vect=None,
     sr = osr.SpatialReference()
     sr.ImportFromEPSG(epsg_code)
 
-    projds.attrs['grid_mapping_name'] = get_grid_mapping_name(sr)
+    projds.attrs['grid_mapping_name'] = np.bytes_(get_grid_mapping_name(sr))
 
     # Set up units
     # Geodetic latitude / longitude


### PR DESCRIPTION
This PR updates attribute `grid_mapping_name` from unicode to byte string. The function `get_grid_mapping_name()` returns a string. This PR converts that string to byte array before saving it as an attribute of the projection dataset.