### PR TITLE
Add corner reflector LLH to AbsCal and RSLC/GSLC PTA output (MCR #93827)

### DIFF
--- a/python/packages/nisar/workflows/estimate_abscal_factor.py
+++ b/python/packages/nisar/workflows/estimate_abscal_factor.py
@@ -10,6 +10,7 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, List, Optional, Union
 
+import numpy as np
 import shapely
 
 import isce3
@@ -136,6 +137,16 @@ def estimate_abscal_factor(
         'absolute_calibration_factor': float
           The absolute radiometric calibration error for the corner reflector (the ratio
           of the measured RCS to the predicted RCS), in linear units.
+
+        'latitude': float
+          The geodetic latitude, in degrees, of the corner reflector.
+
+        'longitude': float
+          The longitude, in degrees, of the corner reflector.
+
+        'height_above_ellipsoid': float
+          The height of the corner reflector, in meters above the WGS 84 reference
+          ellipsoid.
 
         'elevation_angle': float
           The elevation angle of the corner reflector, in radians. Elevation is measured
@@ -286,6 +297,9 @@ def estimate_abscal_factor(
         cr_info = {
             "id": cr.id,
             "absolute_calibration_factor": abscal_error,
+            "latitude": np.rad2deg(cr.llh.latitude),
+            "longitude": np.rad2deg(cr.llh.longitude),
+            "height_above_ellipsoid": cr.llh.height,
             "elevation_angle": el_angle,
             "timestamp": az_datetime,
             "frequency": freq,

--- a/python/packages/nisar/workflows/estimate_abscal_factor.py
+++ b/python/packages/nisar/workflows/estimate_abscal_factor.py
@@ -138,11 +138,11 @@ def estimate_abscal_factor(
           The absolute radiometric calibration error for the corner reflector (the ratio
           of the measured RCS to the predicted RCS), in linear units.
 
-        'latitude': float
+        'latitude_deg': float
           The geodetic latitude, in degrees, of the corner reflector at the time it was
           surveyed.
 
-        'longitude': float
+        'longitude_deg': float
           The longitude, in degrees, of the corner reflector at the time it was
           surveyed.
 
@@ -299,8 +299,8 @@ def estimate_abscal_factor(
         cr_info = {
             "id": cr.id,
             "absolute_calibration_factor": abscal_error,
-            "latitude": np.rad2deg(cr.llh.latitude),
-            "longitude": np.rad2deg(cr.llh.longitude),
+            "latitude_deg": np.rad2deg(cr.llh.latitude),
+            "longitude_deg": np.rad2deg(cr.llh.longitude),
             "height_above_ellipsoid": cr.llh.height,
             "elevation_angle": el_angle,
             "timestamp": az_datetime,

--- a/python/packages/nisar/workflows/estimate_abscal_factor.py
+++ b/python/packages/nisar/workflows/estimate_abscal_factor.py
@@ -139,14 +139,16 @@ def estimate_abscal_factor(
           of the measured RCS to the predicted RCS), in linear units.
 
         'latitude': float
-          The geodetic latitude, in degrees, of the corner reflector.
+          The geodetic latitude, in degrees, of the corner reflector at the time it was
+          surveyed.
 
         'longitude': float
-          The longitude, in degrees, of the corner reflector.
+          The longitude, in degrees, of the corner reflector at the time it was
+          surveyed.
 
         'height_above_ellipsoid': float
-          The height of the corner reflector, in meters above the WGS 84 reference
-          ellipsoid.
+          The height of the corner reflector at the time it was surveyed, in meters
+          above the WGS 84 reference ellipsoid.
 
         'elevation_angle': float
           The elevation angle of the corner reflector, in radians. Elevation is measured

--- a/python/packages/nisar/workflows/gslc_point_target_analysis.py
+++ b/python/packages/nisar/workflows/gslc_point_target_analysis.py
@@ -654,8 +654,8 @@ def analyze_gslc_point_targets_csv(
         perf_dict.update(
             {
                 "id": cr.id,
-                "latitude": np.rad2deg(cr.llh.latitude),
-                "longitude": np.rad2deg(cr.llh.longitude),
+                "latitude_deg": np.rad2deg(cr.llh.latitude),
+                "longitude_deg": np.rad2deg(cr.llh.longitude),
                 "height_above_ellipsoid": cr.llh.height,
                 "frequency": freq,
                 "polarization": pol,

--- a/python/packages/nisar/workflows/gslc_point_target_analysis.py
+++ b/python/packages/nisar/workflows/gslc_point_target_analysis.py
@@ -547,7 +547,7 @@ def analyze_gslc_point_targets_csv(
     y_spacing = geogrid.spacing_y
 
     orbit = gslc.getOrbit()
-    
+
     if dem_path is not None:
         dem_raster = Raster(os.fspath(dem_path))
         dem_interpolator = dem_raster_to_interpolator(dem_raster, geogrid)
@@ -654,6 +654,9 @@ def analyze_gslc_point_targets_csv(
         perf_dict.update(
             {
                 "id": cr.id,
+                "latitude": np.rad2deg(cr.llh.latitude),
+                "longitude": np.rad2deg(cr.llh.longitude),
+                "height_above_ellipsoid": cr.llh.height,
                 "frequency": freq,
                 "polarization": pol,
                 "elevation_angle": el_angle,
@@ -785,7 +788,7 @@ def analyze_gslc_point_target_llh(
     y_spacing = geogrid.spacing_y
 
     orbit = gslc.getOrbit()
-    
+
     if dem_path is not None:
         dem_raster = Raster(os.fspath(dem_path))
         dem_interpolator = dem_raster_to_interpolator(dem_raster, geogrid)

--- a/python/packages/nisar/workflows/point_target_analysis.py
+++ b/python/packages/nisar/workflows/point_target_analysis.py
@@ -620,14 +620,16 @@ def analyze_corner_reflectors(
           The unique identifier of the corner reflector.
 
         'latitude': float
-          The geodetic latitude, in degrees, of the corner reflector.
+          The geodetic latitude, in degrees, of the corner reflector at the time it was
+          surveyed.
 
         'longitude': float
-          The longitude, in degrees, of the corner reflector.
+          The longitude, in degrees, of the corner reflector at the time it was
+          surveyed.
 
         'height_above_ellipsoid': float
-          The height of the corner reflector, in meters above the WGS 84 reference
-          ellipsoid.
+          The height of the corner reflector at the time it was surveyed, in meters
+          above the WGS 84 reference ellipsoid.
 
         'frequency': str
           The frequency sub-band of the data.

--- a/python/packages/nisar/workflows/point_target_analysis.py
+++ b/python/packages/nisar/workflows/point_target_analysis.py
@@ -619,11 +619,11 @@ def analyze_corner_reflectors(
         'id': str
           The unique identifier of the corner reflector.
 
-        'latitude': float
+        'latitude_deg': float
           The geodetic latitude, in degrees, of the corner reflector at the time it was
           surveyed.
 
-        'longitude': float
+        'longitude_deg': float
           The longitude, in degrees, of the corner reflector at the time it was
           surveyed.
 
@@ -793,8 +793,8 @@ def analyze_corner_reflectors(
         # Add some additional metadata.
         extra_cr_info = {
             "id": cr.id,
-            "latitude": np.rad2deg(cr.llh.latitude),
-            "longitude": np.rad2deg(cr.llh.longitude),
+            "latitude_deg": np.rad2deg(cr.llh.latitude),
+            "longitude_deg": np.rad2deg(cr.llh.longitude),
             "height_above_ellipsoid": cr.llh.height,
             "frequency": freq,
             "polarization": pol,

--- a/python/packages/nisar/workflows/point_target_analysis.py
+++ b/python/packages/nisar/workflows/point_target_analysis.py
@@ -619,6 +619,16 @@ def analyze_corner_reflectors(
         'id': str
           The unique identifier of the corner reflector.
 
+        'latitude': float
+          The geodetic latitude, in degrees, of the corner reflector.
+
+        'longitude': float
+          The longitude, in degrees, of the corner reflector.
+
+        'height_above_ellipsoid': float
+          The height of the corner reflector, in meters above the WGS 84 reference
+          ellipsoid.
+
         'frequency': str
           The frequency sub-band of the data.
 
@@ -769,16 +779,6 @@ def analyze_corner_reflectors(
             )
             continue
 
-        # Make sure we're not overwriting any info in the dict.
-        assert "id" not in cr_info
-        assert "frequency" not in cr_info
-        assert "polarization" not in cr_info
-        assert "elevation_angle" not in cr_info
-        assert "timestamp" not in cr_info
-        assert "survey_date" not in cr_info
-        assert "validity" not in cr_info
-        assert "velocity" not in cr_info
-
         # Get the target's zero-Doppler UTC time and elevation angle.
         az_datetime, el_angle = isce3.cal.get_target_observation_time_and_elevation(
             target_llh=cr.llh,
@@ -789,25 +789,31 @@ def analyze_corner_reflectors(
         )
 
         # Add some additional metadata.
-        cr_info.update(
-            {
-                "id": cr.id,
-                "frequency": freq,
-                "polarization": pol,
-                "elevation_angle": el_angle,
-                "timestamp": az_datetime,
-            }
-        )
+        extra_cr_info = {
+            "id": cr.id,
+            "latitude": np.rad2deg(cr.llh.latitude),
+            "longitude": np.rad2deg(cr.llh.longitude),
+            "height_above_ellipsoid": cr.llh.height,
+            "frequency": freq,
+            "polarization": pol,
+            "elevation_angle": el_angle,
+            "timestamp": az_datetime,
+        }
 
         # Add NISAR-specific corner reflector metadata, if available.
         if isinstance(cr, nisar.cal.CornerReflector):
-            cr_info.update(
+            extra_cr_info.update(
                 {
                     "survey_date": cr.survey_date,
                     "validity": cr.validity,
                     "velocity": cr.velocity,
                 }
             )
+
+        # Update `cr_info` with extra metadata (but make sure we're not overwriting
+        # anything).
+        assert all(key not in cr_info for key in extra_cr_info.keys())
+        cr_info.update(extra_cr_info)
 
         results.append(cr_info)
 

--- a/tests/python/packages/nisar/workflows/estimate_abscal_factor.py
+++ b/tests/python/packages/nisar/workflows/estimate_abscal_factor.py
@@ -271,8 +271,8 @@ def test_nisar_corner_reflector_csv():
         expected_keys = {
             "id",
             "absolute_calibration_factor",
-            "latitude",
-            "longitude",
+            "latitude_deg",
+            "longitude_deg",
             "height_above_ellipsoid",
             "elevation_angle",
             "timestamp",

--- a/tests/python/packages/nisar/workflows/estimate_abscal_factor.py
+++ b/tests/python/packages/nisar/workflows/estimate_abscal_factor.py
@@ -271,6 +271,9 @@ def test_nisar_corner_reflector_csv():
         expected_keys = {
             "id",
             "absolute_calibration_factor",
+            "latitude",
+            "longitude",
+            "height_above_ellipsoid",
             "elevation_angle",
             "timestamp",
             "frequency",

--- a/tests/python/packages/nisar/workflows/point_target_analysis.py
+++ b/tests/python/packages/nisar/workflows/point_target_analysis.py
@@ -123,8 +123,8 @@ def test_nisar_csv():
         # Check that the expected fields were populated.
         expected_keys = {
             "id",
-            "latitude",
-            "longitude",
+            "latitude_deg",
+            "longitude_deg",
             "height_above_ellipsoid",
             "frequency",
             "polarization",
@@ -235,8 +235,8 @@ def test_uavsar_csv():
         # Check that the expected fields were populated.
         expected_keys = {
             "id",
-            "latitude",
-            "longitude",
+            "latitude_deg",
+            "longitude_deg",
             "height_above_ellipsoid",
             "frequency",
             "polarization",

--- a/tests/python/packages/nisar/workflows/point_target_analysis.py
+++ b/tests/python/packages/nisar/workflows/point_target_analysis.py
@@ -123,6 +123,9 @@ def test_nisar_csv():
         # Check that the expected fields were populated.
         expected_keys = {
             "id",
+            "latitude",
+            "longitude",
+            "height_above_ellipsoid",
             "frequency",
             "polarization",
             "elevation_angle",
@@ -232,6 +235,9 @@ def test_uavsar_csv():
         # Check that the expected fields were populated.
         expected_keys = {
             "id",
+            "latitude",
+            "longitude",
+            "height_above_ellipsoid",
             "frequency",
             "polarization",
             "elevation_angle",


### PR DESCRIPTION
Adds corner reflector LLH information to the JSON output produced the by AbsCal and (RSLC & GSLC) PTA tools.

The geographic locations of the corner reflectors are supplied in the input corner reflector CSV file but weren't previously copied to the output of these CalTools. It's useful for the PTA tool output to include the geographic location of each corner reflector so that downstream tools could compute and apply corrections for solid earth tides, troposphere/ionosphere effects, etc in order to calibrate geometric offsets. Currently, such downstream tools need to have access to the original input corner reflector CSV file and be able to correctly parse it to get this information.

If/when this PR is merged and a new isce3 release is created, we could update the QA code to populate the QA output STATS.h5 file with the corresponding information. @nemo794  