### PR TITLE
Updated thresholds for FDNF

### DIFF
--- a/share/nisar/examples/noise_spectra_analysis.py
+++ b/share/nisar/examples/noise_spectra_analysis.py
@@ -202,7 +202,7 @@ def update_rfi_hit_stats(
     # Update total hit count
     rfi_freq_bin_hit_count += np.sum(rfi_mask_blk, axis=0)
 
-    # Vectorized max streak computation per frequency bin
+    # Zero-pad start and end of RFI Mask
     diff = np.diff(np.pad(rfi_mask_blk.astype(int), ((1, 1), (0, 0)), mode='constant'), axis=0)
 
     # starts and ends are tuples: starts[0]: pulse idx; starts[1]: freq bin idx
@@ -285,7 +285,7 @@ def process_l0b_data(
         f_out.attrs['num_pulses_block'] = num_pulses_blk
         f_out.attrs['num_fft'] = num_fft
         f_out.attrs['psd_x_axis'] = 'range (axis=1)'
-        f_out.attrs['psd_y_axis'] = 'power (axis=0, dB)'
+        f_out.attrs['psd_y_axis'] = 'power spectra density (axis=0, dB/Hz)'
 
         for freq, pol_list in raw.polarizations.items(): # A, B
             for pol in pol_list: # HH, HV, VV, VH
@@ -336,7 +336,7 @@ def process_l0b_data(
                 dset_fc.attrs["units"] = "Hz"
                 dset_fc.attrs["dtype"] = str(dset_fc.dtype)
 
-                # Center Frequency
+                # Sampling Frequency
                 if "freqSampling" in out_grp:
                     del out_grp["freqSamping"]
                 dset_fs = out_grp.create_dataset('freqSampling', data=fs)

--- a/share/nisar/examples/noise_spectra_analysis.py
+++ b/share/nisar/examples/noise_spectra_analysis.py
@@ -470,7 +470,7 @@ def process_l0b_data(
             f"RFI frequency domain detection margin"
         )
         dset_margin.attrs["units"] = "decibel"
-        dset_margin.attrs["dtype"] = "float32"
+        dset_margin.attrs["dtype"] = "float64"
 
         # Copy Identification group from input L0B file
         input_group_path = f'/science/LSAR/identification'

--- a/share/nisar/examples/noise_spectra_analysis.py
+++ b/share/nisar/examples/noise_spectra_analysis.py
@@ -6,11 +6,11 @@ RFI in terms of power and frequency locations.
 import numpy as np
 import argparse
 import h5py
-from scipy.fft import fft, fftshift
+from scipy.fft import fftshift
 from scipy.signal import welch
 from numpy import linalg as la
 from nisar.products.readers.Raw import Raw
-from collections.abc import Iterator
+from isce3.signal.compute_evd_cpi import slice_gen
 import warnings
 import os
 
@@ -26,7 +26,6 @@ def cmd_line_parse():
         required=True, 
         help='Input L0B file'
     )
-
     parser.add_argument(
         '-o',
         '--output', 
@@ -35,7 +34,6 @@ def cmd_line_parse():
         required=True, 
         help='Output data path. Output file name is input file name + SPECTRA.h5'
     )
-
     parser.add_argument(
         "-c",
         "--cpi",
@@ -45,7 +43,6 @@ def cmd_line_parse():
         default="6",
         help="Number of pulses in a coherent processing interval. Default: 6",
     )
-
     parser.add_argument(
         "-n",
         "--nfft",
@@ -56,7 +53,6 @@ def cmd_line_parse():
              "It is equal to number of FFT to be performed on each segment."
              "Default: 2048"
     )
-
     parser.add_argument(
         "-b",
         "--blk_size",
@@ -66,7 +62,6 @@ def cmd_line_parse():
         default="10000",
         help="Number of pulses per batch to be averaged in Azimuth-Time. Default: 5000",
     )
-
     parser.add_argument(
         "-m",
         "--margin",
@@ -79,45 +74,6 @@ def cmd_line_parse():
     )
 
     return parser.parse_args() 
-
-
-def slice_gen(total_size: int, batch_size: int, combine_rem: bool=True) -> Iterator[slice]:
-    """Generate slices with size defined by batch_size.
-
-    Parameters
-    ----------
-    total_size: int
-        size of data to be manipulated by slice_gen
-    batch_size: int
-        designated data chunk size in which data is sliced into.
-    combine_rem: bool
-        Combine the remaining values with the last complete block if 'True'.
-        If False, ignore the remaining values
-        Default = 'True'
-
-    Yields
-    ------
-    slice: slice obj
-        Iterable slices of data with specified input batch size, bounded by start_idx
-        and stop_idx.
-    """
-
-    num_complete_blks = total_size // batch_size
-    num_total_complete = num_complete_blks * batch_size
-    num_rem = total_size - num_total_complete
-
-    if combine_rem and num_rem > 0:
-        for start_idx in range(0, num_total_complete - batch_size, batch_size):
-            stop_idx = start_idx + batch_size
-            yield slice(start_idx, stop_idx)
-
-        last_blk_start = num_total_complete - batch_size
-        last_blk_stop = total_size
-        yield slice(last_blk_start, last_blk_stop)
-    else:
-        for start_idx in range(0, num_total_complete, batch_size):
-            stop_idx = start_idx + batch_size
-            yield slice(start_idx, stop_idx)
 
 
 def select_pulses_for_estimation(
@@ -277,6 +233,7 @@ def process_l0b_data(
     input_base, input_ext = os.path.splitext(input_filename)
     output_file = os.path.join(output_dir, f'{input_base}_SPECTRA{input_ext}')
     
+    # Print output file information
     print(f'{output_file = }')
     print()
 

--- a/share/nisar/examples/noise_spectra_analysis.py
+++ b/share/nisar/examples/noise_spectra_analysis.py
@@ -1,0 +1,501 @@
+"""
+Analyze noise-only receive power spectra. Collect spectral information with regards to
+RFI in terms of power and frequency locations.
+"""
+
+import numpy as np
+import argparse
+import h5py
+from scipy.fft import fft, fftshift
+from scipy.signal import welch
+from numpy import linalg as la
+from nisar.products.readers.Raw import Raw
+from collections.abc import Iterator
+import warnings
+import os
+
+
+def cmd_line_parse():
+    parser = argparse.ArgumentParser(description='Perform spectra analysis on input L0B file.')
+
+    parser.add_argument(
+        '-i',
+        '--input', 
+        dest='input_file', 
+        type=str,
+        required=True, 
+        help='Input L0B file'
+    )
+
+    parser.add_argument(
+        '-o',
+        '--output', 
+        dest='output_dir', 
+        type=str,
+        required=True, 
+        help='Output data path. Output file name is input file name + SPECTRA.h5'
+    )
+
+    parser.add_argument(
+        "-c",
+        "--cpi",
+        dest="cpi_len",
+        type=int,
+        required=False,
+        default="6",
+        help="Number of pulses in a coherent processing interval. Default: 6",
+    )
+
+    parser.add_argument(
+        "-n",
+        "--nfft",
+        dest="num_fft",
+        type=int,
+        default="2048",
+        help="Number of samples per segment for Scipy Welch function." 
+             "It is equal to number of FFT to be performed on each segment."
+             "Default: 2048"
+    )
+
+    parser.add_argument(
+        "-b",
+        "--blk_size",
+        dest="num_pulses_blk",
+        type=int,
+        required=False,
+        default="10000",
+        help="Number of pulses per batch to be averaged in Azimuth-Time. Default: 5000",
+    )
+
+    parser.add_argument(
+        "-m",
+        "--margin",
+        dest="thresh_margin",
+        type=float,
+        required=False,
+        default="6",
+        help="Additional gain to be added to noise power estimate for RFI thresholding." 
+             "Default: 6"
+    )
+
+    return parser.parse_args() 
+
+
+def slice_gen(total_size: int, batch_size: int, combine_rem: bool=True) -> Iterator[slice]:
+    """Generate slices with size defined by batch_size.
+
+    Parameters
+    ----------
+    total_size: int
+        size of data to be manipulated by slice_gen
+    batch_size: int
+        designated data chunk size in which data is sliced into.
+    combine_rem: bool
+        Combine the remaining values with the last complete block if 'True'.
+        If False, ignore the remaining values
+        Default = 'True'
+
+    Yields
+    ------
+    slice: slice obj
+        Iterable slices of data with specified input batch size, bounded by start_idx
+        and stop_idx.
+    """
+
+    num_complete_blks = total_size // batch_size
+    num_total_complete = num_complete_blks * batch_size
+    num_rem = total_size - num_total_complete
+
+    if combine_rem and num_rem > 0:
+        for start_idx in range(0, num_total_complete - batch_size, batch_size):
+            stop_idx = start_idx + batch_size
+            yield slice(start_idx, stop_idx)
+
+        last_blk_start = num_total_complete - batch_size
+        last_blk_stop = total_size
+        yield slice(last_blk_start, last_blk_stop)
+    else:
+        for start_idx in range(0, num_total_complete, batch_size):
+            stop_idx = start_idx + batch_size
+            yield slice(start_idx, stop_idx)
+
+
+def select_pulses_for_estimation(
+    raw_data: np.ndarray, 
+    cpi_len: int = 6
+):
+    """Select pulses for Eigenvalue Decomposition based on cpi_len
+
+    Parameters
+    ----------
+    raw_data: complex np.ndarray
+        complex input raw data
+    cpi_len: int
+        Number of pulses to be used to estimate noise power of a single pulse
+
+    Returns
+    -------
+    raw_data_selcted: 2D complex array
+        Selected receive pulses for sample covariance estimation and Eigenvalue
+        Decomposition
+    """
+
+    num_pulses = raw_data.shape[0]
+
+    if cpi_len > num_pulses:
+        raise ValueError(f"Requested cpi_len={cpi_len} exceeds number of pulses {num_pulses}")
+    
+    # Equally spaced indices (without repetition)
+    indices = np.linspace(0, num_pulses - 1, cpi_len, dtype=int)
+    raw_data_selected = raw_data[indices, :]
+
+
+    return raw_data_selected
+
+
+def estimate_noise_pwr_pulse(
+    raw_data: np.ndarray, 
+    cpi_len: int = 6
+) -> float:
+    """Estimate noise power per pulse in the time domain using minimum Eigenvalue
+
+    Parameters
+    ----------
+    raw_data: complex np.ndarray
+        complex input raw data
+    cpi_len: int
+        Number of pulses to be used to estimate noise power of a single pulse
+        Default: 6 
+
+    Returns
+    -------
+    noise_pwr_pulse_est_db: float
+        Estmated noise power per pulse using minimum Eigenvalue
+    """
+
+    data_estimate = select_pulses_for_estimation(raw_data, cpi_len)  # [cpi_len, num_range]
+    sample_cov = data_estimate @ data_estimate.conj().T / data_estimate.shape[1]  # [cpi_len x cpi_len]
+    eig_vals, _ = la.eigh(sample_cov)  # ascending order for Hermitian matrix
+
+    noise_pwr_pulse_est_db = 10 * np.log10(eig_vals[0])
+
+    return noise_pwr_pulse_est_db
+
+def update_rfi_hit_stats(
+    rfi_mask_blk, 
+    rfi_freq_bin_hit_count, 
+    rfi_max_streak
+):
+    """
+    Update total RFI hit count and max streak for each frequency bin.
+
+    Parameters
+    ----------
+    rfi_mask_blk : np.ndarray (num_pulses_blk, num_fft)
+        Boolean mask indicating RFI detection for each pulse and frequency bin.
+    rfi_freq_bin_hit_count : np.ndarray (num_fft,)
+        Accumulator for total number of RFI hits per frequency bin.
+    rfi_max_streak : np.ndarray (num_fft,)
+        Accumulator for maximum consecutive hit streak per frequency bin.
+    """
+
+    # Update total hit count
+    rfi_freq_bin_hit_count += np.sum(rfi_mask_blk, axis=0)
+
+    # Vectorized max streak computation per frequency bin
+    diff = np.diff(np.pad(rfi_mask_blk.astype(int), ((1, 1), (0, 0)), mode='constant'), axis=0)
+
+    # starts and ends are tuples: starts[0]: pulse idx; starts[1]: freq bin idx
+    starts = np.where(diff == 1)
+    ends = np.where(diff == -1)
+
+    # For each frequency bin, compute max streak
+    for b in range(rfi_mask_blk.shape[1]):
+        start_idxs = starts[0][starts[1] == b]
+        end_idxs = ends[0][ends[1] == b]
+
+        if len(start_idxs) != len(end_idxs):
+            # If a streak starts but never ends (shouldn't happen with padding)
+             continue
+
+        streaks = end_idxs - start_idxs
+        if len(streaks) > 0:
+            rfi_max_streak[b] = max(rfi_max_streak[b], np.max(streaks))
+
+def copy_group_from_input_hdf5(
+    input_file, output_file, 
+    input_group_path, 
+    output_group_path
+):
+    """
+    Copy a group from the input HDf5 file to an output HDF5 file
+    """
+
+    with h5py.File(input_file, "r") as f_in, h5py.File(output_file, "a") as f_out:
+        if input_group_path in f_in:
+            # Check if the group already exists in output and delete it if necessary
+            if input_group_path in f_out:
+                del f_out[input_group_path]
+
+            # Copy the group
+            f_in.copy(input_group_path, f_out[output_group_path])
+        else:
+            warnings.warn(f"'{input_group_path}' does NOT exist in the input file.")
+
+def process_l0b_data(
+    raw: Raw,
+    input_file: str,
+    output_dir: str,
+    num_pulses_blk: int,
+    thresh_margin: float = 6.0,
+    num_fft: int = 2048,
+):
+    """
+    Process L0B noise-only raw data in chunks to assess RFI power and frequency location
+    through frequency domain power spectra density analysis.
+
+    Parameters
+    ----------
+    raw: Raw
+        ISCE3 Raw object
+    input_file: str
+        Complete file path for input HDF5 file
+    output_dir: str
+        Output HDF5 file path
+    num_pulses_blk: int
+        Number of pulses in slow time block
+    threshold_margin: float
+        After noise power of raw data is estimated, RFI threshold is derived by
+        adding this threshold margin to it.
+    num_fft: int
+        Number of FFT as well number of samples per segment for the Welch Function.
+        Default: 2048
+    """
+
+    # Output file name is consisted of input file name + SPECTRA.hdf5
+    input_filename = os.path.basename(input_file)
+    input_base, input_ext = os.path.splitext(input_filename)
+    output_file = os.path.join(output_dir, f'{input_base}_SPECTRA{input_ext}')
+    
+    print(f'{output_file = }')
+    print()
+
+    with h5py.File(output_file, 'w') as f_out:
+        # Write metadata as HDF5 attributes
+        f_out.attrs['num_pulses_block'] = num_pulses_blk
+        f_out.attrs['num_fft'] = num_fft
+        f_out.attrs['psd_x_axis'] = 'range (axis=1)'
+        f_out.attrs['psd_y_axis'] = 'power (axis=0, dB)'
+
+        for freq, pol_list in raw.polarizations.items(): # A, B
+            for pol in pol_list: # HH, HV, VV, VH
+                print(f'Start Processing: frequency{freq} {pol}')
+
+                # Read raw data
+                raw_data = raw.getRawDataset(freq, pol)
+                
+                pol_tx = pol[0]
+                fc, fs, _, _ = raw.getChirpParameters(freq, pol_tx)
+
+                # Estimate noise power of each dataset corresponding to a polarization
+                # EVD is used due to unknown RFI situation as a priori
+                noise_pwr_pulse_est_db = estimate_noise_pwr_pulse(raw_data, cpi_len) 
+
+                # Convert Time-Domain Pulse Power to Frequency Domain Threshold in dB/Hz
+                threshold_db_hz = noise_pwr_pulse_est_db - 10*np.log10(fs) + thresh_margin
+
+                num_pulses, _ = raw_data.shape
+                slices = list(slice_gen(num_pulses, num_pulses_blk, combine_rem=False))
+                num_az_blocks = len(slices)
+
+                # Compute Frequencies from dummy data: one pulse
+                freqs, _ = welch(
+                    raw_data[0], 
+                    fs=fs, 
+                    nperseg=num_fft, 
+                    nfft=num_fft, 
+                    detrend=False, 
+                    return_onesided=False
+                )
+
+                # Shift to RF Center Frequency
+                freqs = fftshift(freqs) + fc
+                num_freq_bins = len(freqs)
+
+                # Create output group for output HDF5
+                base_path = f"/science/LSAR/QA/data/freq{freq}/{pol}"
+                out_grp = f_out.require_group(base_path)
+
+                # Center Frequency
+                if "freqCenter" in out_grp:
+                    del out_grp["freqCenter"]
+                dset_fc = out_grp.create_dataset('freqCenter', data=fc)
+                dset_fc.attrs["description"] = (
+                    f"Raw data center frequency"
+                )
+                dset_fc.attrs["units"] = "Hz"
+                dset_fc.attrs["dtype"] = str(dset_fc.dtype)
+
+                # Center Frequency
+                if "freqSampling" in out_grp:
+                    del out_grp["freqSamping"]
+                dset_fs = out_grp.create_dataset('freqSampling', data=fs)
+                dset_fs.attrs["description"] = (
+                    f"Raw data sampling frequency"
+                )
+                dset_fs.attrs["units"] = "Hz"
+                dset_fs.attrs["dtype"] = str(dset_fs.dtype)
+
+                # Power Spectra Density
+                if "rangePowerSpectralDensity" in out_grp:
+                    del out_grp["rangePowerSpectralDensity"]
+
+                # Create new dataset
+                dset_psd = out_grp.create_dataset(
+                    'rangePowerSpectralDensity',
+                    shape=(num_az_blocks, num_freq_bins),
+                    dtype=np.float32,
+                    compression='gzip'
+                )
+
+                # Write noise power estimate per pulse
+                if "noisePowerEstimateDB" in out_grp:
+                    del out_grp["Frequency"]
+                dset_noise = out_grp.create_dataset("noisePowerEstimateDB", data=noise_pwr_pulse_est_db)
+                dset_noise.attrs["description"] = f"Estimate of noise floor"
+                dset_noise.attrs["units"] = "decibel re 1 DN^2"
+                dset_noise.attrs["dtype"] = "dataset[float64]"
+
+                # Write frequency domain RFI threshold estimate
+                if "rfiDetectionThreshold" in out_grp:
+                    del out_grp["rfiDetectionThreshold"]
+                dset_thresh = out_grp.create_dataset('rfiDetectionThreshold', data=threshold_db_hz)
+                dset_thresh.attrs["description"] = (
+                    f"Threshold used to classify power spectral density values as contaminated "
+                    f"by radio frequency interference"
+                )
+                dset_thresh.attrs["units"] = "decibel re 1/hertz"
+                dset_thresh.attrs["dtype"] = "dataset[float64]"
+
+                # Initialize hit count array
+                rfi_bin_hit_count = np.zeros(num_freq_bins, dtype=int)
+                rfi_bin_max_streak = np.zeros(num_freq_bins, dtype=int) 
+                
+                # Compute averaged power spectra density and RFI hit count
+                for az_idx, az_slice in enumerate(slices):
+                    az_blk = raw_data[az_slice, :]  # Shape: (num_pulses_blk, range_samples)
+                    _, psd_az_blk = welch(
+                        az_blk, 
+                        fs=fs, 
+                        nperseg=num_fft, 
+                        nfft=num_fft, 
+                        detrend=False, 
+                        axis=1, 
+                        return_onesided=False
+                    )
+                    psd_az_blk_db = 10*np.log10(fftshift(psd_az_blk))
+
+                    # Compare each frequency bin in each pulse against the threshold
+                    rfi_mask_blk = psd_az_blk_db > threshold_db_hz  # shape (num_pulses_blk, num_fft)
+
+                    # Update RFI stats: Collect RFI hit data, and RFI hit max streak data
+                    update_rfi_hit_stats(rfi_mask_blk, rfi_bin_hit_count, rfi_bin_max_streak)
+
+                    # Compute Average range frequency power spectra density (dB/Hz)
+                    avg_psd_az_blk = np.mean(fftshift(psd_az_blk), axis=0)
+                    avg_psd_az_blk_db = 10 * np.log10(avg_psd_az_blk)
+
+                    # Write PSD of each block
+                    dset_psd[az_idx, :] = avg_psd_az_blk_db
+
+                # Write RFI Hit Count
+                if "interferenceHitCount" in out_grp:
+                    del out_grp["interferenceHitCount"]
+                dset_hit = out_grp.create_dataset('interferenceHitCount', data=rfi_bin_hit_count)
+                dset_hit.attrs["description"] = (
+                    f"Count of pulses where RFI detection threshold was exceeded "
+                    f"(in each frequency bin)"
+                )
+                dset_hit.attrs["units"] = "1"
+                dset_hit.attrs["dtype"] = "dataset[list[uint32]]"
+
+                # Write RFI Hit Max Streak
+                if "interferenceMaxStreak" in out_grp:
+                    del out_grp["interferenceMaxStreak"]
+                dset_streak = out_grp.create_dataset('interferenceMaxStreak', data=rfi_bin_max_streak)
+                dset_streak.attrs["description"] = (
+                    f"Maximum number of consecutive pulses where RFI detection threshold was exceeded "
+                    f"(in each freuqency bin)"
+                )
+                dset_streak.attrs["units"] = "1"
+                dset_streak.attrs["dtype"] = "dataset[list[uint32]]"
+
+                print(f'Processed: frequency{freq} {pol}')
+                print()
+            
+            dset_psd.attrs["description"] = (
+                "Radio frequency coordinates for range power spectra (dtype: dataset[list[float64]])"
+            )
+            dset_psd.attrs["units"] = "decibel re 1/hertz"
+            dset_psd.attrs["dtype"] = "dataset[list[list[float32]]]"
+
+        # Frequency
+        top_level_path = f"/science/LSAR/QA/data"
+        top_grp = f_out.require_group(top_level_path)
+
+        # Polarizations
+        if "listOfPolarizations" in top_grp:
+            del top_grp["listOfPolarizations"]
+        dset_pols = top_grp.create_dataset('listOfPolarizations', data=pol_list)
+        dset_pols.attrs["description"] = (
+            f"Polarizations for Frequency A discovered in input NISAR product"
+        )
+        dset_pols.attrs["dtype"] = "dataset[list[str]]"
+
+        # Range Spectra Frequencies
+        if "rangeSpectraFrequencies" in top_grp:
+            del top_grp["rangeSpectraFrequencies"]
+        dset_freq = top_grp.create_dataset('rangeSpectraFrequencies', data=freqs)
+        dset_freq.attrs["description"] = (
+            f"Radio Frequency (RF) frequency coordinates for range power spectra"
+        )
+        dset_freq.attrs["units"] = "decibel re 1/hertz"
+        dset_freq.attrs["dtype"] = "dataset[list[list[float32]]]"
+
+        # Threshold margin in db/Hz
+        if "thresholdMargin" in top_grp:
+            del top_grp["thresholdMargin"]
+        dset_margin = top_grp.create_dataset('thresholdMargin', data=thresh_margin)
+        dset_margin.attrs["description"] = (
+            f"RFI frequency domain detection margin"
+        )
+        dset_margin.attrs["units"] = "decibel"
+        dset_margin.attrs["dtype"] = "float32"
+
+        # Copy Identification group from input L0B file
+        input_group_path = f'/science/LSAR/identification'
+        output_group_path = f'/science/LSAR'
+
+        copy_group_from_input_hdf5(input_file, output_file, input_group_path, output_group_path)
+
+if __name__ == "__main__":
+    inputs = cmd_line_parse()
+
+    input_file = inputs.input_file
+    output_dir = inputs.output_dir
+    cpi_len = inputs.cpi_len
+    num_pulses_blk = inputs.num_pulses_blk
+    num_fft = inputs.num_fft
+    thresh_margin = inputs.thresh_margin
+    
+    raw = Raw(hdf5file=input_file)
+    raw.parsePolarizations()
+
+    process_l0b_data(
+        raw,
+        input_file,
+        output_dir,
+        num_pulses_blk,
+        thresh_margin,
+        num_fft,
+    )

--- a/tests/python/packages/isce3/signal/rfi_freq_null.py
+++ b/tests/python/packages/isce3/signal/rfi_freq_null.py
@@ -253,13 +253,14 @@ def test_freq_null():
     )
 
     # Frequency Domain Nulling Parameters
+    num_pulses_az_blk = 600
+    num_rng_blks = 3
     az_winsize = 25
     rng_winsize = 22
-    num_rng_blks = 3
-    num_pulses_az_blk = 600
     trim_frac = 0.01
-    pvalue_threshold = 0.005
-    cdf_threshold = 0.68
+    zscore_threshold = 3.0
+    tsnb_rfi_hit_threshold = 3
+    tvwb_rfi_hit_threshold = 3
     nb_detect = True
     wb_detect = True
     mitigate_enable = True
@@ -273,8 +274,9 @@ def test_freq_null():
         az_winsize=az_winsize,
         rng_winsize=rng_winsize,
         trim_frac=trim_frac,
-        pvalue_threshold=pvalue_threshold,
-        cdf_threshold=cdf_threshold,
+        zscore_threshold=zscore_threshold,
+        tsnb_rfi_hit_threshold=tsnb_rfi_hit_threshold,
+        tvwb_rfi_hit_threshold=tvwb_rfi_hit_threshold,
         nb_detect=nb_detect,
         wb_detect=wb_detect,
         mitigate_enable=mitigate_enable,
@@ -289,8 +291,8 @@ def test_freq_null():
     max_raw_pulse_pwr_db = raw_data_pulse_pwr_db.max()
     max_miti_pulse_pwr_db = raw_miti_pulse_pwr_db.max()
 
-    npt.assert_allclose(
-        max_raw_pulse_pwr_db,
+    npt.assert_array_less(
         max_miti_pulse_pwr_db,
-        atol=rfi_residue,
+        max_raw_pulse_pwr_db + rfi_residue,
     )
+


### PR DESCRIPTION
Changed user-defined thresholds as follows:

1. Removed p-value threshold for TSNB and TVWB RFI detectors
2. Removed CDF threshold for binary mask
3. Replaced p-value threshold with zscore threshold (number of standard deviation)
4. Replaced CDF threshold with RFI hit count threshold to prevent spurious RFI event.

