### PR TITLE
Allow Partitioning of DM-to-Science L0B

### DIFF
--- a/python/packages/nisar/workflows/helpers.py
+++ b/python/packages/nisar/workflows/helpers.py
@@ -70,7 +70,8 @@ def build_uniform_quantizer_lut_l0b(
     return bfpq_uq
 
 
-def slice_gen(n_smp: int, n_smp_blk: int) -> Iterator[slice]:
+def slice_gen(
+        n_smp: int, n_smp_blk: int, idx_start: int = 0) -> Iterator[slice]:
     """slice generator.
 
     Parameters
@@ -79,6 +80,8 @@ def slice_gen(n_smp: int, n_smp_blk: int) -> Iterator[slice]:
         Total number of samples
     n_smp_blk : int
         Number of samples per full block
+    idx_start : int, default=0
+        Start index.
 
     Yields
     ------
@@ -88,17 +91,16 @@ def slice_gen(n_smp: int, n_smp_blk: int) -> Iterator[slice]:
         number of samples than `n_smp_blk`!
 
     """
-    n_blk = int(np.ceil(n_smp / n_smp_blk))
-    for n in range(n_blk):
-        i_start = n * n_smp_blk
-        i_stop = min(n_smp, i_start + n_smp_blk)
+    idx_max = n_smp + idx_start
+    for i_start in range(idx_start, idx_max, n_smp_blk):
+        i_stop = min(idx_max, i_start + n_smp_blk)
         yield slice(i_start, i_stop)
 
 
 def copols_or_desired_pols_from_raw(
         raw: 'nisar.products.readers.Raw',
         freq_band: str | None = None,
-        txrx_pol:str | None = None
+        txrx_pol: str | None = None
         ) -> dict[str, list[str]]:
     """
     Get list of transmit-receive polarization names of either all co-pol

--- a/python/packages/nisar/workflows/helpers.py
+++ b/python/packages/nisar/workflows/helpers.py
@@ -6,6 +6,7 @@ import datetime
 import os
 import pathlib
 from collections import defaultdict
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 import json
 import h5py
@@ -69,7 +70,7 @@ def build_uniform_quantizer_lut_l0b(
     return bfpq_uq
 
 
-def slice_gen(n_smp: int, n_smp_blk: int) -> slice:
+def slice_gen(n_smp: int, n_smp_blk: int) -> Iterator[slice]:
     """slice generator.
 
     Parameters

--- a/python/packages/nisar/workflows/nisar_l0b_dm1_to_science.py
+++ b/python/packages/nisar/workflows/nisar_l0b_dm1_to_science.py
@@ -603,6 +603,8 @@ def nisar_l0b_dm1_to_science(args):
 
     # get ref epoch and build AZ slice generator
     epoch, azt_raw = raw.getPulseTimes(freq_band_in, txrx_pol[0])
+    n_rgl_tot = azt_raw.size
+    logger.info(f'Total available number of pulses in L0B -> {n_rgl_tot}')
 
     # Get start and end pulse index of input product to be processed
     # expect at least one range line to be processed!
@@ -611,17 +613,19 @@ def nisar_l0b_dm1_to_science(args):
     if (args.time_start < 0) or not (args.time_start < azt_rel[-1]):
         raise ValueError(
             f'"time-start" shall be within [0, {azt_rel[-1]}) (sec)!')
+    # start time is inclusive!
     start_pulse_idx = np.searchsorted(
         azt_rel, args.time_start, side='right') - 1
     # Check the stop time and get its pulse index
     if args.time_stop is None:
-        stop_pulse_idx = azt_rel.size
+        stop_pulse_idx = n_rgl_tot
     else:
         if args.time_stop < azt_rel[start_pulse_idx + 1]:
             raise ValueError('"time-stop" shall be equal or larger than '
                              f'{azt_rel[start_pulse_idx + 1]} (sec)')
+        # stop time is exclusive!
         stop_pulse_idx = np.searchsorted(
-            azt_rel, args.time_stop, side='right')
+            azt_rel, args.time_stop, side='left') - 1
     logger.info('(start, stop) 0-based pulse index to be processed -> '
                 f'({start_pulse_idx}, {stop_pulse_idx})')
     pulse_slice = slice(start_pulse_idx, stop_pulse_idx)

--- a/python/packages/nisar/workflows/nisar_l0b_dm1_to_science.py
+++ b/python/packages/nisar/workflows/nisar_l0b_dm1_to_science.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import os
 import time
 from warnings import warn
+from datetime import datetime
+from copy import copy
 
 import numpy as np
 from scipy import fft
@@ -18,7 +20,7 @@ except ImportError:
 
 from nisar.products.readers.Raw import Raw
 from nisar.log import set_logger
-from isce3.core import Linspace, speed_of_light
+from isce3.core import Linspace, speed_of_light, TimeDelta
 from isce3.signal import build_multi_rate_fir_filter
 from nisar.workflows.helpers import build_uniform_quantizer_lut_l0b, slice_gen
 
