### PR TITLE
Review the C++ implementation of the binary search function

### DIFF
--- a/cxx/isce3/core/Utilities.h
+++ b/cxx/isce3/core/Utilities.h
@@ -357,7 +357,6 @@ namespace isce3 { namespace core {
         // The loop is guaranteed to converge with correct input, but we include
         // this check as a safe measure for unexpected edge cases.
         std::size_t max_iter = std::ceil(std::log2(array.size())) + 1;
-        // std::cout << "binary search" << std::endl;
         while (left + 1 < right) {
             const int middle = static_cast<int>(std::round(0.5 * (left + right)));
             const auto middle_value = array[middle];
@@ -373,7 +372,6 @@ namespace isce3 { namespace core {
                 throw std::runtime_error(
                     "Binary search failed to converge within the allowed iterations.");
             }
-            // std::cout << "count:" << count << std::endl;
         }
 
         if (std::isnan(array[left]) || std::isnan(array[right])) {

--- a/cxx/isce3/core/Utilities.h
+++ b/cxx/isce3/core/Utilities.h
@@ -334,38 +334,52 @@ namespace isce3 { namespace core {
         }
     }
     
-    /** Searches array for index closest to provided value */   
+    /** Searches array for index closest to provided value
+     *
+     *  Assumes the array is sorted in ascending order and contains no NaNs.
+    */
     inline int binarySearch(const std::valarray<double> & array, double value) {
-   
+
+        if (array.size() == 0) {
+                throw std::invalid_argument("input array must contain at least 1 element");
+        }
+        if (array.size() == 1) {
+                return 0;
+        }
+
         // Do the binary search 
         int left = 0;
         int right = array.size() - 1;
-        int index;
 
         std::size_t count = 0;
-        while (left <= right) {
+
+        // `max_iter` provides a safeguard against unexpected behavior.
+        // The loop is guaranteed to converge with correct input, but we include
+        // this check as a safe measure for unexpected edge cases.
+        std::size_t max_iter = std::ceil(std::log2(array.size())) + 1;
+        while (left + 1 < right) {
             const int middle = static_cast<int>(std::round(0.5 * (left + right)));
             const auto middle_value = array[middle];
             if (std::isnan(middle_value)) {
                 throw std::invalid_argument("input array may not contain NaN values");
             }
-            if (left == (right - 1)) {
-                index = left;
-                return index;
-            }
-            if (middle_value <= value) {
+            if (middle_value < value) {
                 left = middle;
             } else {
                 right = middle;
             }
-            count++;
-            if (count > array.size()) {
+            if (++count > max_iter) {
                 throw std::runtime_error(
                     "Binary search failed to converge within the allowed iterations.");
             }
         }
-        index = left;
-        return index;
+
+        // Return the closest of left and right
+        if (std::abs(array[left] - value) <= std::abs(array[right] - value)) {
+            return left;
+        }
+
+        return right;
     }
 
     /** Clip a number between an upper and lower range (implements std::clamp for older GCC) */

--- a/cxx/isce3/core/Utilities.h
+++ b/cxx/isce3/core/Utilities.h
@@ -357,6 +357,7 @@ namespace isce3 { namespace core {
         // The loop is guaranteed to converge with correct input, but we include
         // this check as a safe measure for unexpected edge cases.
         std::size_t max_iter = std::ceil(std::log2(array.size())) + 1;
+        // std::cout << "binary search" << std::endl;
         while (left + 1 < right) {
             const int middle = static_cast<int>(std::round(0.5 * (left + right)));
             const auto middle_value = array[middle];
@@ -372,6 +373,11 @@ namespace isce3 { namespace core {
                 throw std::runtime_error(
                     "Binary search failed to converge within the allowed iterations.");
             }
+            // std::cout << "count:" << count << std::endl;
+        }
+
+        if (std::isnan(array[left]) || std::isnan(array[right])) {
+            throw std::invalid_argument("input array may not contain NaN values");
         }
 
         // Return the closest of left and right

--- a/cxx/isce3/core/Utilities.h
+++ b/cxx/isce3/core/Utilities.h
@@ -337,6 +337,13 @@ namespace isce3 { namespace core {
     /** Searches array for index closest to provided value
      *
      *  Assumes the array is sorted in ascending order and contains no NaNs.
+     * @param array The input array, which must be sorted in ascending order and contain no NaNs.
+     * @param value The value to search for.
+     * @param always_pick_left If true, and `value` is strictly between two array elements,
+     *                         the function will return the lower index (left). If false, the
+     *                         function returns the closest index (left or right).
+     *
+     * @return The index of the array element closest to `value`.
     */
     inline int binarySearch(const std::valarray<double> & array, double value,
                             const bool always_pick_left = false) {
@@ -348,16 +355,24 @@ namespace isce3 { namespace core {
                 return 0;
         }
 
-        // Do the binary search 
         int left = 0;
         int right = array.size() - 1;
+
+        // Test extreme values
+        if (value <= array[left]) {
+            return left;
+        }
+        if (array[right] <= value) {
+            return right;
+        }
 
         std::size_t count = 0;
 
         // `max_iter` provides a safeguard against unexpected behavior.
         // The loop is guaranteed to converge with correct input, but we include
         // this check as a safe measure for unexpected edge cases.
-        std::size_t max_iter = std::ceil(std::log2(array.size())) + 1;
+        constexpr std::size_t padding = 2;
+        std::size_t max_iter = std::ceil(std::log2(array.size())) + padding;
         while (left + 1 < right) {
             const int middle = left + (right - left) / 2;
             const auto middle_value = array[middle];
@@ -375,12 +390,14 @@ namespace isce3 { namespace core {
             }
         }
 
-        if (always_pick_left) {
-            return left;
-        }
-
+        // Test for NaNs
         if (std::isnan(array[left]) || std::isnan(array[right])) {
             throw std::invalid_argument("input array may not contain NaN values");
+        }
+
+        // If always pick left and the `right` index is not pointing at value
+        if (always_pick_left && value < array[right]) {
+            return left;
         }
 
         // Return the closest of left and right

--- a/cxx/isce3/core/Utilities.h
+++ b/cxx/isce3/core/Utilities.h
@@ -340,9 +340,9 @@ namespace isce3 { namespace core {
         int right = array.size() - 1;
         int index;
 
-        long long counter = 0;
+        long long count = 0;
         long long MAX_NUM_ITERATIONS = 1e11;
-        while (left <= right and counter < MAX_NUM_ITERATIONS) {
+        while (left <= right and count < MAX_NUM_ITERATIONS) {
             const int middle = static_cast<int>(std::round(0.5 * (left + right)));
             if (left == (right - 1)) {
                 index = left;
@@ -353,6 +353,7 @@ namespace isce3 { namespace core {
             } else if (array[middle] > value) {
                 right = middle;
             }
+            count++;
         }
         index = left;
         return index;

--- a/cxx/isce3/core/Utilities.h
+++ b/cxx/isce3/core/Utilities.h
@@ -344,13 +344,17 @@ namespace isce3 { namespace core {
         long long MAX_NUM_ITERATIONS = 1e11;
         while (left <= right and count < MAX_NUM_ITERATIONS) {
             const int middle = static_cast<int>(std::round(0.5 * (left + right)));
+            const auto middle_value = array[middle];
+            if (std::isnan(middle_value)) {
+                throw std::invalid_argument("input array may not contain NaN values");
+            }
             if (left == (right - 1)) {
                 index = left;
                 return index;
             }
-            if (array[middle] <= value) {
+            if (middle_value <= value) {
                 left = middle;
-            } else if (array[middle] > value) {
+            } else if (middle_value > value) {
                 right = middle;
             }
             count++;

--- a/cxx/isce3/core/Utilities.h
+++ b/cxx/isce3/core/Utilities.h
@@ -343,8 +343,7 @@ namespace isce3 { namespace core {
         int index;
 
         long long count = 0;
-        long long MAX_NUM_ITERATIONS = 1e11;
-        while (left <= right and count < MAX_NUM_ITERATIONS) {
+        while (left <= right) {
             const int middle = static_cast<int>(std::round(0.5 * (left + right)));
             const auto middle_value = array[middle];
             if (std::isnan(middle_value)) {
@@ -360,6 +359,10 @@ namespace isce3 { namespace core {
                 right = middle;
             }
             count++;
+            if (count >= array.size()) {
+                throw std::runtime_error(
+                    "Binary search failed to converge within the allowed iterations.");
+            }
         }
         index = left;
         return index;

--- a/cxx/isce3/core/Utilities.h
+++ b/cxx/isce3/core/Utilities.h
@@ -356,7 +356,7 @@ namespace isce3 { namespace core {
             }
             if (middle_value <= value) {
                 left = middle;
-            } else if (middle_value > value) {
+            } else {
                 right = middle;
             }
             count++;

--- a/cxx/isce3/core/Utilities.h
+++ b/cxx/isce3/core/Utilities.h
@@ -337,11 +337,13 @@ namespace isce3 { namespace core {
     /** Searches array for index closest to provided value
      *
      *  Assumes the array is sorted in ascending order and contains no NaNs.
-     * @param array The input array, which must be sorted in ascending order and contain no NaNs.
+     * 
+     * @param array The input array, which must be sorted in ascending order
+     * and contain no NaNs.
      * @param value The value to search for.
-     * @param always_pick_left If true, and `value` is strictly between two array elements,
-     *                         the function will return the lower index (left). If false, the
-     *                         function returns the closest index (left or right).
+     * @param always_pick_left If true, and `value` is strictly between two
+     * array elements, the function will return the lower index (left).
+     * If false, the function returns the closest index (left or right).
      *
      * @return The index of the array element closest to `value`.
     */

--- a/cxx/isce3/core/Utilities.h
+++ b/cxx/isce3/core/Utilities.h
@@ -338,7 +338,8 @@ namespace isce3 { namespace core {
      *
      *  Assumes the array is sorted in ascending order and contains no NaNs.
     */
-    inline int binarySearch(const std::valarray<double> & array, double value) {
+    inline int binarySearch(const std::valarray<double> & array, double value,
+                            const bool always_pick_left = false) {
 
         if (array.size() == 0) {
                 throw std::invalid_argument("input array must contain at least 1 element");
@@ -358,7 +359,7 @@ namespace isce3 { namespace core {
         // this check as a safe measure for unexpected edge cases.
         std::size_t max_iter = std::ceil(std::log2(array.size())) + 1;
         while (left + 1 < right) {
-            const int middle = static_cast<int>(std::round(0.5 * (left + right)));
+            const int middle = left + (right - left) / 2;
             const auto middle_value = array[middle];
             if (std::isnan(middle_value)) {
                 throw std::invalid_argument("input array may not contain NaN values");
@@ -372,6 +373,10 @@ namespace isce3 { namespace core {
                 throw std::runtime_error(
                     "Binary search failed to converge within the allowed iterations.");
             }
+        }
+
+        if (always_pick_left) {
+            return left;
         }
 
         if (std::isnan(array[left]) || std::isnan(array[right])) {

--- a/cxx/isce3/core/Utilities.h
+++ b/cxx/isce3/core/Utilities.h
@@ -16,6 +16,8 @@
 #include <vector>
 #include <valarray>
 #include <complex>
+#include <cmath>
+#include <stdexcept>
 
 // Macro wrappers to check vector lengths 
 // (adds calling function and variable name information to the exception)

--- a/cxx/isce3/core/Utilities.h
+++ b/cxx/isce3/core/Utilities.h
@@ -342,7 +342,7 @@ namespace isce3 { namespace core {
         int right = array.size() - 1;
         int index;
 
-        long long count = 0;
+        std::size_t count = 0;
         while (left <= right) {
             const int middle = static_cast<int>(std::round(0.5 * (left + right)));
             const auto middle_value = array[middle];
@@ -359,7 +359,7 @@ namespace isce3 { namespace core {
                 right = middle;
             }
             count++;
-            if (count >= array.size()) {
+            if (count > array.size()) {
                 throw std::runtime_error(
                     "Binary search failed to converge within the allowed iterations.");
             }

--- a/cxx/isce3/core/Utilities.h
+++ b/cxx/isce3/core/Utilities.h
@@ -339,7 +339,10 @@ namespace isce3 { namespace core {
         int left = 0;
         int right = array.size() - 1;
         int index;
-        while (left <= right) {
+
+        long long counter = 0;
+        long long MAX_NUM_ITERATIONS = 1e11;
+        while (left <= right and counter < MAX_NUM_ITERATIONS) {
             const int middle = static_cast<int>(std::round(0.5 * (left + right)));
             if (left == (right - 1)) {
                 index = left;

--- a/cxx/isce3/geometry/Topo.cpp
+++ b/cxx/isce3/geometry/Topo.cpp
@@ -812,7 +812,9 @@ setLayoverShadow(TopoLayers& layers, DEMInterpolator& demInterp,
 
             // Compute nearest ctrack index for current ctrackGrid value
             const double crossTrack = ctrackGrid[i];
-            int k = isce3::core::binarySearch(ctrack, crossTrack);
+            const bool always_pick_left = true;
+            int k = isce3::core::binarySearch(ctrack, crossTrack, always_pick_left);
+
             // Adjust edges if necessary
             if (k == (width - 1)) {
                 k = width - 2;

--- a/tests/cxx/isce3/Sources.cmake
+++ b/tests/cxx/isce3/Sources.cmake
@@ -23,6 +23,7 @@ core/projections/utm.cpp
 core/serialization/serializeAttitude.cpp
 core/serialization/serializeDoppler.cpp
 core/serialization/serializeOrbit.cpp
+core/utilities/binarySearch.cpp
 fft/fft.cpp
 fft/fftplan.cpp
 fft/fftutil.cpp

--- a/tests/cxx/isce3/core/utilities/binarySearch.cpp
+++ b/tests/cxx/isce3/core/utilities/binarySearch.cpp
@@ -13,8 +13,8 @@ TEST(BinarySearchTest, SingleElementArray) {
 TEST(BinarySearchTest, SingleElementArrayPickLeft) {
     const bool always_pick_left = true;
     std::valarray<double> arr = {2.0};
-    EXPECT_EQ(binarySearch(arr, 0.0), 0, always_pick_left);
-    EXPECT_EQ(binarySearch(arr, 100.0), 0, always_pick_left);
+    EXPECT_EQ(binarySearch(arr, 0.0, always_pick_left)), 0);
+    EXPECT_EQ(binarySearch(arr, 100.0, always_pick_left)), 0);
 }
 
 
@@ -27,8 +27,8 @@ TEST(BinarySearchTest, ClosestMatchExact) {
 TEST(BinarySearchTest, ClosestMatchExactPickLeft) {
     const bool always_pick_left = true;
     std::valarray<double> arr = {1.0, 3.0, 5.0, 7.0};
-    EXPECT_EQ(binarySearch(arr, 3.0), 1, always_pick_left);
-    EXPECT_EQ(binarySearch(arr, 7.0), 3, always_pick_left);
+    EXPECT_EQ(binarySearch(arr, 3.0, always_pick_left)), 1);
+    EXPECT_EQ(binarySearch(arr, 7.0, always_pick_left)), 3);
 }
 
 TEST(BinarySearchTest, ClosestMatchInBetween) {
@@ -41,9 +41,9 @@ TEST(BinarySearchTest, ClosestMatchInBetween) {
 TEST(BinarySearchTest, ClosestMatchInBetweenPickLeft) {
     const bool always_pick_left = true;
     std::valarray<double> arr = {1.0, 3.0, 5.0, 7.0};
-    EXPECT_EQ(binarySearch(arr, 2.1), 0, always_pick_left);
-    EXPECT_EQ(binarySearch(arr, 4.1), 1, always_pick_left);
-    EXPECT_EQ(binarySearch(arr, 6.4), 2, always_pick_left);
+    EXPECT_EQ(binarySearch(arr, 2.1, always_pick_left)), 0);
+    EXPECT_EQ(binarySearch(arr, 4.1, always_pick_left)), 1);
+    EXPECT_EQ(binarySearch(arr, 6.4, always_pick_left)), 2);
 }
 
 TEST(BinarySearchTest, ValueBeforeFirstElement) {
@@ -54,7 +54,7 @@ TEST(BinarySearchTest, ValueBeforeFirstElement) {
 TEST(BinarySearchTest, ValueBeforeFirstElementPickLeft) {
     const bool always_pick_left = true;
     std::valarray<double> arr = {1.0, 2.0, 3.0};
-    EXPECT_EQ(binarySearch(arr, -1.0), 0, always_pick_left);
+    EXPECT_EQ(binarySearch(arr, -1.0, always_pick_left)), 0);
 }
 
 TEST(BinarySearchTest, ValueAfterLastElement) {
@@ -65,7 +65,7 @@ TEST(BinarySearchTest, ValueAfterLastElement) {
 TEST(BinarySearchTest, ValueAfterLastElementPickLeft) {
     const bool always_pick_left = true;
     std::valarray<double> arr = {1.0, 2.0, 3.0};
-    EXPECT_EQ(binarySearch(arr, 5.0), 2, always_pick_left);
+    EXPECT_EQ(binarySearch(arr, 5.0, always_pick_left)), 2);
 }
 
 TEST(BinarySearchTest, EqualDistanceChoosesLeft) {
@@ -80,7 +80,7 @@ TEST(BinarySearchTest, EqualDistanceChoosesLeftPickLeft) {
     std::valarray<double> arr = {1.0, 2.0, 3.0, 4.0};
 
     // `2` and `3` equally distant; picks left (`2`)
-    EXPECT_EQ(binarySearch(arr, 2.5), 1, always_pick_left);
+    EXPECT_EQ(binarySearch(arr, 2.5, always_pick_left)), 1);
 }
 
 TEST(BinarySearchTest, ThrowsOnEmptyArray) {

--- a/tests/cxx/isce3/core/utilities/binarySearch.cpp
+++ b/tests/cxx/isce3/core/utilities/binarySearch.cpp
@@ -10,10 +10,25 @@ TEST(BinarySearchTest, SingleElementArray) {
     EXPECT_EQ(binarySearch(arr, 100.0), 0);
 }
 
+TEST(BinarySearchTest, SingleElementArrayPickLeft) {
+    const bool always_pick_left = true;
+    std::valarray<double> arr = {2.0};
+    EXPECT_EQ(binarySearch(arr, 0.0), 0, always_pick_left);
+    EXPECT_EQ(binarySearch(arr, 100.0), 0, always_pick_left);
+}
+
+
 TEST(BinarySearchTest, ClosestMatchExact) {
     std::valarray<double> arr = {1.0, 3.0, 5.0, 7.0};
     EXPECT_EQ(binarySearch(arr, 3.0), 1);
     EXPECT_EQ(binarySearch(arr, 7.0), 3);
+}
+
+TEST(BinarySearchTest, ClosestMatchExactPickLeft) {
+    const bool always_pick_left = true;
+    std::valarray<double> arr = {1.0, 3.0, 5.0, 7.0};
+    EXPECT_EQ(binarySearch(arr, 3.0), 1, always_pick_left);
+    EXPECT_EQ(binarySearch(arr, 7.0), 3, always_pick_left);
 }
 
 TEST(BinarySearchTest, ClosestMatchInBetween) {
@@ -23,14 +38,49 @@ TEST(BinarySearchTest, ClosestMatchInBetween) {
     EXPECT_EQ(binarySearch(arr, 6.4), 3); // closer to `7`
 }
 
+TEST(BinarySearchTest, ClosestMatchInBetweenPickLeft) {
+    const bool always_pick_left = true;
+    std::valarray<double> arr = {1.0, 3.0, 5.0, 7.0};
+    EXPECT_EQ(binarySearch(arr, 2.1), 0, always_pick_left);
+    EXPECT_EQ(binarySearch(arr, 4.1), 1, always_pick_left);
+    EXPECT_EQ(binarySearch(arr, 6.4), 2, always_pick_left);
+}
+
 TEST(BinarySearchTest, ValueBeforeFirstElement) {
     std::valarray<double> arr = {1.0, 2.0, 3.0};
     EXPECT_EQ(binarySearch(arr, -1.0), 0); // `-1` closest to `1`
 }
 
+TEST(BinarySearchTest, ValueBeforeFirstElementPickLeft) {
+    const bool always_pick_left = true;
+    std::valarray<double> arr = {1.0, 2.0, 3.0};
+    EXPECT_EQ(binarySearch(arr, -1.0), 0, always_pick_left);
+}
+
 TEST(BinarySearchTest, ValueAfterLastElement) {
     std::valarray<double> arr = {1.0, 2.0, 3.0};
     EXPECT_EQ(binarySearch(arr, 5.0), 2); // `5` closest to `3`
+}
+
+TEST(BinarySearchTest, ValueAfterLastElementPickLeft) {
+    const bool always_pick_left = true;
+    std::valarray<double> arr = {1.0, 2.0, 3.0};
+    EXPECT_EQ(binarySearch(arr, 5.0), 2, always_pick_left);
+}
+
+TEST(BinarySearchTest, EqualDistanceChoosesLeft) {
+    std::valarray<double> arr = {1.0, 2.0, 3.0, 4.0};
+
+    // `2` and `3` equally distant; picks left (`2`)
+    EXPECT_EQ(binarySearch(arr, 2.5), 1);
+}
+
+TEST(BinarySearchTest, EqualDistanceChoosesLeftPickLeft) {
+    const bool always_pick_left = true;
+    std::valarray<double> arr = {1.0, 2.0, 3.0, 4.0};
+
+    // `2` and `3` equally distant; picks left (`2`)
+    EXPECT_EQ(binarySearch(arr, 2.5), 1, always_pick_left);
 }
 
 TEST(BinarySearchTest, ThrowsOnEmptyArray) {

--- a/tests/cxx/isce3/core/utilities/binarySearch.cpp
+++ b/tests/cxx/isce3/core/utilities/binarySearch.cpp
@@ -13,8 +13,8 @@ TEST(BinarySearchTest, SingleElementArray) {
 TEST(BinarySearchTest, SingleElementArrayPickLeft) {
     const bool always_pick_left = true;
     std::valarray<double> arr = {2.0};
-    EXPECT_EQ(binarySearch(arr, 0.0, always_pick_left)), 0);
-    EXPECT_EQ(binarySearch(arr, 100.0, always_pick_left)), 0);
+    EXPECT_EQ(binarySearch(arr, 0.0, always_pick_left), 0);
+    EXPECT_EQ(binarySearch(arr, 100.0, always_pick_left), 0);
 }
 
 
@@ -27,8 +27,8 @@ TEST(BinarySearchTest, ClosestMatchExact) {
 TEST(BinarySearchTest, ClosestMatchExactPickLeft) {
     const bool always_pick_left = true;
     std::valarray<double> arr = {1.0, 3.0, 5.0, 7.0};
-    EXPECT_EQ(binarySearch(arr, 3.0, always_pick_left)), 1);
-    EXPECT_EQ(binarySearch(arr, 7.0, always_pick_left)), 3);
+    EXPECT_EQ(binarySearch(arr, 3.0, always_pick_left), 1);
+    EXPECT_EQ(binarySearch(arr, 7.0, always_pick_left), 3);
 }
 
 TEST(BinarySearchTest, ClosestMatchInBetween) {
@@ -41,9 +41,9 @@ TEST(BinarySearchTest, ClosestMatchInBetween) {
 TEST(BinarySearchTest, ClosestMatchInBetweenPickLeft) {
     const bool always_pick_left = true;
     std::valarray<double> arr = {1.0, 3.0, 5.0, 7.0};
-    EXPECT_EQ(binarySearch(arr, 2.1, always_pick_left)), 0);
-    EXPECT_EQ(binarySearch(arr, 4.1, always_pick_left)), 1);
-    EXPECT_EQ(binarySearch(arr, 6.4, always_pick_left)), 2);
+    EXPECT_EQ(binarySearch(arr, 2.1, always_pick_left), 0);
+    EXPECT_EQ(binarySearch(arr, 4.1, always_pick_left), 1);
+    EXPECT_EQ(binarySearch(arr, 6.4, always_pick_left), 2);
 }
 
 TEST(BinarySearchTest, ValueBeforeFirstElement) {
@@ -54,7 +54,7 @@ TEST(BinarySearchTest, ValueBeforeFirstElement) {
 TEST(BinarySearchTest, ValueBeforeFirstElementPickLeft) {
     const bool always_pick_left = true;
     std::valarray<double> arr = {1.0, 2.0, 3.0};
-    EXPECT_EQ(binarySearch(arr, -1.0, always_pick_left)), 0);
+    EXPECT_EQ(binarySearch(arr, -1.0, always_pick_left), 0);
 }
 
 TEST(BinarySearchTest, ValueAfterLastElement) {
@@ -65,7 +65,7 @@ TEST(BinarySearchTest, ValueAfterLastElement) {
 TEST(BinarySearchTest, ValueAfterLastElementPickLeft) {
     const bool always_pick_left = true;
     std::valarray<double> arr = {1.0, 2.0, 3.0};
-    EXPECT_EQ(binarySearch(arr, 5.0, always_pick_left)), 2);
+    EXPECT_EQ(binarySearch(arr, 5.0, always_pick_left), 2);
 }
 
 TEST(BinarySearchTest, EqualDistanceChoosesLeft) {
@@ -80,7 +80,7 @@ TEST(BinarySearchTest, EqualDistanceChoosesLeftPickLeft) {
     std::valarray<double> arr = {1.0, 2.0, 3.0, 4.0};
 
     // `2` and `3` equally distant; picks left (`2`)
-    EXPECT_EQ(binarySearch(arr, 2.5, always_pick_left)), 1);
+    EXPECT_EQ(binarySearch(arr, 2.5, always_pick_left), 1);
 }
 
 TEST(BinarySearchTest, ThrowsOnEmptyArray) {

--- a/tests/cxx/isce3/core/utilities/binarySearch.cpp
+++ b/tests/cxx/isce3/core/utilities/binarySearch.cpp
@@ -1,0 +1,50 @@
+#include <gtest/gtest.h>
+
+#include <isce3/core/Utilities.h>
+
+using isce3::core::binarySearch;
+
+TEST(BinarySearchTest, SingleElementArray) {
+    std::valarray<double> arr = {2.0};
+    EXPECT_EQ(binarySearch(arr, 0.0), 0);
+    EXPECT_EQ(binarySearch(arr, 100.0), 0);
+}
+
+TEST(BinarySearchTest, ClosestMatchExact) {
+    std::valarray<double> arr = {1.0, 3.0, 5.0, 7.0};
+    EXPECT_EQ(binarySearch(arr, 3.0), 1);
+    EXPECT_EQ(binarySearch(arr, 7.0), 3);
+}
+
+TEST(BinarySearchTest, ClosestMatchInBetween) {
+    std::valarray<double> arr = {1.0, 3.0, 5.0, 7.0};
+    EXPECT_EQ(binarySearch(arr, 2.1), 1); // closer to `3`
+    EXPECT_EQ(binarySearch(arr, 4.1), 2); // closer to `5`
+    EXPECT_EQ(binarySearch(arr, 6.4), 3); // closer to `7`
+}
+
+TEST(BinarySearchTest, ValueBeforeFirstElement) {
+    std::valarray<double> arr = {1.0, 2.0, 3.0};
+    EXPECT_EQ(binarySearch(arr, -1.0), 0); // `-1` closest to `1`
+}
+
+TEST(BinarySearchTest, ValueAfterLastElement) {
+    std::valarray<double> arr = {1.0, 2.0, 3.0};
+    EXPECT_EQ(binarySearch(arr, 5.0), 2); // `5` closest to `3`
+}
+
+TEST(BinarySearchTest, ThrowsOnEmptyArray) {
+    std::valarray<double> arr;
+    EXPECT_THROW(binarySearch(arr, 0.0), std::invalid_argument);
+}
+
+TEST(BinarySearchTest, ThrowsOnNaN) {
+    std::valarray<double> arr = {1.0, 2.0, NAN, 4.0};
+    EXPECT_THROW(binarySearch(arr, 3.0), std::invalid_argument);
+}
+
+int main(int argc, char * argv[])
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This PR sets an upper limit on the number of iterations for the binary search in ISCE3. It addresses an issue reported [here](https://github.com/opera-adt/RTC/issues/94#issuecomment-2948290065), where Topo processing runs indefinitely. The root cause was traced to the presence of NaNs in the DEM, which prevented ISCE3’s binary search from converging to a solution. To prevent such cases from causing infinite loops, this PR adds a maximum iteration threshold to the while loop in the binary search.

(UPDATE) This PR now reviews the binary search function `binarySearch()` entirely and adds unit tests to verify its correctness.