### PR TITLE
Fix annotations compatibility with python < 3.10

### DIFF
--- a/python/packages/nisar/noise/noise_estimation_from_raw.py
+++ b/python/packages/nisar/noise/noise_estimation_from_raw.py
@@ -1,6 +1,7 @@
 """
 Functions and classes for noise power estimation from Raw data
 """
+from __future__ import annotations
 from warnings import warn
 from dataclasses import dataclass
 from collections.abc import Iterator


### PR DESCRIPTION
This patch is already in our conda-forge feedstock: https://github.com/conda-forge/isce3-feedstock/commit/0726b64694bcb3e936d32c38a19ae09e32df0e48