@@ -40,8 +42,10 @@ def cmd_line_parser():
     prs.add_argument('-p', '--product-name', type=str, dest='prod_name',
                      help=('Product science L0B HDF5 file and path name. '
                            'Default is input L0B filename with suffix '
-                           '"Science" added prior to the extension and is '
-                           'stored at the current directory.')
+                           '"_Science_<utc-first>_<utc-last>" added prior to '
+                           'the extension and is stored at the current '
+                           'directory. First/last UTC is set by first/last '
+                           'pulses to be processed.')
                      )
     prs.add_argument('--num-cpu', type=int, dest='num_cpu',
                      help=('Number of CPU/Workers used in filtering.'
@@ -72,6 +76,13 @@ def cmd_line_parser():
     prs.add_argument('--nbits', type=int, dest='nbits', default=12,
                      help='Number of bits representing full dynamic'
                      ' range of valid encoded echo samples.')
+    prs.add_argument('--num-pulses-max', type=int,
+                     help=('Max number of pulses, >=1, starting from '
+                           '`start-pulse` to be processed. Default is all.')
+                     )
+    prs.add_argument('--start-pulse', type=int, default=0,
+                     help='Start pulse 0-based index, >=0, to be processed.'
+                     )
     return prs.parse_args()
 
 
@@ -136,12 +147,16 @@ def _join_paths(path1: str, path2: str) -> str:
 
 
 def copy_swath_except_echo_sr_h5(fid_in, fid_out, swath_path,
-                                 frq_pol, freq_band_in='A', n_sbsw=1):
+                                 frq_pol, freq_band_in='A', n_sbsw=1,
+                                 tx_keys=None, rx_keys=None):
     """
     Copy all groups and datasets under swath from input HDF5 to output
-    HDF5 except for echo products and slant range vector.
-    Slant range and echo fields are skipped because those need to be
-    updated with new size and shape after filtering in range direction.
+    HDF5 except for echo products, slant range vector and optionally for
+    desired datasets under tx and rx group listed by tx_keys and rx_keys.
+    "validSamplesSubSwath*" on tx group will be excluded from being copied..
+    These fields are skipped because those need to be
+    updated with new size and shape after filtering in range direction and
+    slicing in azimuth.
     Given output may have two frequency bands as opposed to the input, e.g.,
     in QQ case, the input values are repeated for output products.
 
@@ -162,8 +177,19 @@ def copy_swath_except_echo_sr_h5(fid_in, fid_out, swath_path,
         "A" or "B" for DM1 not both!
     n_sbsw : int, default=1
         Number of valid subswath with valid values for the output L0B.
+    tx_keys : sequence of str, optional
+        Sequence of dataset names to be excluded from tx group in `fid_out`.
+    rx_keys : sequence of str, optional
+        Sequence of dataset names to be excluded from rx group in `fid_out`.
+        Echo datasets are always excluded from RX group!
 
     """
+    tx_names = ['slantRange']
+    if tx_keys is not None:
+        tx_names.extend(tx_keys)
+    rx_names = []
+    if rx_keys is not None:
+        rx_names.extend(rx_keys)
     # form input single freq-band path.
     band_path_in = _join_paths(swath_path, f'frequency{freq_band_in}/')
     for freq_band in frq_pol:
@@ -173,6 +199,10 @@ def copy_swath_except_echo_sr_h5(fid_in, fid_out, swath_path,
         grp_band = fid_out.require_group(band_path)
         # list of all TxRx products
         txrx_pols = frq_pol[freq_band]
+        # form rx datset names plus echo for all pols to be
+        # excluded from output
+        rx_names_echo = copy(txrx_pols)
+        rx_names_echo.extend(rx_names)
         # list of group names txp where "p" is all TX pols
         # TX is either H or V per output freq_band!
         txp = {f'tx{p[0]}' for p in txrx_pols}
@@ -196,22 +226,13 @@ def copy_swath_except_echo_sr_h5(fid_in, fid_out, swath_path,
                             # create RX group for output product
                             grp_rx = fid_out.require_group(rx_path)
                             for rx_item in fid_in[rx_path_in]:
-                                if rx_item not in txrx_pols:
+                                if rx_item not in rx_names_echo:
                                     # copy all RX fields except echo product
                                     fid_in.copy(rx_path_in + rx_item, grp_rx)
-                    elif tx_item == 'slantRange':
-                        continue
-
-                    elif 'validSamplesSubSwath' in tx_item:
-                        # simply copy good subswaths
-                        if int(tx_item[-1]) <= n_sbsw:
-                            fid_in.copy(tx_path_in + tx_item, grp_tx)
-
-                    else:  # copy the rest of TX as it is
+                    # copy the rest of TX that is not in tx_keys
+                    elif ((tx_item not in tx_names) and
+                          ('validSamplesSubSwath' not in tx_item)):
                         fid_in.copy(tx_path_in + tx_item, grp_tx)
-                        # update number of good subswath
-                        if tx_item == 'numberOfSubSwaths':
-                            grp_tx[tx_item][()] = n_sbsw
 
             else:
                 if band_item[:2] != 'tx':
@@ -222,11 +243,11 @@ def copy_swath_except_echo_sr_h5(fid_in, fid_out, swath_path,
 
 
 def copy_update_identification_h5(
-        fid_in, fid_out, ident_path, list_freqs):
+        fid_in, fid_out, ident_path, list_freqs, **kwargs):
     """
     Copy all items of identification group from input file and update
-    a couple of items for the output product such as DM flag and
-    list of frequencies.
+    a couple of items for the output product such as those in kwargs
+    and the list of frequencies.
 
     Parameters
     ----------
@@ -238,6 +259,9 @@ def copy_update_identification_h5(
         HDF5 path for identification.
     list_freqs : list(str)
         List of frequency band chars.
+    kwargs : dict
+        A dict containing dataset names and values under
+        identification group of HDF5.
 
     """
     grp_ident = fid_out.require_group(ident_path)
@@ -251,8 +275,9 @@ def copy_update_identification_h5(
                 ds.attrs[a_name] = a_val
         else:  # copy everything else
             fid_in.copy(p, grp_ident)
-    # fix DM flag
-    grp_ident['diagnosticModeFlag'][()] = np.uint8(0)
+    # update some fields in kwargs
+    for key, val in kwargs.items():
+        grp_ident[key][()] = val
 
 
 def create_echo_dataset_h5(fid_in, fid_out, band_path, txrx_pol,
@@ -348,25 +373,94 @@ def create_slantrange_update_range_h5(
         fid_out[item_path][()] = val
 
 
-def update_subswath_h5(fid_out, sbsw_path_prefix, sbswath):
+def dump_subswath_h5(fid_out, tx_path, sbswath):
     """
-    Update valid subswath values for an existing fields in new hdf5
-    product.
+    Dump valid subswath values to output HDF5 product.
 
     Parameters
     ----------
     fid_out : h5py.File
         File-like object for output HDF5 L0B product
-    sbsw_path_prefix : str
-        Path prefix for all validsubswath datasets in L0B HDF5 product.
+    tx_path : str
+        TX path where datasets "validSamplesSubSwath*" are located.
     sbswath : np.ndarray(int)
         3-D array for all valid subswaths to be used for the output product.
 
     """
-    num_sbsw, _, _ = sbswath.shape
+    num_sbsw, nrgls, nitems = sbswath.shape
+    shape_sbsw = (nrgls, nitems)
+    grp = fid_out[tx_path]
+    # update number of subswath
+    grp['numberOfSubSwaths'][()] = num_sbsw
+    # create/dump validsubswath datasets
     for n in range(num_sbsw):
-        sbsw_path = sbsw_path_prefix + f'{n + 1}'
-        fid_out[sbsw_path][...] = sbswath[n]
+        sbsw_name = f'validSamplesSubSwath{n + 1}'
+        grp.require_dataset(
+            sbsw_name, shape=shape_sbsw, dtype=sbswath.dtype, data=sbswath[n]
+        )
+
+
+def copy_datasets_truncated_dm1(
+        fid_in, fid_out, band_path_in, band_path, pol, pulse_slice,
+        logger, keys):
+    """
+    Copy truncated version of non-echo pulse-dependent datasets under
+    either tx or rx group from input DM1 HDF5 to output one given desired
+    input pulse slice.
+    The type of tx or rx is determined by the size of pol.
+    If single char then it is tx group and if two-char str then
+    it will be dataset under rx group
+
+    Paramaters
+    ----------
+    fid_in : h5py.File
+        File-like object for input HDF5 L0B product
+    fid_out : h5py.File
+        File-like object for output HDF5 L0B product
+    band_path_in : str
+        Frequency band path of input L0B HDF5 product.
+    band_path : str
+        Frequency band path of output L0B HDF5 product.
+    pol : str
+        Either signle-char tx pol or two-char TxRx polarization
+        of the new echo product
+    pulse_slice : slice
+        Desired pulse slice from input HDF5 file.
+    logger: logging.Logger
+    keys: sequence of str
+        Desired keys under RX group to be copied as long as
+        they exist in input hdf5.
+
+    Notes
+    -----
+    For input DM1, RX and TX pols are the same and they are sitting
+    under the same frequency band as opposed to the output science version.
+
+    """
+    path_in = _join_paths(band_path_in, f'tx{pol[0]}/')
+    path = _join_paths(band_path, f'tx{pol[0]}/')
+    if len(pol) == 2:
+        # XXX for input DM1, RX and TX pols are the same!
+        path_in += f'rx{pol[0]}/'
+        path += f'rx{pol[1]}/'
+    # output group
+    grp_out = fid_out[path]
+    for name in set(keys):
+        try:
+            dset_in = fid_in[path_in + name]
+        except KeyError as err:
+            logger.warning(
+                f'Missing dataset "{path_in + name}" in input L0B!'
+                f' Detailed Error -> "{err}"'
+            )
+            continue
+        else:
+            data_in = dset_in[pulse_slice]
+            dset_out = grp_out.require_dataset(
+                name, shape=data_in.shape, dtype=data_in.dtype, data=data_in)
+            # copy attributes for the product from input
+            for a_name, a_val in dset_in.attrs.items():
+                dset_out.attrs[a_name] = a_val
 
 
 def form_products_dm1(raw: Raw):
@@ -451,6 +545,13 @@ def number_valid_subswath(sbsw):
 
 def nisar_l0b_dm1_to_science(args):
     """Create NISAR science L0B from DM1 L0B product"""
+    # Const
+    # list of rx/tx dataset keys/names to be resized/reproduced
+    # in truncated output HDF5
+    rx_keys = ('caltone', 'RD', 'WD', 'WL', 'basebandPhaseCorrection',
+               'TRMDataWindow', 'attenuation')
+    tx_keys = ('rangeLineIndex', 'radarTime', 'UTCtime', 'txPhase',
+               'calType', 'chirpCorrelator')
 
     tic = time.time()
     # set logger
@@ -500,6 +601,33 @@ def nisar_l0b_dm1_to_science(args):
     epoch, azt_raw = raw.getPulseTimes(freq_band_in, txrx_pol[0])
     n_rgl_tot = azt_raw.size
 
+    # Get start and end pulse index of input product to be processed
+    # expect at least 1 pulse!
+    if args.start_pulse < 0 or args.start_pulse >= (n_rgl_tot - 1):
+        raise ValueError(
+            f'Start pulse {args.start_pulse} must be a non-negative value '
+            f'less than {n_rgl_tot - 1}!'
+        )
+    start_pulse_idx = args.start_pulse
+    num_pulses = n_rgl_tot - start_pulse_idx
+    # get number of pulses to be processed
+    if args.num_pulses_max is not None:
+        if args.num_pulses_max < 1:
+            raise ValueError(
+                f'Max number of pulses {args.num_pulses_max} must be >=1!'
+            )
+        num_pulses = min(args.num_pulses_max,  num_pulses)
+    stop_pulse_idx = start_pulse_idx + num_pulses
+    logger.info(f'Number of pulses for output L0B -> {num_pulses}')
+    logger.info('(start, stop) 0-based pulse index to be processed -> '
+                f'({start_pulse_idx}, {stop_pulse_idx})')
+    pulse_slice = slice(start_pulse_idx, stop_pulse_idx)
+    # Get start and end UTC datetime for output L0B products
+    start_dt_utc = (epoch + TimeDelta(azt_raw[start_pulse_idx])).isoformat()
+    end_dt_utc = (epoch + TimeDelta(azt_raw[stop_pulse_idx - 1])).isoformat()
+    logger.info('(start, end) datetime for output L0B -> '
+                f'({start_dt_utc}, {end_dt_utc})')
+
     # form BFPQ LUT for uniform quantizer to be used for output product
     if args.sign_mag:
         logger.info(
@@ -513,11 +641,17 @@ def nisar_l0b_dm1_to_science(args):
     # BFPQ decoder for basebanded requantized 16-bit output raw echo
     bfpq_uq_16bit = build_uniform_quantizer_lut_l0b(16)
 
+    def utc2filename(dt_utc: str) -> str:
+        """Datetime UTC string into filename string"""
+        return datetime.fromisoformat(dt_utc[:19]).strftime('%Y%m%dT%H%M%S')
+
     # get in/out files and file objects
     p_in = Path(args.l0b_file)
     out_path = Path(args.out_path)
     if args.prod_name is None:
-        suffix = '_Science.h5'
+        utc_first = utc2filename(start_dt_utc)
+        utc_last = utc2filename(end_dt_utc)
+        suffix = f'_Science_{utc_first}_{utc_last}.h5'
         file_out = p_in.stem + suffix
     else:
         file_out = args.prod_name
@@ -536,10 +670,15 @@ def nisar_l0b_dm1_to_science(args):
         logger.warning(f'Missing group "{hrt_path}" in input L0B!'
                        f' Detailed Error -> "{err}"')
     # copy the entire identification into the output product
-    # but modify diagnostic mode flags from DM2 to DBF
-    # and update list of frequencies
+    # but modify diagnostic mode flags from DM2 to DBF,
+    # update start/end zero-Doppler time, and update list of frequencies
+    kwarg_ident = dict()
+    kwarg_ident['diagnosticModeFlag'] = np.uint8(0)
+    kwarg_ident['zeroDopplerStartTime'] = np.bytes_(start_dt_utc)
+    kwarg_ident['zeroDopplerEndTime'] = np.bytes_(end_dt_utc)
     copy_update_identification_h5(
-        fid_in, fid_out, raw.IdentificationPath, list(frq_pol_out))
+        fid_in, fid_out, raw.IdentificationPath, list(frq_pol_out),
+        **kwarg_ident)
 
     # get number of valid subswath
     sbswath = raw.getSubSwaths(freq_band_in, txrx_pol[0])
@@ -550,15 +689,25 @@ def nisar_l0b_dm1_to_science(args):
     logger.info(
         f'Number of subswath in the output file -> {n_sbsw}'
     )
-    # copy entire swath except for TxRx echo products and slant range
+    # copy entire swath except for TxRx echo products and slant range,
+    # validsubswaths and optional TX/RX keys
     copy_swath_except_echo_sr_h5(
-        fid_in, fid_out, raw.SwathPath, frq_pol_out, freq_band_in, n_sbsw)
-
-    # loop over all products and bands
+        fid_in, fid_out, raw.SwathPath, frq_pol_out, freq_band_in, n_sbsw,
+        tx_keys=tx_keys, rx_keys=rx_keys
+    )
     # form a vector of range line slices used for all products
-    rgl_slices = list(slice_gen(n_rgl_tot, args.num_rgl))
+    rgl_slices = list(
+        slice_gen(num_pulses, args.num_rgl, idx_start=start_pulse_idx)
+    )
     logger.info(f'Number of AZ blocks -> {len(rgl_slices)}')
-
+    # Build slices for output L0B that always starts from zero index
+    if start_pulse_idx == 0:
+        rgl_slices_out = rgl_slices
+    else:
+        rgl_slices_out = list(
+            slice_gen(num_pulses, args.num_rgl, idx_start=0)
+        )
+    # loop over all output products and bands
     for freq_band in frq_pol_out:
         # group path for frequency band
         band_path = raw.BandPath(freq_band) + '/'
@@ -567,6 +716,16 @@ def nisar_l0b_dm1_to_science(args):
             logger.info(
                 f'Processing frequency band {freq_band} and Pol '
                 f'{txrx_pol} ...')
+
+            # copy truncated tx/rx datasets per desired rx/tx keys
+            copy_datasets_truncated_dm1(
+                fid_in, fid_out, band_path_in, band_path, txrx_pol[0],
+                pulse_slice, logger, keys=tx_keys
+            )
+            copy_datasets_truncated_dm1(
+                fid_in, fid_out, band_path_in, band_path, txrx_pol,
+                pulse_slice, logger, keys=rx_keys
+            )
 
             # product group path
             tx_grp = band_path + f'tx{txrx_pol[0]}/'
@@ -612,7 +771,7 @@ def nisar_l0b_dm1_to_science(args):
                     'It will be replaced!')
                 dset.table[...] = bfpq_uq
 
-            nazb, nrgb_in = dset.shape
+            _, nrgb_in = dset.shape
             nrgb_up = nrgb_in * flt.upfact
             nrgb_out = round(nrgb_up / flt.downfact)
             logger.info(f'Number of output complex samples -> {nrgb_out}')
@@ -655,26 +814,26 @@ def nisar_l0b_dm1_to_science(args):
             rgb_scalar = 1 / rng_space_scalar
             def scale_rgb(b): return np.int_(np.round(b * rgb_scalar))
             # adjust the range bins in valid sub swath array
-            sbswath = raw.getSubSwaths(freq_band_in, txrx_pol[0])[:n_sbsw]
+            sbswath = raw.getSubSwaths(
+                freq_band_in, txrx_pol[0])[:n_sbsw, pulse_slice]
             sbswath[...] = scale_rgb(sbswath)
             sbswath[sbswath > nrgb_out] = nrgb_out
-            # update valid subswaths values in L0B
-            sbsw_path_prefix = tx_grp + 'validSamplesSubSwath'
-            update_subswath_h5(fid_out, sbsw_path_prefix, sbswath)
+            # copy valid subswaths in L0B
+            dump_subswath_h5(fid_out, tx_grp, sbswath)
 
             # create a placeholder for echo product and use uniform-quantizer
             # BFPQ LUT in place of BFPQ ones.
             dset_prod_out = create_echo_dataset_h5(
-                fid_in, fid_out, band_path, txrx_pol, (nazb, nrgb_out),
+                fid_in, fid_out, band_path, txrx_pol, (num_pulses, nrgb_out),
                 dset.dtype_storage, args.comp_level_h5, band_path_in)
 
             bfpq_path = prod_grp + 'BFPQLUT'
             fid_out[bfpq_path][:] = bfpq_uq_16bit
 
             # loop over AZ blocks
-            for n_blk, rgl_slice in enumerate(rgl_slices, start=1):
+            for n_blk, (rgl_slice, rgl_slice_o) in enumerate(
+                    zip(rgl_slices, rgl_slices_out), start=1):
                 logger.info(f'Processing AZ block # {n_blk} ...')
-
                 # perform filtering in range per AZ block
                 echo_flt = range_filtering_per_az_block(
                     dset[rgl_slice], coefs_flt_fft, flt, n_cpu
@@ -701,7 +860,7 @@ def nisar_l0b_dm1_to_science(args):
                 # quantize and recast
                 dset_prod_out.write_direct(
                     echo_flt.view('f4').round().astype('uint16').view(
-                        dset.dtype_storage), dest_sel=rgl_slice)
+                        dset.dtype_storage), dest_sel=rgl_slice_o)
 
     # close in/out HDF5 files
     fid_in.close()

--- a/python/packages/nisar/workflows/nisar_l0b_dm1_to_science.py
+++ b/python/packages/nisar/workflows/nisar_l0b_dm1_to_science.py
@@ -76,12 +76,16 @@ def cmd_line_parser():
     prs.add_argument('--nbits', type=int, dest='nbits', default=12,
                      help='Number of bits representing full dynamic'
                      ' range of valid encoded echo samples.')
-    prs.add_argument('--num-pulses-max', type=int,
-                     help=('Max number of pulses, >=1, starting from '
-                           '`start-pulse` to be processed. Default is all.')
+    prs.add_argument('--time-start', type=float, default=0,
+                     help=('Start time (seconds) wrt the first range line, '
+                           '>= 0, to be processed. This is inclusive.')
                      )
-    prs.add_argument('--start-pulse', type=int, default=0,
-                     help='Start pulse 0-based index, >=0, to be processed.'
+    prs.add_argument('--time-stop', type=float,
+                     help=('Stop time (seconds) wrt the first range line, '
+                           '> 0, to be processed. Must be larger than '
+                           '`time-start`. Its value will be limited by the '
+                           'time of the last range line. This is exclusive. '
+                           'The default is entire L0B.')
                      )
     return prs.parse_args()
 
@@ -599,29 +603,31 @@ def nisar_l0b_dm1_to_science(args):
 
     # get ref epoch and build AZ slice generator
     epoch, azt_raw = raw.getPulseTimes(freq_band_in, txrx_pol[0])
-    n_rgl_tot = azt_raw.size
 
     # Get start and end pulse index of input product to be processed
-    # expect at least 1 pulse!
-    if args.start_pulse < 0 or args.start_pulse >= (n_rgl_tot - 1):
+    # expect at least one range line to be processed!
+    # Check the start time and get its pulse index
+    azt_rel = azt_raw - azt_raw[0]
+    if (args.time_start < 0) or not (args.time_start < azt_rel[-1]):
         raise ValueError(
-            f'Start pulse {args.start_pulse} must be a non-negative value '
-            f'less than {n_rgl_tot - 1}!'
-        )
-    start_pulse_idx = args.start_pulse
-    num_pulses = n_rgl_tot - start_pulse_idx
-    # get number of pulses to be processed
-    if args.num_pulses_max is not None:
-        if args.num_pulses_max < 1:
-            raise ValueError(
-                f'Max number of pulses {args.num_pulses_max} must be >=1!'
-            )
-        num_pulses = min(args.num_pulses_max,  num_pulses)
-    stop_pulse_idx = start_pulse_idx + num_pulses
-    logger.info(f'Number of pulses for output L0B -> {num_pulses}')
+            f'"time-start" shall be within [0, {azt_rel[-1]}) (sec)!')
+    start_pulse_idx = np.searchsorted(
+        azt_rel, args.time_start, side='right') - 1
+    # Check the stop time and get its pulse index
+    if args.time_stop is None:
+        stop_pulse_idx = azt_rel.size
+    else:
+        if args.time_stop < azt_rel[start_pulse_idx + 1]:
+            raise ValueError('"time-stop" shall be equal or larger than '
+                             f'{azt_rel[start_pulse_idx + 1]} (sec)')
+        stop_pulse_idx = np.searchsorted(
+            azt_rel, args.time_stop, side='right')
     logger.info('(start, stop) 0-based pulse index to be processed -> '
                 f'({start_pulse_idx}, {stop_pulse_idx})')
     pulse_slice = slice(start_pulse_idx, stop_pulse_idx)
+    # get number of pulses to be processed
+    num_pulses = stop_pulse_idx - start_pulse_idx
+    logger.info(f'Number of pulses for output L0B -> {num_pulses}')
     # Get start and end UTC datetime for output L0B products
     start_dt_utc = (epoch + TimeDelta(azt_raw[start_pulse_idx])).isoformat()
     end_dt_utc = (epoch + TimeDelta(azt_raw[stop_pulse_idx - 1])).isoformat()
@@ -834,6 +840,7 @@ def nisar_l0b_dm1_to_science(args):
             for n_blk, (rgl_slice, rgl_slice_o) in enumerate(
                     zip(rgl_slices, rgl_slices_out), start=1):
                 logger.info(f'Processing AZ block # {n_blk} ...')
+                logger.info(f'Processing input rangelines -> {rgl_slice}')
                 # perform filtering in range per AZ block
                 echo_flt = range_filtering_per_az_block(
                     dset[rgl_slice], coefs_flt_fft, flt, n_cpu

--- a/python/packages/nisar/workflows/nisar_l0b_dm1_to_science.py
+++ b/python/packages/nisar/workflows/nisar_l0b_dm1_to_science.py
@@ -42,7 +42,7 @@ def cmd_line_parser():
     prs.add_argument('-p', '--product-name', type=str, dest='prod_name',
                      help=('Product science L0B HDF5 file and path name. '
                            'Default is input L0B filename with suffix '
-                           '"_Science_<utc-first>_<utc-last>" added prior to '
+                           '"_SCIENCE_<utc-first>_<utc-last>" added prior to '
                            'the extension and is stored at the current '
                            'directory. First/last UTC is set by first/last '
                            'pulses to be processed.')
@@ -657,7 +657,7 @@ def nisar_l0b_dm1_to_science(args):
     if args.prod_name is None:
         utc_first = utc2filename(start_dt_utc)
         utc_last = utc2filename(end_dt_utc)
-        suffix = f'_Science_{utc_first}_{utc_last}.h5'
+        suffix = f'_SCIENCE_{utc_first}_{utc_last}.h5'
         file_out = p_in.stem + suffix
     else:
         file_out = args.prod_name

--- a/python/packages/nisar/workflows/nisar_l0b_dm2_to_dbf.py
+++ b/python/packages/nisar/workflows/nisar_l0b_dm2_to_dbf.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import os
 import time
 import tempfile
+from copy import copy
 
 import numpy as np
 from scipy.signal import fftconvolve
@@ -25,14 +26,17 @@ from isce3.io import Raster
 from nisar.log import set_logger
 from isce3.signal import dbf_onetap_from_dm2, dbf_onetap_from_dm2_seamless
 from isce3.focus import fill_gaps, form_linear_chirp
+from isce3.core import TimeDelta
 from nisar.workflows.helpers import build_uniform_quantizer_lut_l0b, slice_gen
 from isce3.antenna import ant2rgdop
 
 
-def copy_swath_except_echo_h5(fid_in, fid_out, swath_path, frq_pol):
+def copy_swath_except_echo_h5(
+        fid_in, fid_out, swath_path, frq_pol, tx_keys=None, rx_keys=None):
     """
     Copy all groups and datasets under swath from input HDF5 to output
-    HDF5 except for echo products.
+    HDF5 except for echo and optionally for desired datasets under tx and
+    rx group listed by tx_keys and rx_keys.
 
     Parameters
     ----------
@@ -45,8 +49,21 @@ def copy_swath_except_echo_h5(fid_in, fid_out, swath_path, frq_pol):
     frq_pol : dict
         A dict of all frequency bands as keys and list of TxRx
         polarization as values.
+    tx_keys : sequence of str, optional
+        Sequence of dataset names to be excluded from tx group in `fid_out`.
+    rx_keys : sequence of str, optional
+        Sequence of dataset names to be excluded from rx group in `fid_out`.
+        Echo datasets are always excluded from RX group!
 
     """
+    # TX/RX dataset names to be excluded over all frequency bands and pols!
+    tx_names = []
+    if tx_keys is not None:
+        tx_names.extend(tx_keys)
+    rx_names = []
+    if rx_keys is not None:
+        rx_names.extend(rx_keys)
+
     for freq_band in frq_pol:
         # build band path
         band_path = os.path.join(swath_path, f'frequency{freq_band}/')
@@ -54,6 +71,10 @@ def copy_swath_except_echo_h5(fid_in, fid_out, swath_path, frq_pol):
         grp_band = fid_out.require_group(band_path)
         # list of all TxRx products
         txrx_pols = frq_pol[freq_band]
+        # form rx datset names plus echo for all pols to be
+        # excluded from output
+        rx_names_echo = copy(txrx_pols)
+        rx_names_echo.extend(rx_names)
         # list of group names txp where "p" is all TX pols
         txp = {f'tx{p[0]}' for p in txrx_pols}
         # list of group names rxp where "p" is all RX pols
@@ -71,11 +92,13 @@ def copy_swath_except_echo_h5(fid_in, fid_out, swath_path, frq_pol):
                         # create RX group for output product
                         grp_rx = fid_out.require_group(rx_path)
                         for rx_item in fid_in[rx_path]:
-                            if rx_item not in txrx_pols:
-                                # copy all RX fields except echo product
+                            if rx_item not in rx_names_echo:
+                                # copy all RX fields except
+                                # echo + rx_keys
                                 fid_in.copy(rx_path + rx_item, grp_rx)
-
-                    else:  # copy the rest of TX as it is
+                    # copy the rest of TX that is not in tx_keys
+                    elif ((tx_item not in tx_names) and
+                          ('validSamplesSubSwath' not in tx_item)):
                         fid_in.copy(tx_path + tx_item, grp_tx)
 
             else:
@@ -130,6 +153,137 @@ def create_echo_dataset_h5(fid_in, fid_out, band_path, txrx_pol,
     for a_name, a_val in fid_in[p_path].attrs.items():
         dset_prod.attrs[a_name] = a_val
     return dset_prod
+
+
+def _copy_datasets_truncated(
+        fid_in, fid_out, band_path, pol, pulse_slice, logger, keys):
+    """
+    Copy truncated version of non-echo pulse-dependent datasets under
+    either tx or rx group from input HDF5 to output one given desired
+    input pulse slice.
+    The type of tx or rx is determined by the size of pol.
+    If single char then it is tx group and if two-char str then
+    it will be dataset under rx group
+
+    Paramaters
+    ----------
+    fid_in : h5py.File
+        File-like object for input HDF5 L0B product
+    fid_out : h5py.File
+        File-like object for output HDF5 L0B product
+    band_path : str
+        Frequency band path in L0B HDF5 product.
+    pol : str
+        Either signle-char tx pol or two-char TxRx polarization
+        of the new echo product
+    pulse_slice : slice
+        Desired pulse slice for input HDF5 file.
+    logger: logging.Logger
+    keys: sequence of str
+        Desired keys under RX group to be copied as long as
+        they exist in input hdf5.
+
+    """
+    path = os.path.join(band_path, f'tx{pol[0]}/')
+    if len(pol) == 2:
+        path += f'rx{pol[1]}/'
+    # output group
+    grp_out = fid_out[path]
+    for name in set(keys):
+        try:
+            dset_in = fid_in[path + name]
+        except KeyError as err:
+            logger.warning(
+                f'Missing dataset "{path + name}" in input L0B!'
+                f' Detailed Error -> "{err}"'
+            )
+            continue
+        else:
+            data_in = dset_in[pulse_slice.start:pulse_slice.stop]
+            dset_out = grp_out.create_dataset(
+                name, shape=data_in.shape, dtype=data_in.dtype, data=data_in)
+            # copy attributes for the product from input
+            for a_name, a_val in dset_in.attrs.items():
+                dset_out.attrs[a_name] = a_val
+
+
+def copy_rx_datasets_truncated(
+        fid_in, fid_out, band_path, txrx_pol, pulse_slice, logger,
+        keys=('caltone', 'RD', 'WD', 'WL', 'basebandPhaseCorrection',
+              'TRMDataWindow', 'attenuation')
+):
+    """
+    Copy truncated version of non-echo pulse-dependent datasets under rx group
+    from input HDF5 to output one given desired input pulse slice.
+
+    Paramaters
+    ----------
+    fid_in : h5py.File
+        File-like object for input HDF5 L0B product
+    fid_out : h5py.File
+        File-like object for output HDF5 L0B product
+    band_path : str
+        Frequency band path in L0B HDF5 product.
+    txrx_pol : str
+        TxRx polarization of the new echo product
+    pulse_slice : slice
+        Desired pulse slice for input HDF5 file.
+    logger: logging.Logger
+    keys: sequence of str
+        Desired keys under RX group to be copied as long as
+        they exist in input hdf5.
+        Default is ('caltone', 'RD', 'WD', 'WL', 'basebandPhaseCorrection',
+        'TRMDataWindow', 'attenuation').
+
+    """
+    _copy_datasets_truncated(
+        fid_in, fid_out, band_path, txrx_pol, pulse_slice, logger, keys)
+
+
+def copy_tx_datasets_truncated(
+        fid_in, fid_out, band_path, tx_pol, pulse_slice, logger,
+        keys=('rangeLineIndex', 'radarTime', 'UTCtime', 'txPhase',
+              'calType', 'chirpCorrelator')
+):
+    """
+    Copy truncated version of non-echo pulse-dependent datasets under tx group
+    from input HDF5 to output one given desired input pulse slice.
+
+    Paramaters
+    ----------
+    fid_in : h5py.File
+        File-like object for input HDF5 L0B product
+    fid_out : h5py.File
+        File-like object for output HDF5 L0B product
+    band_path : str
+        Frequency band path in L0B HDF5 product.
+    tx_pol : str
+        Tx polarization of the new echo product
+    pulse_slice : slice
+        Desired pulse slice for input HDF5 file.
+    logger: logging.Logger
+    keys: sequence of str
+        Desired keys under TX group to be copied as long as
+        they exist in input hdf5.
+        Default is
+        ('rangeLineIndex', 'radarTime', 'UTCtime', 'txPhase',
+        'calType', 'chirpCorrelator')
+
+    Notes
+    -----
+    'validSamplesSubSwath*' will be accounted for internally and
+    thus shall be excluded from the `keys`.
+
+    """
+    # form list of keys excluding valid subswath
+    keys_new = [k for k in keys if "validSamplesSubSwath" not in k]
+    # get dataset names for valid subswath and appended them to the new list
+    path = os.path.join(band_path, f'tx{tx_pol[0]}/')
+    num_sbsw = fid_in[path + 'numberOfSubSwaths'][()]
+    for n in range(1, num_sbsw + 1):
+        keys_new.append(f'validSamplesSubSwath{n}')
+    _copy_datasets_truncated(
+        fid_in, fid_out, band_path, tx_pol, pulse_slice, logger, keys_new)
 
 
 def cmd_line_parser():
@@ -236,11 +390,25 @@ def cmd_line_parser():
                            'pattern coverage of swath. A positive value used '
                            'only if `rx-antpat-calib`.')
                      )
+    prs.add_argument('--num-pulses-max', type=int,
+                     help=('Max number of pulses, >=1, starting from '
+                           '`start-pulse` to be processed. Default is all.')
+                     )
+    prs.add_argument('--start-pulse', type=int, default=1,
+                     help='Start pulse number, >=1, to be processed.'
+                     )
     return prs.parse_args()
 
 
 def nisar_l0b_dm2_to_dbf(args):
     """Create NISAR one-tap DBFed L0B from DM2 L0B product"""
+    # Const
+    # list of rx/tx dataset keys/names to be resized/reproduced
+    # in truncated output HDF5
+    rx_keys = ('caltone', 'RD', 'WD', 'WL', 'basebandPhaseCorrection',
+               'TRMDataWindow', 'attenuation')
+    tx_keys = ('rangeLineIndex', 'radarTime', 'UTCtime', 'txPhase',
+               'calType', 'chirpCorrelator')
 
     tic = time.time()
     if args.multiplier is not None and args.multiplier < 0:
@@ -301,6 +469,32 @@ def nisar_l0b_dm2_to_dbf(args):
     # get ref epoch and build AZ slice generator
     epoch, azt_raw = raw.getPulseTimes(freq_band, txrx_pol[0])
     n_rgl_tot = azt_raw.size
+    logger.info(f'Total available number of pulses in L0B -> {n_rgl_tot}')
+    # Get start and end pulse index of input product to be processed
+    # expect at least 1 pulse!
+    if args.start_pulse >= n_rgl_tot:
+        raise ValueError(
+            f'Start pulse {args.start_pulse} must be less than {n_rgl_tot}!'
+        )
+    start_pulse_idx = args.start_pulse - 1
+    num_pulses = n_rgl_tot - start_pulse_idx
+    # get number of pulses to be processed
+    if args.num_pulses_max is not None:
+        if args.num_pulses_max < 1:
+            raise ValueError(
+                f'Max number of pulses {args.num_pulses_max} must be >=1!'
+            )
+        num_pulses = min(args.num_pulses_max,  num_pulses)
+    stop_pulse_idx = start_pulse_idx + num_pulses
+    logger.info(f'Number of pulses for output L0B -> {num_pulses}')
+    logger.info('(start, stop) 0-based pulse index to be processed -> '
+                f'({start_pulse_idx}, {stop_pulse_idx})')
+    pulse_slice = slice(start_pulse_idx, stop_pulse_idx)
+    # Get start and end UTC datetime for output L0B products
+    start_dt_utc = (epoch + TimeDelta(azt_raw[start_pulse_idx])).isoformat()
+    end_dt_utc = (epoch + TimeDelta(azt_raw[stop_pulse_idx - 1])).isoformat()
+    logger.info('(start, end) datetime for output L0B -> '
+                f'({start_dt_utc}, {end_dt_utc})')
 
     # check the size of the sample delays and reverse the sign
     dset = raw.getRawDataset(freq_band, txrx_pol)
@@ -387,12 +581,16 @@ def nisar_l0b_dm2_to_dbf(args):
                        f' Detailed Error -> "{err}"')
     # copy the entire identification into the output product
     # but modify diagnostic mode flags from DM2 to DBF
+    # as well as update start and end zero-Doppler datetime!
     grp_root = fid_out.require_group(raw.RootPath)
     fid_in.copy(raw.IdentificationPath, grp_root)
     grp_ident = fid_out[raw.IdentificationPath]
     grp_ident['diagnosticModeFlag'][()] = np.uint8(0)
+    grp_ident['zeroDopplerStartTime'][()] = np.bytes_(start_dt_utc)
+    grp_ident['zeroDopplerEndTime'][()] = np.bytes_(end_dt_utc)
     # copy entire swath except for TxRx echo products
-    copy_swath_except_echo_h5(fid_in, fid_out, raw.SwathPath, frq_pol)
+    copy_swath_except_echo_h5(fid_in, fid_out, raw.SwathPath, frq_pol,
+                              tx_keys=tx_keys, rx_keys=rx_keys)
 
     # get DBF sampling rate
     fs_dbf = raw.getSampleRateDBF(freq_band, txrx_pol)
@@ -400,8 +598,17 @@ def nisar_l0b_dm2_to_dbf(args):
 
     # loop over all products and bands
     # form a vector of range line slices used for all products
-    rgl_slices = list(slice_gen(n_rgl_tot, args.num_rgl))
+    rgl_slices = list(
+        slice_gen(num_pulses, args.num_rgl, idx_start=start_pulse_idx)
+    )
     logger.info(f'Number of AZ blocks -> {len(rgl_slices)}')
+    # Build slices for output L0B that always starts from zero index
+    if start_pulse_idx == 0:
+        rgl_slices_out = rgl_slices
+    else:
+        rgl_slices_out = list(
+            slice_gen(num_pulses, args.num_rgl, idx_start=0)
+        )
 
     for freq_band, sample_delays in zip(frq_pol, sample_delays_all):
         # group path for frequency band
@@ -431,6 +638,11 @@ def nisar_l0b_dm2_to_dbf(args):
                     amp_cal = cal_avg_amp.min() / cal_avg
                 logger.info(f'Final calibration multipliers -> {amp_cal}')
 
+            # copy truncated tx/rx datasets per desired rx/tx keys
+            copy_tx_datasets_truncated(fid_in, fid_out, band_path, txrx_pol[0],
+                                       pulse_slice, logger, keys=tx_keys)
+            copy_rx_datasets_truncated(fid_in, fid_out, band_path, txrx_pol,
+                                       pulse_slice, logger, keys=rx_keys)
             # product group path
             prod_grp = band_path + f'tx{txrx_pol[0]}/rx{txrx_pol[1]}/'
 
@@ -462,12 +674,11 @@ def nisar_l0b_dm2_to_dbf(args):
             # create a placeholder for echo product and use uniform-quantizer
             # BFPQ LUT in place of BFPQ ones.
             dset_prod_out = create_echo_dataset_h5(
-                fid_in, fid_out, band_path, txrx_pol, dset.shape[1:],
+                fid_in, fid_out, band_path, txrx_pol, (num_pulses, sr.size),
                 dset.dtype_storage, args.comp_level_h5)
 
             bfpq_path = prod_grp + 'BFPQLUT'
             fid_out[bfpq_path][:] = bfpq_uq
-
             # Get valid subswath to fill in TX gap regions with zero
             # due to non-mitigated strong TX Cal loop-back chirps.
             sbsw = raw.getSubSwaths(freq_band, txrx_pol[0])
@@ -561,7 +772,8 @@ def nisar_l0b_dm2_to_dbf(args):
                 shape=(num_chanl, num_rgl, sr.size),
                 dtype=dset.dtype)
             # loop over AZ blocks
-            for n_blk, rgl_slice in enumerate(rgl_slices, start=1):
+            for n_blk, (rgl_slice, rgl_slice_o) in enumerate(
+                    zip(rgl_slices, rgl_slices_out), start=1):
                 logger.info(f'Processing AZ block # {n_blk} ...')
                 num_rgl = rgl_slice.stop - rgl_slice.start
                 # fill in 3-D memmap complex array with decoded echo,
@@ -665,20 +877,22 @@ def nisar_l0b_dm2_to_dbf(args):
 
                 # store echo data per AZ block
                 dset_prod_out.write_direct(echo_dbf.astype(
-                    'uint16').view(dset.dtype_storage), dest_sel=rgl_slice)
+                    'uint16').view(dset.dtype_storage), dest_sel=rgl_slice_o)
 
                 # compute WD/WL values to be updated per single-tap DBF
                 # use mid range line values
                 rgb_limits_dbf = _rescale2dbf(rgb_limits)
                 rgl_mid = (rgl_slice.start + rgl_slice.stop) // 2
+                rd_new = rd[rgl_mid]
                 wd_new, wl_new = _wd_wl_single_tap_dbf(
-                    rgb_limits_dbf, dwp_first[rgl_mid], rd[rgl_mid])
+                    rgb_limits_dbf, dwp_first[rgl_mid], rd_new)
                 logger.info(f'New WDs per AZ block # {n_blk} -> {wd_new}')
                 logger.info(f'New WLs per AZ block # {n_blk} -> {wl_new}')
