### PR TITLE
Initialize maxval to lowest float for correct peak detection consistenc…

### DIFF
--- a/cxx/isce3/matchtemplate/pycuampcor/cuOffset.cpp
+++ b/cxx/isce3/matchtemplate/pycuampcor/cuOffset.cpp
@@ -21,7 +21,7 @@ void  cudaKernel_maxloc2D(const float* const images, int2* maxloc, float* maxval
     const int imageSize = imageNX * imageNY;
 
     for (int bid = 0; bid < nImages; bid++) {
-        float my_maxval = -std::numeric_limits<float>::max();
+        float my_maxval = std::numeric_limits<float>::lowest();
         int2 my_maxloc;
         const float* image = &images[bid * imageSize];
         for (int i = 0; i < imageSize; i++) {

--- a/cxx/isce3/matchtemplate/pycuampcor/cuOffset.cpp
+++ b/cxx/isce3/matchtemplate/pycuampcor/cuOffset.cpp
@@ -21,7 +21,7 @@ void  cudaKernel_maxloc2D(const float* const images, int2* maxloc, float* maxval
     const int imageSize = imageNX * imageNY;
 
     for (int bid = 0; bid < nImages; bid++) {
-        float my_maxval = std::numeric_limits<float>::min();
+        float my_maxval = -std::numeric_limits<float>::max();
         int2 my_maxloc;
         const float* image = &images[bid * imageSize];
         for (int i = 0; i < imageSize; i++) {


### PR DESCRIPTION
Closes #62 

**Background**
The goal of incoherent cross-correlation, also known as Ampcor, is to identify the peak value and the location of the cross-correlation surface. This information is propagated downstream to estimate the offset between time-separated SAR image pairs.

**Description of the Issue**
In the CPU implementation of incoherent cross-correlation, the variable used to track the maximum value of the correlation surface was incorrectly initialized to the smallest positive representable floating-point number. This causes problems when the correlation surface contains uniformly low values (e.g., exp(-38)). In such cases, none of the surface values are recognized as higher than the initialized `my_maxval`, which means `my_maxloc` i.e., the location of the peak of the correlation surface, either remains uninitialized or is incorrectly set.
This leads to extremely large and incorrect offset estimates. For example, Figure 1 shows this behavior for a 46-day ALOS/PALSAR RSLC image pair:

![Peak](https://github.com/user-attachments/assets/a3d62e51-78ff-4c7a-89e9-4f8fff8ced85)



Figure 1a displays the peak of a correlation surface, where the upper region contains values around 1.18e-38. These low values, when incorrectly handled, result in offset estimates on the order of 1e38 (top-part of Figure 1b).

**Solution**
This PR corrects the initialization of variable holding the cross-correlation peak in the CPU code. This variable is initialized as: 

`float my_maxval = -std::numeric_limits<float>::max();`

This change ensures that any valid correlation surface value—regardless of how small—is correctly compared during peak detection. It also brings the CPU implementation in line with the CUDA version, which uses `-FLT_MAX `for the same purpose.

**Testing**

- Executed existing unit tests on a variety of correlation surfaces, including those with extremely low peak values.
- Verified that peak detection in the CPU implementation is now robust and produces accurate locations even for nearly flat surfaces.
- Confirmed that results now match the CUDA implementation for the same input data.




