### PR TITLE
nullify azimuth mean

### DIFF
--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1816,6 +1816,8 @@ def focus(runconfig, runconfig_path=""):
                 z[np.isnan(z)] = 0.0
                 if cfg.processing.zero_fill_gaps:
                     fill_gaps(z, swaths[:, pulse:pulse+nblock, :], 0.0)
+                if cfg.processing.nullify_azimuth_mean:
+                    z -= z.mean(axis=0)
                 raw_mm[block_out] = z
 
             raw_clean, rfi_likelihood = process_rfi(cfg, raw_mm, temp)

--- a/share/nisar/defaults/focus.yaml
+++ b/share/nisar/defaults/focus.yaml
@@ -415,6 +415,12 @@ runconfig:
             # cal pulses.
             zero_fill_gaps: True
 
+            # If true, subtract the azimuth mean from the raw data, which is
+            # useful when the caltone is nearly constant in azimuth but not
+            # stationary in range.  Calculating the mean and subtracting it is
+            # done in blocks using rangecomp.block_size
+            nullify_azimuth_mean: True
+
             # Processing stage switches, mostly for debug.
             # Any missing stages assumed True
             is_enabled:

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -253,6 +253,12 @@ runconfig:
       # If true, fill transmit gaps with zeros to remove loop-back cal pulses.
       zero_fill_gaps: bool(required=False)
 
+      # If true, subtract the azimuth mean from the raw data, which is useful
+      # when the caltone is nearly constant in azimuth but not stationary in
+      # range.  Calculating the mean and subtracting it is done in blocks using
+      # rangecomp.block_size
+      nullify_azimuth_mean: bool(required=False)
+
       # Processing stage switches, mostly for debug.
       # Any missing stages assumed True
       is_enabled:


### PR DESCRIPTION
This adds an option to the RSLC workflow to remove a running mean in the azimuth direction. The intent is to remove the calibration tone, assuming it is stationary vs slow time for the duration of the block. For NISAR this is somewhat preferable to a range-frequency notch filter because
* The caltone frequency can be mode-dependent, and its aliased image after on-board DSP may also be mode-dependent even if the RF tone is not. It's nice to avoid the bookkeeping.
* The signal is not necessarily stationary in range. It may change abruptly across beam transitions or transmit gaps. This can cause filter artifacts.
* The azimuth DC component is not relevant to the image because the radar squint means it's not in the processing band.

A similar approach is to apply a cosine-weighted notch function to the azimuth. One nice feature of that approach is you can control the width of the notch, which is necessary if the caltone is not constant vs slow time. However, the proposed approach has a similar parameter: the length of the moving average. Thus is it can handle some variation as well, plus it has the benefit of continuity across image frame boundaries (e.g., for seamless mosaics of independently processed images).

@hb6688 You might find this helpful when testing RFI mitigation algorithms.