-                # update HDF5 datasets WD/WL per AZ block
+                # update HDF5 datasets RD/WD/WL per AZ block
                 grp_prod = dset_prod_out.parent
-                grp_prod['WD'][rgl_slice] = wd_new
-                grp_prod['WL'][rgl_slice] = wl_new
+                grp_prod['WD'][rgl_slice_o] = wd_new
+                grp_prod['WL'][rgl_slice_o] = wl_new
+                grp_prod['RD'][rgl_slice_o] = rd_new
 
             # destroy memmap and close the temp file
             del dset_azblk, fid_tmp

--- a/python/packages/nisar/workflows/nisar_l0b_dm2_to_dbf.py
+++ b/python/packages/nisar/workflows/nisar_l0b_dm2_to_dbf.py
@@ -402,12 +402,16 @@ def cmd_line_parser():
                            'pattern coverage of swath. A positive value used '
                            'only if `rx-antpat-calib`.')
                      )
-    prs.add_argument('--num-pulses-max', type=int,
-                     help=('Max number of pulses, >=1, starting from '
-                           '`start-pulse` to be processed. Default is all.')
+    prs.add_argument('--time-start', type=float, default=0,
+                     help=('Start time (seconds) wrt the first range line, '
+                           '>= 0, to be processed. This is inclusive.')
                      )
-    prs.add_argument('--start-pulse', type=int, default=0,
-                     help='Start pulse 0-based index, >=0, to be processed.'
+    prs.add_argument('--time-stop', type=float,
+                     help=('Stop time (seconds) wrt the first range line, '
+                           '> 0, to be processed. Must be larger than '
+                           '`time-start`. Its value will be limited by the '
+                           'time of the last range line. This is exclusive. '
+                           'The default is entire L0B.')
                      )
     return prs.parse_args()
 
@@ -478,31 +482,37 @@ def nisar_l0b_dm2_to_dbf(args):
                         ' averaged complex caltones!')
     else:  # No calibration, set cal amplitude to None!
         amp_cal = None
+
     # get ref epoch and build AZ slice generator
     epoch, azt_raw = raw.getPulseTimes(freq_band, txrx_pol[0])
     n_rgl_tot = azt_raw.size
     logger.info(f'Total available number of pulses in L0B -> {n_rgl_tot}')
     # Get start and end pulse index of input product to be processed
-    # expect at least 1 pulse!
-    if args.start_pulse < 0 or args.start_pulse >= (n_rgl_tot - 1):
+    # expect at least one range line to be processed!
+    # Check the start time and get its pulse index
+    azt_rel = azt_raw - azt_raw[0]
+    if (args.time_start < 0) or not (args.time_start < azt_rel[-1]):
         raise ValueError(
-            f'Start pulse {args.start_pulse} must be a non-negative value '
-            f'less than {n_rgl_tot - 1}!'
-        )
-    start_pulse_idx = args.start_pulse
-    num_pulses = n_rgl_tot - start_pulse_idx
-    # get number of pulses to be processed
-    if args.num_pulses_max is not None:
-        if args.num_pulses_max < 1:
-            raise ValueError(
-                f'Max number of pulses {args.num_pulses_max} must be >=1!'
-            )
-        num_pulses = min(args.num_pulses_max,  num_pulses)
-    stop_pulse_idx = start_pulse_idx + num_pulses
-    logger.info(f'Number of pulses for output L0B -> {num_pulses}')
+            f'"time-start" shall be within [0, {azt_rel[-1]}) (sec)!')
+    # start time is inclusive!
+    start_pulse_idx = np.searchsorted(
+        azt_rel, args.time_start, side='right') - 1
+    # Check the stop time and get its pulse index
+    if args.time_stop is None:
+        stop_pulse_idx = n_rgl_tot
+    else:
+        if args.time_stop < azt_rel[start_pulse_idx + 1]:
+            raise ValueError('"time-stop" shall be equal or larger than '
+                             f'{azt_rel[start_pulse_idx + 1]} (sec)')
+        # stop time is exclusive!
+        stop_pulse_idx = np.searchsorted(
+            azt_rel, args.time_stop, side='left') - 1
     logger.info('(start, stop) 0-based pulse index to be processed -> '
                 f'({start_pulse_idx}, {stop_pulse_idx})')
     pulse_slice = slice(start_pulse_idx, stop_pulse_idx)
