### PR TITLE
Update Product Spec Version from v1.2.1 to v1.3.0

### DIFF
--- a/python/packages/nisar/products/insar/InSAR_products_info.py
+++ b/python/packages/nisar/products/insar/InSAR_products_info.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import isce3
 
 ISCE3_VERSION = isce3.__version__
-PRODUCT_SPECIFICATION_VERSION = "1.2.1"
+PRODUCT_SPECIFICATION_VERSION = "1.3.0"
 
 @dataclass
 class InSARProductsInfo:
@@ -15,7 +15,7 @@ class InSARProductsInfo:
     Attributes
     ----------
     ProductSpecificationVersion : str
-        Product specification version (default is '1.2.1')
+        Product specification version (default is '1.3.0')
     ProductType : str
         Product type, one of 'RIFG', 'ROFF', 'RUNW', 'GOFF', 'GUNW'
     ProductLevel : str

--- a/python/packages/nisar/products/writers/BaseWriterSingleInput.py
+++ b/python/packages/nisar/products/writers/BaseWriterSingleInput.py
@@ -622,7 +622,7 @@ class BaseWriterSingleInput():
 
         self.set_value(
             'identification/productSpecificationVersion',
-            '1.2.1')
+            '1.3.0')
 
         self.copy_from_input(
             'identification/lookDirection',

--- a/python/packages/nisar/products/writers/SLC.py
+++ b/python/packages/nisar/products/writers/SLC.py
@@ -687,7 +687,7 @@ class SLC(h5py.File):
                             planned_observation_id: Optional[str] = None,
                             is_urgent: Optional[bool] = None,
                             is_joint: Optional[bool] = None,
-                            product_spec_version: str = "1.2.1",
+                            product_spec_version: str = "1.3.0",
                             processing_center: str = "JPL",
                             granule_id: str = "None",
                             product_version: str = "0.1.0",

--- a/python/packages/nisar/workflows/h5_prep.py
+++ b/python/packages/nisar/workflows/h5_prep.py
@@ -258,7 +258,7 @@ def cp_geocode_meta(cfg, output_hdf5, dst):
 
         # Assign product specification version
         dst_h5[f'{ident_path}/productSpecificationVersion'] = \
-            np.bytes_('1.2.1')
+            np.bytes_('1.3.0')
 
         # Assign granule ID
         dst_h5[f'{ident_path}/granuleId'] = \


### PR DESCRIPTION
This PR updates the product specification version from 1.2.1 to 1.3.0. This corresponds to PIX Release v1.3.0, in anticipation of R5.

The companion PR to update GSLC/GCOV XMLs is #70 .