### PR TITLE
Add product spec version to `ProductSpec` XML parser (MCR NOT NEEDED)

### DIFF
--- a/python/packages/nisar/products/product_spec.py
+++ b/python/packages/nisar/products/product_spec.py
@@ -316,12 +316,16 @@ class ProductSpec:
         """
         Create a new `ProductSpec` object.
 
+        This constructor typically shouldn't be called directly. Instead, the
+        `from_file` and `from_string` methods provide convenient ways to create
+        `ProductSpec` objects from XML files and strings.
+
         Parameters
         ----------
         tree : xml.etree.ElementTree.ElementTree
             The XML element tree containing the product specification.
         version : str
-            The product specification version string.
+            The product specification version string (for example, '1.2.3').
         """
         self._tree = tree
         self.version = version
@@ -334,7 +338,8 @@ class ProductSpec:
         Parameters
         ----------
         xml_string : str
-            The contents of a NISAR product specification XML file.
+            The contents of a NISAR product specification XML file. Must be a string in
+            XML syntax conforming to the NISAR product specification XML format.
         """
         # `ET.fromstring` (and `ET.parse`) skip over comments, so we need to parse the
         # version string separately from the other XML contents.
@@ -350,7 +355,8 @@ class ProductSpec:
         Parameters
         ----------
         xml_path : path-like
-            The path to the XML file.
+            The path to the XML file. Must be a valid XML file conforming to the NISAR
+            product specification XML format.
         """
         xml_string = Path(xml_path).read_text()
         return cls.from_string(xml_string)

--- a/python/packages/nisar/products/product_spec.py
+++ b/python/packages/nisar/products/product_spec.py
@@ -323,7 +323,7 @@ class ProductSpec:
 
         Parameters
         ----------
-        element : xml.etree.ElementTree.ElementTree
+        tree : xml.etree.ElementTree.ElementTree
             The XML element tree containing the product specification.
         version : str, optional
             The product specification version string. Defaults to '0.0.0'.

--- a/python/packages/nisar/products/product_spec.py
+++ b/python/packages/nisar/products/product_spec.py
@@ -317,7 +317,7 @@ class ProductSpec:
         the dict are attributes that the root HDF5 Group is expected to contain.
     """
 
-    def __init__(self, tree: ET.ElementTree, version: str = "0.0.0"):
+    def __init__(self, tree: ET.ElementTree, version: str):
         """
         Create a new `ProductSpec` object.
 
@@ -325,8 +325,8 @@ class ProductSpec:
         ----------
         tree : xml.etree.ElementTree.ElementTree
             The XML element tree containing the product specification.
-        version : str, optional
-            The product specification version string. Defaults to '0.0.0'.
+        version : str
+            The product specification version string.
         """
         self._tree = tree
         self.version = version

--- a/python/packages/nisar/products/product_spec.py
+++ b/python/packages/nisar/products/product_spec.py
@@ -290,7 +290,7 @@ def get_product_spec_version(xml_string: str) -> str:
     # this may change in the future. This regex should be format-agnostic.
     regex = re.compile(
         r"^<!-- product specification version is (?P<version>\S+) -->$",
-        flags=re.MULTILINE,
+        flags=(re.MULTILINE | re.IGNORECASE),
     )
     if (match := regex.search(xml_string)) is not None:
         return match["version"]

--- a/python/packages/nisar/products/product_spec.py
+++ b/python/packages/nisar/products/product_spec.py
@@ -271,14 +271,14 @@ class DatasetSpec:
         }
 
 
-def get_product_spec_version(xml_path: str | os.PathLike) -> str:
+def get_product_spec_version(xml_string: str) -> str:
     """
-    Get the product specification version by parsing the XML file.
+    Get the product specification version by parsing the XML contents.
 
     Parameters
     ----------
-    xml_path : path-like
-        The path to a NISAR product specification XML file.
+    xml_string : str
+        The contents of a NISAR product specification XML file.
 
     Returns
     -------
