### PR TITLE
Fix function `normalize_geocode_output_mode()`

### DIFF
--- a/python/packages/isce3/geocode/geocode_cov.py
+++ b/python/packages/isce3/geocode/geocode_cov.py
@@ -25,7 +25,7 @@ def normalize_geocode_output_mode(mode: str | GeocodeOutputMode) -> GeocodeOutpu
 
     if mode == "area_projection":
         return GeocodeOutputMode.AREA_PROJECTION
-    if mode == "interp":
+    if mode in ["sinc", "bilinear", "bicubic", "nearest", "biquintic"]:
         return GeocodeOutputMode.INTERP
 
     raise ValueError(f"unexpected GeocodeOutputMode argument: {mode!r}")

--- a/share/nisar/defaults/gcov.yaml
+++ b/share/nisar/defaults/gcov.yaml
@@ -177,7 +177,7 @@ runconfig:
                 # HV and VH), otherwise, the flag is ignored.
                 # If enabled, the output product's "HV" dataset will contain symmetrized
                 # HV/VH data and the "VH" dataset will be omitted from the output.
-                symmetrize_cross_pol_channels:  True
+                symmetrize_cross_pol_channels:  False
 
             # TODO OPTIONAL - Only checked when internet access is available
             dem_download:

--- a/share/nisar/defaults/gcov.yaml
+++ b/share/nisar/defaults/gcov.yaml
@@ -177,7 +177,7 @@ runconfig:
                 # HV and VH), otherwise, the flag is ignored.
                 # If enabled, the output product's "HV" dataset will contain symmetrized
                 # HV/VH data and the "VH" dataset will be omitted from the output.
-                symmetrize_cross_pol_channels:  False
+                symmetrize_cross_pol_channels:  True
 
             # TODO OPTIONAL - Only checked when internet access is available
             dem_download:


### PR DESCRIPTION
This PR fixes the function `normalize_geocode_output_mode()`. The interpolation algorithm are selected in the GCOV runconfig through the name of the algorithm ("sinc", "bilinear", "bicubic", "nearest", or "biquintic"), not "interp".