### PR TITLE
Reorganize populating CRS metadata into a separate function

### DIFF
--- a/python/packages/isce3/core/__init__.py
+++ b/python/packages/isce3/core/__init__.py
@@ -16,5 +16,6 @@ from .orbit import (
 from .poly2d import fit_bivariate_polynomial
 from . import rdr_geo_block_generator
 from .block_param_generator import BlockParam
+from .projections import is_utm
 from .serialization import load_orbit_from_h5_group
 from . import types

--- a/python/packages/isce3/core/projections.py
+++ b/python/packages/isce3/core/projections.py
@@ -1,0 +1,16 @@
+def is_utm(epsg: int) -> bool:
+    """
+    Check if the input EPSG code represents a UTM zone.
+
+    Parameters
+    ----------
+    epsg : int
+        The input EPSG code.
+
+    Returns
+    -------
+    bool
+        True if the coordinate reference system represented by `epsg` is a Universal
+        Transverse Mercator (UTM) projection; otherwise False.
+    """
+    return (32600 < epsg <= 32660) or (32700 < epsg <= 32760)

--- a/python/packages/nisar/products/__init__.py
+++ b/python/packages/nisar/products/__init__.py
@@ -9,3 +9,4 @@ from .product_spec import (
     populate_global_attrs_from_spec,
     populate_dataset_attrs_from_spec,
 )
+from .projection import build_projection_dataset_attrs_dict

--- a/python/packages/nisar/products/projection.py
+++ b/python/packages/nisar/products/projection.py
@@ -1,0 +1,97 @@
+import numpy as np
+from osgeo import osr
+from numpy.typing import ArrayLike
+
+import isce3
+from isce3.product.cf_conventions import get_grid_mapping_name
+
+
+def build_projection_dataset_attrs_dict(epsg: int) -> dict[str, ArrayLike]:
+    """
+    Get attributes describing the spatial reference system of NISAR L2 products.
+
+    Returns a dict that may be used to populate the Attributes of `projection` Datasets
+    in NISAR Level 2 products in a way that's compliant with Climate and Forecast (CF)
+    Metadata Conventions.
+
+    Parameters
+    ----------
+    epsg : int
+        The EPSG code associated with the spatial reference system.
+
+    Returns
+    -------
+    dict
+        A dict containing attributes describing the spatial reference system.
+        String-valued attributes are represented by bytestrings with 'utf-8' encoding.
+    """
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(epsg)
+
+    # Common attributes for all spatial reference systems.
+    # FIXME: Should `spatial_ref` be replaced with `crs_wkt` for CF-1.7 compliance? See
+    # https://github-fn.jpl.nasa.gov/NISAR-ADT/NISAR_PIX/issues/318.
+    attrs = dict(
+        epsg_code=epsg,
+        spatial_ref=np.bytes_(srs.ExportToWkt()),
+        grid_mapping_name=np.bytes_(get_grid_mapping_name(srs)),
+        semi_major_axis=6378137.0,
+        inverse_flattening=298.257223563,
+        ellipsoid=np.bytes_("WGS84"),
+    )
+
+    if epsg == 4326:  # WGS 84
+        attrs["longitude_of_prime_meridian"] = 0.0
+        return attrs
+
+    # Common attributes for all projected spatial reference systems.
+    attrs["false_easting"] = srs.GetProjParm(osr.SRS_PP_FALSE_EASTING)
+    attrs["false_northing"] = srs.GetProjParm(osr.SRS_PP_FALSE_NORTHING)
+    attrs["longitude_of_projection_origin"] = srs.GetProjParm(
+        osr.SRS_PP_LONGITUDE_OF_ORIGIN
+    )
+
+    if epsg == 3413:  # Polar Stereographic (North)
+        attrs["latitude_of_projection_origin"] = 90.0
+        attrs["standard_parallel"] = 70.0
+        attrs["straight_vertical_longitude_from_pole"] = -45.0
+        return attrs
+
+    if epsg == 3031:  # Polar Stereographic (South)
+        attrs["latitude_of_projection_origin"] = -90.0
+        attrs["standard_parallel"] = -71.0
+        attrs["straight_vertical_longitude_from_pole"] = 0.0
+        return attrs
+
+    # Attribute for non-Polar-Stereographic spatial reference systems.
+    attrs["latitude_of_projection_origin"] = srs.GetProjParm(
+        osr.SRS_PP_LATITUDE_OF_ORIGIN
+    )
+
+    if isce3.core.is_utm(epsg):
+        attrs["utm_zone_number"] = epsg % 100
+        attrs["longitude_of_central_meridian"] = srs.GetProjParm(
+            osr.SRS_PP_CENTRAL_MERIDIAN
+        )
+        attrs["scale_factor_at_central_meridian"] = srs.GetProjParm(
+            osr.SRS_PP_SCALE_FACTOR
+        )
+        return attrs
+
+    if epsg == 6933:  # EASE-Grid 2.0
+        attrs["longitude_of_central_meridian"] = 0.0
+        attrs["standard_parallel"] = 30.0
+        return attrs
+
+    # FIXME: This CRS uses the GRS80 reference ellipsoid -- not WGS 84. The ellipsoid
+    # parameters defined above are not valid for this EPSG code. LAEA Europe is not
+    # supported anywhere else in ISCE3. Should we remove this? See
+    # https://github.com/isce-framework/isce3/issues/72.
+    if epsg == 3035:  # LAEA Europe
+        attrs["standard_parallel"] = -71.0
+        attrs["straight_vertical_longitude_from_pole"] = 0.0
+        return attrs
+
+    raise NotImplementedError(
+        f"EPSG {epsg} waiting for implementation / not supported in ISCE3"
+    )

--- a/python/packages/nisar/workflows/h5_prep.py
+++ b/python/packages/nisar/workflows/h5_prep.py
@@ -7,14 +7,13 @@ import os
 
 import h5py
 import isce3
-from isce3.product.cf_conventions import get_grid_mapping_name
 import journal
 import numpy as np
 from isce3.core.types import complex32, to_complex32
 from isce3.io import HDF5OptimizedReader, optimize_chunk_size
 from nisar.h5 import cp_h5_meta_data
+from nisar.products.projection import build_projection_dataset_attrs_dict
 from nisar.products.readers import SLC
-from osgeo import osr
 
 
 def get_dataset_output_options(cfg: dict):
@@ -769,99 +768,18 @@ def set_get_geo_info(hdf5_obj, root_ds, geo_grid, z_vect=None,
                                       shape=(),
                                       dtype=np.uint32,
                                       data=epsg_code)
-    # Set up osr for wkt
-    srs = osr.SpatialReference()
-    srs.ImportFromEPSG(epsg_code)
+
+    projds_attrs = build_projection_dataset_attrs_dict(epsg_code)
+    projds.attrs.update(projds_attrs)
 
     # Add projection description
     projds.attrs['description'] = np.bytes_('Product map grid projection: EPSG code, '
                                              'with additional projection information as HDF5 Attributes')
 
-    # WGS84 ellipsoid
-    projds.attrs['semi_major_axis'] = 6378137.0
-    projds.attrs['inverse_flattening'] = 298.257223563
-    projds.attrs['ellipsoid'] = np.bytes_("WGS84")
-
-    # Additional fields
-    projds.attrs['epsg_code'] = epsg_code
-
-    # CF 1.7+ requires this attribute to be named "crs_wkt"
-    # spatial_ref is old GDAL way. Using that for testing only.
-    # For NISAR replace with "crs_wkt"
-    projds.attrs['spatial_ref'] = np.bytes_(srs.ExportToWkt())
-
-    # Here we have handcoded the attributes for the different cases
-    # Recommended method is to use pyproj.CRS.to_cf() as shown above
-    # To get complete set of attributes.
-
-    sr = osr.SpatialReference()
-    sr.ImportFromEPSG(epsg_code)
-
-    projds.attrs['grid_mapping_name'] = np.bytes_(get_grid_mapping_name(sr))
-
-    # Set up units
-    # Geodetic latitude / longitude
-    if epsg_code == 4326:
-        # Set up grid mapping
-        projds.attrs['longitude_of_prime_meridian'] = 0.0
-    else:
-        # UTM zones
-        if ((epsg_code > 32600 and
-             epsg_code < 32661) or
-                (epsg_code > 32700 and
-                 epsg_code < 32761)):
-            # Set up grid mapping
-            projds.attrs['utm_zone_number'] = epsg_code % 100
-            projds.attrs["longitude_of_central_meridian"] = srs.GetProjParm(
-                osr.SRS_PP_CENTRAL_MERIDIAN)
-            projds.attrs["scale_factor_at_central_meridian"] = srs.GetProjParm(
-                osr.SRS_PP_SCALE_FACTOR)
-
-        # Polar Stereo North
-        elif epsg_code == 3413:
-            # Set up grid mapping
-            projds.attrs['latitude_of_projection_origin'] = 90.0
-            projds.attrs['standard_parallel'] = 70.0
-            projds.attrs['straight_vertical_longitude_from_pole'] = -45.0
-
-        # Polar Stereo south
-        elif epsg_code == 3031:
-            # Set up grid mapping
-            projds.attrs['latitude_of_projection_origin'] = -90.0
-            projds.attrs['standard_parallel'] = -71.0
-            projds.attrs['straight_vertical_longitude_from_pole'] = 0.0
-
-        # EASE 2 for soil moisture L3
-        elif epsg_code == 6933:
-            # Set up grid mapping
-            projds.attrs['longitude_of_central_meridian'] = 0.0
-            projds.attrs['standard_parallel'] = 30.0
-
-        # Europe Equal Area for Deformation map (to be implemented in isce3)
-        elif epsg_code == 3035:
-            # Set up grid mapping
-            projds.attrs['standard_parallel'] = -71.0
-            projds.attrs['straight_vertical_longitude_from_pole'] = 0.0
-
-        else:
-            raise NotImplementedError(
-                f'EPSG {epsg_code} waiting for implementation / not supported in ISCE3')
-
+    if epsg_code != 4326:
         # Setup common parameters
         xds.attrs['long_name'] = np.bytes_("X coordinate of projection")
         yds.attrs['long_name'] = np.bytes_("Y coordinate of projection")
-
-        projds.attrs['false_easting'] = sr.GetProjParm(osr.SRS_PP_FALSE_EASTING)
-        projds.attrs['false_northing'] = sr.GetProjParm(
-            osr.SRS_PP_FALSE_NORTHING)
-
-        projds.attrs['longitude_of_projection_origin'] = sr.GetProjParm(
-            osr.SRS_PP_LONGITUDE_OF_ORIGIN)
-
-        if epsg_code not in [3413, 3031]:
-            projds.attrs['latitude_of_projection_origin'] = sr.GetProjParm(
-                osr.SRS_PP_LATITUDE_OF_ORIGIN)
-
 
     if z_vect is not None:
         return zds, yds, xds

--- a/tests/python/packages/CMakeLists.txt
+++ b/tests/python/packages/CMakeLists.txt
@@ -46,6 +46,7 @@ nisar/products/readers/raw.py
 nisar/products/readers/rslc.py
 nisar/products/readers/rslc_cal.py
 nisar/products/product_spec.py
+nisar/products/projection.py
 nisar/workflows/crossmul.py
 nisar/workflows/estimate_abscal_factor.py
 nisar/workflows/faraday_rot_angle_from_rslc.py

--- a/tests/python/packages/nisar/products/projection.py
+++ b/tests/python/packages/nisar/products/projection.py
@@ -1,0 +1,83 @@
+from nisar.products import build_projection_dataset_attrs_dict
+
+
+class TestBuildProjectionDatasetAttrsDict:
+    def test_epsg4326(self):
+        epsg = 4326
+        attrs = build_projection_dataset_attrs_dict(epsg)
+
+        # Reference values obtained from https://epsg.io/4326.
+        assert attrs.pop("spatial_ref").startswith(b'GEOGCS["WGS 84",')
+        assert attrs == dict(
+            epsg_code=epsg,
+            semi_major_axis=6378137.0,
+            inverse_flattening=298.257223563,
+            ellipsoid=b"WGS84",
+            grid_mapping_name=b"latitude_longitude",
+            longitude_of_prime_meridian=0.0,
+        )
+
+    def test_epsg3413(self):
+        epsg = 3413
+        attrs = build_projection_dataset_attrs_dict(epsg)
+
+        # Reference values obtained from https://epsg.io/3413.
+        assert attrs.pop("spatial_ref").startswith(
+            b'PROJCS["WGS 84 / NSIDC Sea Ice Polar Stereographic North",'
+        )
+        assert attrs == dict(
+            epsg_code=epsg,
+            semi_major_axis=6378137.0,
+            inverse_flattening=298.257223563,
+            ellipsoid=b"WGS84",
+            grid_mapping_name=b"polar_stereographic",
+            false_easting=0.0,
+            false_northing=0.0,
+            longitude_of_projection_origin=0.0,
+            latitude_of_projection_origin=90.0,
+            standard_parallel=70.0,
+            straight_vertical_longitude_from_pole=-45.0,
+        )
+
+    def test_epsg32601(self):
+        epsg = 32601
+        attrs = build_projection_dataset_attrs_dict(epsg)
+
+        # Reference values obtained from https://epsg.io/32601.
+        assert attrs.pop("spatial_ref").startswith(b'PROJCS["WGS 84 / UTM zone 1N",')
+        assert attrs == dict(
+            epsg_code=epsg,
+            semi_major_axis=6378137.0,
+            inverse_flattening=298.257223563,
+            ellipsoid=b"WGS84",
+            grid_mapping_name=b"transverse_mercator",
+            false_easting=500_000.0,
+            false_northing=0.0,
+            longitude_of_projection_origin=0.0,
+            latitude_of_projection_origin=0.0,
+            utm_zone_number=1,
+            longitude_of_central_meridian=-177.0,
+            scale_factor_at_central_meridian=0.9996,
+        )
+
+    def test_epsg6933(self):
+        epsg = 6933
+        attrs = build_projection_dataset_attrs_dict(epsg)
+
+        # Reference values obtained from https://epsg.io/6933.
+        assert attrs.pop("spatial_ref").startswith(
+            b'PROJCS["WGS 84 / NSIDC EASE-Grid 2.0 Global",'
+        )
+        assert attrs == dict(
+            epsg_code=epsg,
+            semi_major_axis=6378137.0,
+            inverse_flattening=298.257223563,
+            ellipsoid=b"WGS84",
+            grid_mapping_name=b"cylindrical_equal_area",
+            false_easting=0.0,
+            false_northing=0.0,
+            longitude_of_projection_origin=0.0,
+            latitude_of_projection_origin=0.0,
+            longitude_of_central_meridian=0.0,
+            standard_parallel=30.0,
+        )


### PR DESCRIPTION
Currently, the [`set_get_geo_info()`](https://github.com/isce-framework/isce3/blob/d806ba7b9aaf151bbf9d1b2159195f795d4e5a94/python/packages/nisar/workflows/h5_prep.py#L666) function in `h5_prep.py` is responsible for populating a bunch of datasets and attributes in NISAR L2 products.

Among its responsibilities is adding attributes to the `projection` dataset that describe the coordinate reference system (CRS) of the product's raster grid(s). I'd like to reuse that functionality in the Static Layers workflow without inheriting all of the other behavior of `set_get_geo_info()`.

This PR is pulling out that functionality into a separate function that can be reused in the Static Layers workflow. The new function `build_projection_dataset_attrs_dict()` takes an input EPSG code and returns a dict of attributes that can then be added to the `projection` datasets in NISAR L2 products.

This PR is not intended to affect the functionality of existing NISAR SAS workflows -- it's just intended to modularize/reorganize the existing code to improve reusability.

I also added a few unit tests to validate the behavior for a few EPSG codes.