@@ -286,19 +286,14 @@ def get_product_spec_version(xml_path: str | os.PathLike) -> str:
         The product specification version as a string in '<MAJOR>.<MINOR>.<PATCH>'
         format.
     """
-    xml_path = Path(xml_path)
-    xml = xml_path.read_text()
-
     regex = re.compile(
         r"^<!-- product specification version is (?P<version>\d+\.\d+\.\d+) -->$",
         flags=re.MULTILINE,
     )
-    if (match := regex.search(xml)) is not None:
+    if (match := regex.search(xml_string)) is not None:
         return match["version"]
 
-    raise RuntimeError(
-        f"unable to parse product specification version string from xml file {xml_path}"
-    )
+    raise RuntimeError("unable to parse product specification version string from xml")
 
 
 class ProductSpec:
@@ -332,6 +327,22 @@ class ProductSpec:
         self.version = version
 
     @classmethod
+    def from_string(cls: type[ProductSpecT], xml_string: str) -> ProductSpecT:
+        """
+        Create a new `ProductSpec` from an XML file.
+
+        Parameters
+        ----------
+        xml_string : str
+            The contents of a NISAR product specification XML file.
+        """
+        # `ET.fromstring` (and `ET.parse`) skip over comments, so we need to parse the
+        # version string separately from the other XML contents.
+        tree = ET.fromstring(xml_string)
+        version = get_product_spec_version(xml_string)
+        return cls(tree, version)
+
+    @classmethod
     def from_file(cls: type[ProductSpecT], xml_path: str | os.PathLike) -> ProductSpecT:
         """
         Create a new `ProductSpec` from an XML file.
@@ -341,9 +352,8 @@ class ProductSpec:
         xml_path : path-like
             The path to the XML file.
         """
-        tree = ET.parse(xml_path)
-        version = get_product_spec_version(xml_path)
-        return cls(tree, version)
+        xml_string = Path(xml_path).read_text()
+        return cls.from_string(xml_string)
 
     @cached_property
     def global_attrs(self) -> dict[str, str]:

--- a/python/packages/nisar/products/product_spec.py
+++ b/python/packages/nisar/products/product_spec.py
@@ -283,8 +283,7 @@ def get_product_spec_version(xml_string: str) -> str:
     Returns
     -------
     str
-        The product specification version string in
-        format.
+        The product specification version string.
     """
     # The version string is expected to follow the format '<MAJOR>.<MINOR>.<PATCH>', but
     # this may change in the future. This regex should be format-agnostic.

--- a/python/packages/nisar/products/product_spec.py
+++ b/python/packages/nisar/products/product_spec.py
@@ -283,11 +283,13 @@ def get_product_spec_version(xml_string: str) -> str:
     Returns
     -------
     str
-        The product specification version as a string in '<MAJOR>.<MINOR>.<PATCH>'
+        The product specification version string in
         format.
     """
+    # The version string is expected to follow the format '<MAJOR>.<MINOR>.<PATCH>', but
+    # this may change in the future. This regex should be format-agnostic.
     regex = re.compile(
-        r"^<!-- product specification version is (?P<version>\d+\.\d+\.\d+) -->$",
+        r"^<!-- product specification version is (?P<version>\S+) -->$",
         flags=re.MULTILINE,
     )
     if (match := regex.search(xml_string)) is not None:

--- a/python/packages/nisar/products/product_spec.py
+++ b/python/packages/nisar/products/product_spec.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 import xml.etree.ElementTree as ET
 from collections.abc import Callable, Iterator
 from functools import cached_property
@@ -270,6 +271,36 @@ class DatasetSpec:
         }
 
 
+def get_product_spec_version(xml_path: str | os.PathLike) -> str:
+    """
+    Get the product specification version by parsing the XML file.
+
+    Parameters
+    ----------
+    xml_path : path-like
+        The path to a NISAR product specification XML file.
+
+    Returns
+    -------
+    str
+        The product specification version as a string in '<MAJOR>.<MINOR>.<PATCH>'
+        format.
+    """
+    xml_path = Path(xml_path)
+    xml = xml_path.read_text()
+
+    regex = re.compile(
+        r"^<!-- product specification version is (?P<version>\d+\.\d+\.\d+) -->$",
+        flags=re.MULTILINE,
+    )
+    if (match := regex.search(xml)) is not None:
+        return match["version"]
+
+    raise RuntimeError(
+        f"unable to parse product specification version string from xml file {xml_path}"
+    )
+
+
 class ProductSpec:
     """
     NISAR product specification.
@@ -279,12 +310,14 @@ class ProductSpec:
 
     Attributes
     ----------
+    version : str
+        The product specification version string.
     global_attrs : dict
         A dict of global attributes found in the specification document. The contents of
         the dict are attributes that the root HDF5 Group is expected to contain.
     """
 
-    def __init__(self, tree: ET.ElementTree):
+    def __init__(self, tree: ET.ElementTree, version: str = "0.0.0"):
         """
         Create a new `ProductSpec` object.
 
