### PR TITLE
Remove processing type "Undefined" from the GCOV & GSLC writer

### DIFF
--- a/python/packages/nisar/products/writers/BaseWriterSingleInput.py
+++ b/python/packages/nisar/products/writers/BaseWriterSingleInput.py
@@ -664,10 +664,9 @@ class BaseWriterSingleInput():
             processing_type = np.bytes_('Nominal')
         elif processing_type_runconfig == 'UR':
             processing_type = np.bytes_('Urgent')
-        elif processing_type_runconfig == 'OD':
-            processing_type = np.bytes_('Custom')
         else:
-            processing_type = np.bytes_('Undefined')
+            processing_type = np.bytes_('Custom')
+
         self.set_value(
             'identification/processingType',
             processing_type,

--- a/python/packages/nisar/products/writers/BaseWriterSingleInput.py
+++ b/python/packages/nisar/products/writers/BaseWriterSingleInput.py
@@ -665,12 +665,13 @@ class BaseWriterSingleInput():
         elif processing_type_runconfig == 'UR':
             processing_type = np.bytes_('Urgent')
         else:
-            warning_channel = journal.warning(
-                'BaseWriterSingleInput.populate_identification_common()')
-            warning_channel.log(
-                'The processing type in the runconfig is set to'
-                f' "{processing_type_runconfig}", which is not a valid value'
-                ' for the output product metadata. Defaulting to "Custom"')
+            if processing_type_runconfig == 'OD':
+                warning_channel = journal.warning(
+                    'BaseWriterSingleInput.populate_identification_common()')
+                warning_channel.log(
+                    'The processing type in the runconfig is set to'
+                    f' "{processing_type_runconfig}", which is not a valid value'
+                    ' for the output product metadata. Defaulting to "Custom"')
             processing_type = np.bytes_('Custom')
 
         self.set_value(

--- a/python/packages/nisar/products/writers/BaseWriterSingleInput.py
+++ b/python/packages/nisar/products/writers/BaseWriterSingleInput.py
@@ -665,7 +665,7 @@ class BaseWriterSingleInput():
         elif processing_type_runconfig == 'UR':
             processing_type = np.bytes_('Urgent')
         else:
-            if processing_type_runconfig == 'OD':
+            if processing_type_runconfig != 'OD':
                 warning_channel = journal.warning(
                     'BaseWriterSingleInput.populate_identification_common()')
                 warning_channel.log(

--- a/python/packages/nisar/products/writers/BaseWriterSingleInput.py
+++ b/python/packages/nisar/products/writers/BaseWriterSingleInput.py
@@ -665,6 +665,12 @@ class BaseWriterSingleInput():
         elif processing_type_runconfig == 'UR':
             processing_type = np.bytes_('Urgent')
         else:
+            warning_channel = journal.warning(
+                'BaseWriterSingleInput.populate_identification_common()')
+            warning_channel.log(
+                'The processing type in the runconfig is set to'
+                f' "{processing_type}", which is not a valid value'
+                ' for the output product metadata. Defaulting to "Custom"')
             processing_type = np.bytes_('Custom')
 
         self.set_value(

--- a/python/packages/nisar/products/writers/BaseWriterSingleInput.py
+++ b/python/packages/nisar/products/writers/BaseWriterSingleInput.py
@@ -669,7 +669,7 @@ class BaseWriterSingleInput():
                 'BaseWriterSingleInput.populate_identification_common()')
             warning_channel.log(
                 'The processing type in the runconfig is set to'
-                f' "{processing_type}", which is not a valid value'
+                f' "{processing_type_runconfig}", which is not a valid value'
                 ' for the output product metadata. Defaulting to "Custom"')
             processing_type = np.bytes_('Custom')
 

--- a/share/nisar/defaults/gcov.yaml
+++ b/share/nisar/defaults/gcov.yaml
@@ -177,7 +177,7 @@ runconfig:
                 # HV and VH), otherwise, the flag is ignored.
                 # If enabled, the output product's "HV" dataset will contain symmetrized
                 # HV/VH data and the "VH" dataset will be omitted from the output.
-                symmetrize_cross_pol_channels:  True
+                symmetrize_cross_pol_channels:  False
 
             # TODO OPTIONAL - Only checked when internet access is available
             dem_download:

--- a/share/nisar/defaults/gcov.yaml
+++ b/share/nisar/defaults/gcov.yaml
@@ -177,7 +177,7 @@ runconfig:
                 # HV and VH), otherwise, the flag is ignored.
                 # If enabled, the output product's "HV" dataset will contain symmetrized
                 # HV/VH data and the "VH" dataset will be omitted from the output.
-                symmetrize_cross_pol_channels:  False
+                symmetrize_cross_pol_channels:  True
 
             # TODO OPTIONAL - Only checked when internet access is available
             dem_download:


### PR DESCRIPTION
This PR removes processing type "Undefined" from the GCOV & GSLC writer. With the update, if a process type is not "PR" or "UR", it is considered as a "Custom" processing.