+    # get number of pulses to be processed
+    num_pulses = stop_pulse_idx - start_pulse_idx
+    logger.info(f'Number of pulses for output L0B -> {num_pulses}')
     # Get start and end UTC datetime for output L0B products
     start_dt_utc = (epoch + TimeDelta(azt_raw[start_pulse_idx])).isoformat()
     end_dt_utc = (epoch + TimeDelta(azt_raw[stop_pulse_idx - 1])).isoformat()
@@ -794,6 +804,7 @@ def nisar_l0b_dm2_to_dbf(args):
             for n_blk, (rgl_slice, rgl_slice_o) in enumerate(
                     zip(rgl_slices, rgl_slices_out), start=1):
                 logger.info(f'Processing AZ block # {n_blk} ...')
+                logger.info(f'Processing input rangelines -> {rgl_slice}')
                 num_rgl = rgl_slice.stop - rgl_slice.start
                 # fill in 3-D memmap complex array with decoded echo,
                 # one channel at a time to avoid memory issue!

--- a/python/packages/nisar/workflows/nisar_l0b_dm2_to_dbf.py
+++ b/python/packages/nisar/workflows/nisar_l0b_dm2_to_dbf.py
@@ -331,7 +331,7 @@ def cmd_line_parser():
     prs.add_argument('-p', '--product-name', type=str, dest='prod_name',
                      help=('Product science L0B HDF5 file and path name. '
                            'Default is input L0B filename with suffix '
-                           '"_OneTap_DBF_<utc-first>_<utc-last>" added prior '
+                           '"_ONE_TAP_DBF_<utc-first>_<utc-last>" added prior '
                            'to the extension and is stored at the current '
                            'directory. First/last UTC is set by first/last '
                            'pulses to be processed.')
@@ -590,7 +590,7 @@ def nisar_l0b_dm2_to_dbf(args):
     if args.prod_name is None:
         utc_first = utc2filename(start_dt_utc)
         utc_last = utc2filename(end_dt_utc)
-        suffix = f'_OneTap_DBF_{utc_first}_{utc_last}.h5'
+        suffix = f'_ONE_TAP_DBF_{utc_first}_{utc_last}.h5'
         file_out = p_in.stem + suffix
     else:
         file_out = args.prod_name

--- a/python/packages/nisar/workflows/nisar_l0b_dm2_to_dbf.py
+++ b/python/packages/nisar/workflows/nisar_l0b_dm2_to_dbf.py
@@ -8,6 +8,7 @@ import os
 import time
 import tempfile
 from copy import copy
+from datetime import datetime
 
 import numpy as np
 from scipy.signal import fftconvolve
@@ -37,6 +38,7 @@ def copy_swath_except_echo_h5(
     Copy all groups and datasets under swath from input HDF5 to output
     HDF5 except for echo and optionally for desired datasets under tx and
     rx group listed by tx_keys and rx_keys.
+    "validSamplesSubSwath*" on tx group will be excluded from being copied.
 
     Parameters
     ----------
@@ -200,7 +202,7 @@ def _copy_datasets_truncated(
             continue
         else:
             data_in = dset_in[pulse_slice.start:pulse_slice.stop]
-            dset_out = grp_out.create_dataset(
+            dset_out = grp_out.require_dataset(
                 name, shape=data_in.shape, dtype=data_in.dtype, data=data_in)
             # copy attributes for the product from input
             for a_name, a_val in dset_in.attrs.items():
@@ -321,8 +323,10 @@ def cmd_line_parser():
     prs.add_argument('-p', '--product-name', type=str, dest='prod_name',
                      help=('Product science L0B HDF5 file and path name. '
                            'Default is input L0B filename with suffix '
-                           '"OneTap_DBF" added prior to the extension and is '
-                           'stored at the current directory.')
+                           '"_OneTap_DBF_<utc-first>_<utc-last>" added prior '
+                           'to the extension and is stored at the current '
+                           'directory. First/last UTC is set by first/last '
+                           'pulses to be processed.')
                      )
     prs.add_argument('--num-cpu', type=int, dest='num_cpu',
                      help=('Number of CPU/Workers used in range compression. '
@@ -557,11 +561,17 @@ def nisar_l0b_dm2_to_dbf(args):
     bfpq_uq = build_uniform_quantizer_lut_l0b(nbits)
     max_valid_int = 2**(nbits - 1) - 1
 
+    def utc2filename(dt_utc: str) -> str:
+        """Datetime UTC string into filename string"""
+        return datetime.fromisoformat(dt_utc[:19]).strftime('%Y%m%dT%H%M%S')
+
     # get in/out files and file objects
     p_in = Path(args.l0b_file)
     out_path = Path(args.out_path)
     if args.prod_name is None:
-        suffix = '_OneTap_DBF.h5'
+        utc_first = utc2filename(start_dt_utc)
+        utc_last = utc2filename(end_dt_utc)
+        suffix = f'_OneTap_DBF_{utc_first}_{utc_last}.h5'
         file_out = p_in.stem + suffix
     else:
         file_out = args.prod_name

--- a/python/packages/nisar/workflows/nisar_l0b_dm2_to_dbf.py
+++ b/python/packages/nisar/workflows/nisar_l0b_dm2_to_dbf.py
@@ -406,8 +406,8 @@ def cmd_line_parser():
                      help=('Max number of pulses, >=1, starting from '
                            '`start-pulse` to be processed. Default is all.')
                      )
-    prs.add_argument('--start-pulse', type=int, default=1,
-                     help='Start pulse number, >=1, to be processed.'
+    prs.add_argument('--start-pulse', type=int, default=0,
+                     help='Start pulse 0-based index, >=0, to be processed.'
                      )
     return prs.parse_args()
 
@@ -484,11 +484,12 @@ def nisar_l0b_dm2_to_dbf(args):
     logger.info(f'Total available number of pulses in L0B -> {n_rgl_tot}')
     # Get start and end pulse index of input product to be processed
     # expect at least 1 pulse!
-    if args.start_pulse >= n_rgl_tot:
+    if args.start_pulse < 0 or args.start_pulse >= (n_rgl_tot - 1):
         raise ValueError(
-            f'Start pulse {args.start_pulse} must be less than {n_rgl_tot}!'
+            f'Start pulse {args.start_pulse} must be a non-negative value '
+            f'less than {n_rgl_tot - 1}!'
         )
-    start_pulse_idx = args.start_pulse - 1
+    start_pulse_idx = args.start_pulse
     num_pulses = n_rgl_tot - start_pulse_idx
     # get number of pulses to be processed
     if args.num_pulses_max is not None:

--- a/python/packages/nisar/workflows/nisar_l0b_dm2_to_dbf.py
+++ b/python/packages/nisar/workflows/nisar_l0b_dm2_to_dbf.py
@@ -32,6 +32,14 @@ from nisar.workflows.helpers import build_uniform_quantizer_lut_l0b, slice_gen
 from isce3.antenna import ant2rgdop
 
 
+def _join_paths(path1: str, path2: str) -> str:
+    """Join two paths to be used in HDF5"""
+    sep = '/'
+    if path1.endswith(sep):
+        sep = ''
+    return path1 + sep + path2
+
+
 def copy_swath_except_echo_h5(
         fid_in, fid_out, swath_path, frq_pol, tx_keys=None, rx_keys=None):
     """
@@ -68,7 +76,7 @@ def copy_swath_except_echo_h5(
 
     for freq_band in frq_pol:
         # build band path
-        band_path = os.path.join(swath_path, f'frequency{freq_band}/')
+        band_path = _join_paths(swath_path, f'frequency{freq_band}/')
         # create freq band group for output product
         grp_band = fid_out.require_group(band_path)
         # list of all TxRx products
@@ -142,7 +150,7 @@ def create_echo_dataset_h5(fid_in, fid_out, band_path, txrx_pol,
     in output HDF5
 
     """
-    rx_path = os.path.join(band_path, f'tx{txrx_pol[0]}/rx{txrx_pol[1]}/')
+    rx_path = _join_paths(band_path, f'tx{txrx_pol[0]}/rx{txrx_pol[1]}/')
     # create a place holder for dataset
     grp_rx = fid_out[rx_path]
     dset_prod = grp_rx.create_dataset(
@@ -186,7 +194,7 @@ def _copy_datasets_truncated(
         they exist in input hdf5.
 
     """
-    path = os.path.join(band_path, f'tx{pol[0]}/')
+    path = _join_paths(band_path, f'tx{pol[0]}/')
     if len(pol) == 2:
         path += f'rx{pol[1]}/'
     # output group
@@ -201,7 +209,7 @@ def _copy_datasets_truncated(
             )
             continue
         else:
-            data_in = dset_in[pulse_slice.start:pulse_slice.stop]
+            data_in = dset_in[pulse_slice]
             dset_out = grp_out.require_dataset(
                 name, shape=data_in.shape, dtype=data_in.dtype, data=data_in)
             # copy attributes for the product from input
@@ -280,7 +288,7 @@ def copy_tx_datasets_truncated(
     # form list of keys excluding valid subswath
     keys_new = [k for k in keys if "validSamplesSubSwath" not in k]
     # get dataset names for valid subswath and appended them to the new list
-    path = os.path.join(band_path, f'tx{tx_pol[0]}/')
+    path = _join_paths(band_path, f'tx{tx_pol[0]}/')
     num_sbsw = fid_in[path + 'numberOfSubSwaths'][()]
     for n in range(1, num_sbsw + 1):
         keys_new.append(f'validSamplesSubSwath{n}')

--- a/tests/python/packages/nisar/workflows/nisar_l0b_dm1_to_science.py
+++ b/tests/python/packages/nisar/workflows/nisar_l0b_dm1_to_science.py
@@ -8,14 +8,15 @@ import iscetest
 
 
 @pytest.mark.parametrize(
-        "prod_name,ovsf_rg,plot,num_cpu",
-        [
-            (None, None, False, None),
-            ('dm1.h5', 1.2, True, 4)
-        ],
-        ids=["default", "non-default"]
+    "prod_name,ovsf_rg,plot,num_cpu,start_pulse,num_pulses_max",
+    [
+        (None, None, False, None, 0, None),
+        ('dm1.h5', 1.2, True, 4, 11, 30)
+    ],
+    ids=["default", "non-default"]
 )
-def test_nisar_l0b_dm1_to_science(prod_name, ovsf_rg, plot, num_cpu):
+def test_nisar_l0b_dm1_to_science(
+        prod_name, ovsf_rg, plot, num_cpu, start_pulse, num_pulses_max):
     # sub directory for all test files under "isce3/tests/data"
     sub_dir = 'dm1_dm2'
     # Simulated single-pol single-band NISAR-like DM1 L0B product
@@ -35,6 +36,8 @@ def test_nisar_l0b_dm1_to_science(prod_name, ovsf_rg, plot, num_cpu):
         plot=plot,
         ovsf_rg=ovsf_rg,
         sign_mag=False,
-        nbits=12
+        nbits=12,
+        start_pulse=start_pulse,
+        num_pulses_max=num_pulses_max
     )
     nisar_l0b_dm1_to_science(args)

--- a/tests/python/packages/nisar/workflows/nisar_l0b_dm1_to_science.py
+++ b/tests/python/packages/nisar/workflows/nisar_l0b_dm1_to_science.py
@@ -8,15 +8,15 @@ import iscetest
 
 
 @pytest.mark.parametrize(
-    "prod_name,ovsf_rg,plot,num_cpu,start_pulse,num_pulses_max",
+    "prod_name,ovsf_rg,plot,num_cpu,time_start,time_stop",
     [
         (None, None, False, None, 0, None),
-        ('dm1.h5', 1.2, True, 4, 11, 30)
+        ('dm1.h5', 1.2, True, 4, 0.01, 0.5)
     ],
     ids=["default", "non-default"]
 )
 def test_nisar_l0b_dm1_to_science(
-        prod_name, ovsf_rg, plot, num_cpu, start_pulse, num_pulses_max):
+        prod_name, ovsf_rg, plot, num_cpu, time_start, time_stop):
     # sub directory for all test files under "isce3/tests/data"
     sub_dir = 'dm1_dm2'
     # Simulated single-pol single-band NISAR-like DM1 L0B product
@@ -37,7 +37,7 @@ def test_nisar_l0b_dm1_to_science(
         ovsf_rg=ovsf_rg,
         sign_mag=False,
         nbits=12,
-        start_pulse=start_pulse,
-        num_pulses_max=num_pulses_max
+        time_start=time_start,
+        time_stop=time_stop
     )
     nisar_l0b_dm1_to_science(args)

--- a/tests/python/packages/nisar/workflows/nisar_l0b_dm2_to_dbf.py
+++ b/tests/python/packages/nisar/workflows/nisar_l0b_dm2_to_dbf.py
@@ -8,16 +8,18 @@ import iscetest
 
 
 @pytest.mark.parametrize(
-    "no_rgcomp,calib,plot,prod_name,rx_antpat_calib,max_p2p_ant",
+    ("no_rgcomp,calib,plot,prod_name,rx_antpat_calib,max_p2p_ant,"
+     "start_pulse,num_pulses_max"),
     [
-        (True, False, False, "dm2_seamed.h5", False, None),
-        (True, False, False, "dm2_seamed_antpat_calib.h5", True, None),
-        (False, True, True, None, True, 6.0)
+        (True, False, False, "dm2_seamed.h5", False, None, 15, 1000),
+        (True, False, False, "dm2_seamed_antpat_calib.h5", True, None, 5, 35),
+        (False, True, True, None, True, 6.0, 1, None)
     ],
     ids=["seamed", "seamed_antcal", "seamless"]
 )
 def test_nisar_l0b_dm2_to_dbf(
-        no_rgcomp, calib, plot, prod_name, rx_antpat_calib, max_p2p_ant):
+        no_rgcomp, calib, plot, prod_name, rx_antpat_calib,
+        max_p2p_ant, start_pulse, num_pulses_max):
     # sub directory for all test files under "isce3/tests/data"
     sub_dir = 'dm1_dm2'
     # Simulated single-pol single-band NISAR-like DM2 L0B product
@@ -53,6 +55,8 @@ def test_nisar_l0b_dm2_to_dbf(
         sample_delays=11 * [0],
         sample_delays2=None,
         rx_antpat_calib=rx_antpat_calib,
-        max_p2p_ant=max_p2p_ant
+        max_p2p_ant=max_p2p_ant,
+        start_pulse=start_pulse,
+        num_pulses_max=num_pulses_max
     )
     nisar_l0b_dm2_to_dbf(args)

--- a/tests/python/packages/nisar/workflows/nisar_l0b_dm2_to_dbf.py
+++ b/tests/python/packages/nisar/workflows/nisar_l0b_dm2_to_dbf.py
@@ -11,9 +11,9 @@ import iscetest
     ("no_rgcomp,calib,plot,prod_name,rx_antpat_calib,max_p2p_ant,"
      "start_pulse,num_pulses_max"),
     [
-        (True, False, False, "dm2_seamed.h5", False, None, 15, 1000),
+        (True, False, False, "dm2_seamed.h5", False, None, 14, 1000),
         (True, False, False, "dm2_seamed_antpat_calib.h5", True, None, 5, 35),
-        (False, True, True, None, True, 6.0, 1, None)
+        (False, True, True, None, True, 6.0, 0, None)
     ],
     ids=["seamed", "seamed_antcal", "seamless"]
 )

--- a/tests/python/packages/nisar/workflows/nisar_l0b_dm2_to_dbf.py
+++ b/tests/python/packages/nisar/workflows/nisar_l0b_dm2_to_dbf.py
@@ -9,17 +9,17 @@ import iscetest
 
 @pytest.mark.parametrize(
     ("no_rgcomp,calib,plot,prod_name,rx_antpat_calib,max_p2p_ant,"
-     "start_pulse,num_pulses_max"),
+     "time_start,time_stop"),
     [
-        (True, False, False, "dm2_seamed.h5", False, None, 14, 1000),
-        (True, False, False, "dm2_seamed_antpat_calib.h5", True, None, 5, 35),
+        (True, False, False, "dm2_seamed.h5", False, None, 0.01, 1.0),
+        (True, False, False, "dm2_seamed_antpat_calib.h5", True, None, 0.005, 0.03),
         (False, True, True, None, True, 6.0, 0, None)
     ],
     ids=["seamed", "seamed_antcal", "seamless"]
 )
 def test_nisar_l0b_dm2_to_dbf(
         no_rgcomp, calib, plot, prod_name, rx_antpat_calib,
-        max_p2p_ant, start_pulse, num_pulses_max):
+        max_p2p_ant, time_start, time_stop):
     # sub directory for all test files under "isce3/tests/data"
     sub_dir = 'dm1_dm2'
     # Simulated single-pol single-band NISAR-like DM2 L0B product
@@ -56,7 +56,7 @@ def test_nisar_l0b_dm2_to_dbf(
         sample_delays2=None,
         rx_antpat_calib=rx_antpat_calib,
         max_p2p_ant=max_p2p_ant,
-        start_pulse=start_pulse,
-        num_pulses_max=num_pulses_max
+        time_start=time_start,
+        time_stop=time_stop
     )
     nisar_l0b_dm2_to_dbf(args)


### PR DESCRIPTION
This PR simply adds optional L0B partitioning capability to DM2-to-science workflow to speed up generation of large mosaicked (1-tap DBF) L0B product via embarrassingly parallel I/O over smaller chunks of a large DM2 L0B product (way beyond `240-km` along track).
Due to similarity to DM2 counterpart, the DM1-to-science workflow has also being updated in similar fashion.
Note that trivial instrument-related high-rate telemetry fields of input L0B product are not chunked but rather repeated in all sub-products.
Moreover, the bounding polygon and the original filename covering entire input L0B are preserved in all sub-products for the sake of convenient tracking of original product and DEM generation.
Simply start/end zero Doppler date-time associated with each part is reflected in both L0B identification as well as an extension to the original filename to distinguish various parts/chunks at the output properly.
I've got almost double speed-up of entire runtime by simply breaking up the `42-sec` DM2 L0B product w/ `RCID=34` into two `21-sec` science ones via two background jobs running on a single machine. 