@@ -292,8 +325,11 @@ class ProductSpec:
         ----------
         element : xml.etree.ElementTree.ElementTree
             The XML element tree containing the product specification.
+        version : str, optional
+            The product specification version string. Defaults to '0.0.0'.
         """
         self._tree = tree
+        self.version = version
 
     @classmethod
     def from_file(cls: type[ProductSpecT], xml_path: str | os.PathLike) -> ProductSpecT:
@@ -306,7 +342,8 @@ class ProductSpec:
             The path to the XML file.
         """
         tree = ET.parse(xml_path)
-        return cls(tree)
+        version = get_product_spec_version(xml_path)
+        return cls(tree, version)
 
     @cached_property
     def global_attrs(self) -> dict[str, str]:

--- a/tests/python/packages/nisar/products/product_spec.py
+++ b/tests/python/packages/nisar/products/product_spec.py
@@ -27,8 +27,9 @@ def gcov_product_spec() -> ProductSpec:
 @pytest.fixture
 def partial_gcov_product_spec() -> ProductSpec:
     xml = textwrap.dedent(
-        """
+        """\
         <?xml version="1.0"?>
+        <!-- product specification version is 1.2.0 -->
         <algorithm name="L2_GeocodedCovariance"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
           <product template="L2_GCOV_template">
@@ -59,11 +60,9 @@ def partial_gcov_product_spec() -> ProductSpec:
             </science>
           </product>
         </algorithm>
-        """.strip()
+        """
     )
-    element = ET.fromstring(xml)
-    tree = ET.ElementTree(element)
-    return ProductSpec(tree)
+    return ProductSpec.from_string(xml)
 
 
 @contextmanager
@@ -132,10 +131,7 @@ class TestProductSpec:
             """
         )
         with temporary_xml_file(xml_contents) as xml_path:
-            regex = (
-                "^unable to parse product specification version string from xml file"
-                f" {xml_path}"
-            )
+            regex = "^unable to parse product specification version string from xml$"
             with pytest.raises(RuntimeError, match=regex):
                 ProductSpec.from_file(xml_path)
 
@@ -158,8 +154,9 @@ class TestProductSpec:
 
     def test_duplicate_dataset_specs(self):
         xml = textwrap.dedent(
-            """
+            """\
             <?xml version="1.0"?>
+            <!-- product specification version is 1.2.0 -->
             <algorithm name="L2_GeocodedCovariance"
                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
               <product template="L2_GCOV_template">
@@ -183,11 +180,9 @@ class TestProductSpec:
                 </science>
               </product>
             </algorithm>
-            """.strip()
+            """
         )
-        element = ET.fromstring(xml)
-        tree = ET.ElementTree(element)
-        product_spec = ProductSpec(tree)
+        product_spec = ProductSpec.from_string(xml)
 
         name = "/science/LSAR/identification/absoluteOrbitNumber"
         with pytest.raises(ValueError, match="^multiple xml elements found matching"):

--- a/tests/python/packages/nisar/products/product_spec.py
+++ b/tests/python/packages/nisar/products/product_spec.py
@@ -2,6 +2,7 @@ import textwrap
 import xml.etree.ElementTree as ET
 from collections.abc import Generator
 from contextlib import contextmanager
+from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 import h5py
@@ -65,6 +66,30 @@ def partial_gcov_product_spec() -> ProductSpec:
     return ProductSpec(tree)
 
 
+@contextmanager
+def temporary_xml_file(contents: str) -> Generator[Path, None, None]:
+    """
+    Create a temporary XML file with the specified contents.
+
+    The file is automatically removed from the file system upon exiting the context
+    manager.
+
+    Parameters
+    ----------
+    contents : str
+        A string in XML syntax.
+
+    Yields
+    ------
+    Path
+        The XML file path.
+    """
+    with NamedTemporaryFile(suffix=".xml") as tmp_file:
+        path = Path(tmp_file.name)
+        path.write_text(contents)
+        yield path
+
+
 class TestProductSpec:
     def test_get_global_attrs(self, gcov_product_spec: ProductSpec):
         assert gcov_product_spec.global_attrs == dict(
@@ -78,6 +103,21 @@ class TestProductSpec:
             ),
             contact="nisar-sds-ops@jpl.nasa.gov",
         )
+
+    def test_version(self):
+        xml_contents = textwrap.dedent(
+            """\
+            <?xml version="1.0"?>
+            <!-- product specification version is 1.2.0 -->
+            <algorithm name="L1_SingleLookComplex"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xsi:noNamespaceSchemaLocation="../../SDS/pix/schema.xsd">
+            </algorithm>
+            """
+        )
+        with temporary_xml_file(xml_contents) as xml_path:
+            product_spec = ProductSpec.from_file(xml_path)
+            assert product_spec.version == "1.2.0"
 
     def test_get_dataset_spec(self, gcov_product_spec: ProductSpec):
         name = "/science/LSAR/identification/absoluteOrbitNumber"

--- a/tests/python/packages/nisar/products/product_spec.py
+++ b/tests/python/packages/nisar/products/product_spec.py
@@ -103,11 +103,12 @@ class TestProductSpec:
             contact="nisar-sds-ops@jpl.nasa.gov",
         )
 
-    def test_version(self):
+    @pytest.mark.parametrize("version", ["1.2.0", "1.2", "1.2.x", "1.2.3-rc1"])
+    def test_version(self, version: str):
         xml_contents = textwrap.dedent(
-            """\
+            f"""\
             <?xml version="1.0"?>
-            <!-- product specification version is 1.2.0 -->
+            <!-- product specification version is {version} -->
             <algorithm name="L1_SingleLookComplex"
                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                        xsi:noNamespaceSchemaLocation="../../SDS/pix/schema.xsd">
@@ -116,24 +117,7 @@ class TestProductSpec:
         )
         with temporary_xml_file(xml_contents) as xml_path:
             product_spec = ProductSpec.from_file(xml_path)
-            assert product_spec.version == "1.2.0"
-
-    @pytest.mark.parametrize("bad_version_string", ["1.2", "1.2.x", "1.2.3-rc1"])
-    def test_bad_version_string(self, bad_version_string: str):
-        xml_contents = textwrap.dedent(
-            f"""\
-            <?xml version="1.0"?>
-            <!-- product specification version is {bad_version_string} -->
-            <algorithm name="L1_SingleLookComplex"
-                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                       xsi:noNamespaceSchemaLocation="../../SDS/pix/schema.xsd">
-            </algorithm>
-            """
-        )
-        with temporary_xml_file(xml_contents) as xml_path:
-            regex = "^unable to parse product specification version string from xml$"
-            with pytest.raises(RuntimeError, match=regex):
-                ProductSpec.from_file(xml_path)
+            assert product_spec.version == version
 
     def test_get_dataset_spec(self, gcov_product_spec: ProductSpec):
         name = "/science/LSAR/identification/absoluteOrbitNumber"

--- a/tests/python/packages/nisar/products/product_spec.py
+++ b/tests/python/packages/nisar/products/product_spec.py
@@ -119,6 +119,26 @@ class TestProductSpec:
             product_spec = ProductSpec.from_file(xml_path)
             assert product_spec.version == "1.2.0"
 
+    @pytest.mark.parametrize("bad_version_string", ["1.2", "1.2.x", "1.2.3-rc1"])
+    def test_bad_version_string(self, bad_version_string: str):
+        xml_contents = textwrap.dedent(
+            f"""\
+            <?xml version="1.0"?>
+            <!-- product specification version is {bad_version_string} -->
+            <algorithm name="L1_SingleLookComplex"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xsi:noNamespaceSchemaLocation="../../SDS/pix/schema.xsd">
+            </algorithm>
+            """
+        )
+        with temporary_xml_file(xml_contents) as xml_path:
+            regex = (
+                "^unable to parse product specification version string from xml file"
+                f" {xml_path}"
+            )
+            with pytest.raises(RuntimeError, match=regex):
+                ProductSpec.from_file(xml_path)
+
     def test_get_dataset_spec(self, gcov_product_spec: ProductSpec):
         name = "/science/LSAR/identification/absoluteOrbitNumber"
         dataset_spec = gcov_product_spec.get_dataset_spec(name)


### PR DESCRIPTION
I realized that the `ProductSpec` XML parser class is missing a way to get the product spec version. This is useful since each NISAR product includes the product spec version as a dataset in the product -- it's convenient to get this info directly from the XML file instead of manually updating the product spec version each time we update the XML file.

This PR uses a regex to parse the product spec version from a comment in the XML file.