### PR TITLE
Parallel stats

### DIFF
--- a/cxx/isce3/math/Stats.cpp
+++ b/cxx/isce3/math/Stats.cpp
@@ -174,7 +174,7 @@ void StatsRealImag<T>::update(const std::complex<T>* values,
             #pragma omp single
             {
                 partial_stats.resize(threads);
-            } 
+            }
             const auto max_chunk_size = (size + threads - 1) / threads;
             const auto start = tid * max_chunk_size;
             const auto end = std::min(start + max_chunk_size, size);
@@ -228,7 +228,7 @@ void _runBlock(isce3::io::Raster& input_raster,
 
     _Pragma("omp critical")
     {
-        input_raster.getBlock(block_array.data(), 
+        input_raster.getBlock(block_array.data(),
                               x0, y0, block_width,
                               block_length, band + 1);
     }
@@ -274,8 +274,8 @@ std::vector<Stats<T>> computeRasterStats(
         block_length = input_raster.length();
     } else {
         isce3::core::getBlockProcessingParametersY(
-            input_raster.length(), input_raster.width(), 
-            nbands, GDALGetDataTypeSizeBytes(input_raster.dtype()), 
+            input_raster.length(), input_raster.width(),
+            nbands, GDALGetDataTypeSizeBytes(input_raster.dtype()),
             &info, &block_length, &nblocks);
     }
 
@@ -299,23 +299,23 @@ std::vector<Stats<T>> computeRasterStats(
 
         }
     }
-        
-    const auto n_elements = (static_cast<long long>(input_raster.width()) * 
+
+    const auto n_elements = (static_cast<long long>(input_raster.width()) *
                              input_raster.length());
-    
+
     for (int band = 0; band < nbands; ++band) {
 
         stats_vector[band] = _aggregateStats(block_stats_vector[band]);
 
         info << "band: " << band + 1 << pyre::journal::newline
-             << "    n. valid: " << stats_vector[band].n_valid 
+             << "    n. valid: " << stats_vector[band].n_valid
              << " (" << 100 * stats_vector[band].n_valid / n_elements
              << "%) " << pyre::journal::newline
              << "    min: " << stats_vector[band].min
              << ", mean: " << stats_vector[band].mean
              << ", max: " << stats_vector[band].max
-             << ", sample stddev: " << stats_vector[band].sample_stddev() 
-             << pyre::journal::endl; 
+             << ", sample stddev: " << stats_vector[band].sample_stddev()
+             << pyre::journal::endl;
 
     }
     return stats_vector;
@@ -362,11 +362,11 @@ std::vector<StatsRealImag<T>> computeRasterStatsRealImag(
         block_length = input_raster.length();
     } else {
         isce3::core::getBlockProcessingParametersY(
-            input_raster.length(), input_raster.width(), 
-            nbands, GDALGetDataTypeSizeBytes(input_raster.dtype()), 
+            input_raster.length(), input_raster.width(),
+            nbands, GDALGetDataTypeSizeBytes(input_raster.dtype()),
             &info, &block_length, &nblocks);
     }
-    
+
     std::vector<StatsRealImag<T>> stats_vector(nbands);
     std::vector<std::vector<StatsRealImag<T>>> block_stats_vector(
         nbands, std::vector<StatsRealImag<T>>(nblocks));
@@ -385,16 +385,16 @@ std::vector<StatsRealImag<T>> computeRasterStatsRealImag(
                       x0, block_width, y0, this_block_length, band);
         }
     }
-        
-    const auto n_elements = (static_cast<long long>(input_raster.width()) * 
+
+    const auto n_elements = (static_cast<long long>(input_raster.width()) *
                              input_raster.length());
-    
+
     for (int band = 0; band < nbands; ++band) {
 
         stats_vector[band] = _aggregateStats(block_stats_vector[band]);
 
         info << "band: " << band + 1 << pyre::journal::newline
-             << "    n. valid: " << stats_vector[band].n_valid 
+             << "    n. valid: " << stats_vector[band].n_valid
              << " (" << 100 * stats_vector[band].n_valid / n_elements
              << "%) " << pyre::journal::newline
 
@@ -408,7 +408,7 @@ std::vector<StatsRealImag<T>> computeRasterStatsRealImag(
              << ", mean (imag): " << stats_vector[band].imag.mean
              << ", max (imag): " << stats_vector[band].imag.max
              << ", sample stddev (imag): " << stats_vector[band].imag.sample_stddev()
-             << pyre::journal::endl; 
+             << pyre::journal::endl;
 
     }
     return stats_vector;

--- a/cxx/isce3/math/Stats.cpp
+++ b/cxx/isce3/math/Stats.cpp
@@ -2,6 +2,9 @@
 
 #include <pyre/journal.h>
 #include <isce3/math/complexOperations.h>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
 
 
 namespace isce3 {
@@ -159,8 +162,30 @@ StatsRealImag<T>::StatsRealImag(const std::complex<T>* values,
 
 template<class T>
 void StatsRealImag<T>::update(const std::complex<T>* values,
-        size_t size, size_t stride)
+        size_t size, size_t stride, const std::optional<bool>& parallel)
 {
+#ifdef _OPENMP
+    if (parallel.value_or(true)) {
+        std::vector<StatsRealImag<T>> partial_stats;
+        #pragma omp parallel
+        {
+            const auto tid = omp_get_thread_num();
+            const auto threads = omp_get_num_threads();
+            #pragma omp single
+            {
+                partial_stats.resize(threads);
+            } 
+            const auto max_chunk_size = (size + threads - 1) / threads;
+            const auto start = tid * max_chunk_size;
+            const auto end = std::min(start + max_chunk_size, size);
+            partial_stats[tid].update(values + start, end - start, stride, false);
+        }
+        for (const auto& stats : partial_stats) {
+            update(stats);
+        }
+        return;
+    }
+#endif
     const StatsRealImag<T> block_stats(values, size, stride);
     update(block_stats);
 }

--- a/cxx/isce3/math/Stats.cpp
+++ b/cxx/isce3/math/Stats.cpp
@@ -2,9 +2,6 @@
 
 #include <pyre/journal.h>
 #include <isce3/math/complexOperations.h>
-#ifdef _OPENMP
-#include <omp.h>
-#endif
 
 
 namespace isce3 {
@@ -153,30 +150,21 @@ StatsRealImag<T>::StatsRealImag(const std::complex<T>* values,
         size_t size, size_t stride, const bool& parallel)
 {
     const auto end = values + size * stride;
-#ifdef _OPENMP
     if (parallel) {
-        std::vector<StatsRealImag<T>> partial_stats;
         #pragma omp parallel
         {
-            const auto tid = omp_get_thread_num();
-            const auto threads = omp_get_num_threads();
-            #pragma omp single
-            {
-                partial_stats.resize(threads);
-            }
+            StatsRealImag<T> partial_stats;
             #pragma omp for
             for (auto ptr = values; ptr < end; ptr += stride) {
-                partial_stats[tid].update(*ptr);
+                partial_stats.update(*ptr);
             }
+            #pragma omp critical
+            update(partial_stats);
         }
-        for (const auto& stats : partial_stats) {
-            update(stats);
+    } else {
+        for (auto ptr = values; ptr < end; ptr += stride) {
+            update(*ptr);
         }
-        return;
-    }
-#endif
-    for (auto ptr = values; ptr < end; ptr += stride) {
-        update(*ptr);
     }
 }
 

--- a/cxx/isce3/math/Stats.cpp
+++ b/cxx/isce3/math/Stats.cpp
@@ -147,7 +147,7 @@ void StatsRealImag<T>::update(const StatsRealImag<T>& other)
 
 template<class T>
 StatsRealImag<T>::StatsRealImag(const std::complex<T>* values,
-        size_t size, size_t stride, const bool& parallel)
+        size_t size, size_t stride, bool parallel)
 {
     const auto end = values + size * stride;
     if (parallel) {
@@ -171,7 +171,7 @@ StatsRealImag<T>::StatsRealImag(const std::complex<T>* values,
 
 template<class T>
 void StatsRealImag<T>::update(const std::complex<T>* values,
-        size_t size, size_t stride, const bool& parallel)
+        size_t size, size_t stride, bool parallel)
 {
     const StatsRealImag<T> block_stats(values, size, stride, parallel);
     update(block_stats);

--- a/cxx/isce3/math/Stats.cpp
+++ b/cxx/isce3/math/Stats.cpp
@@ -150,22 +150,11 @@ void StatsRealImag<T>::update(const StatsRealImag<T>& other)
 
 template<class T>
 StatsRealImag<T>::StatsRealImag(const std::complex<T>* values,
-        size_t size, size_t stride)
+        size_t size, size_t stride, const bool& parallel)
 {
-    using C = std::complex<T>;
-    const C* end = values + size * stride;
-    for (const C* ptr = values; ptr < end; ptr += stride) {
-        update(*ptr);
-    }
-}
-
-
-template<class T>
-void StatsRealImag<T>::update(const std::complex<T>* values,
-        size_t size, size_t stride, const std::optional<bool>& parallel)
-{
+    const auto end = values + size * stride;
 #ifdef _OPENMP
-    if (parallel.value_or(true)) {
+    if (parallel) {
         std::vector<StatsRealImag<T>> partial_stats;
         #pragma omp parallel
         {
@@ -175,10 +164,10 @@ void StatsRealImag<T>::update(const std::complex<T>* values,
             {
                 partial_stats.resize(threads);
             }
-            const auto max_chunk_size = (size + threads - 1) / threads;
-            const auto start = tid * max_chunk_size;
-            const auto end = std::min(start + max_chunk_size, size);
-            partial_stats[tid].update(values + start, end - start, stride, false);
+            #pragma omp for
+            for (auto ptr = values; ptr < end; ptr += stride) {
+                partial_stats[tid].update(*ptr);
+            }
         }
         for (const auto& stats : partial_stats) {
             update(stats);
@@ -186,7 +175,17 @@ void StatsRealImag<T>::update(const std::complex<T>* values,
         return;
     }
 #endif
-    const StatsRealImag<T> block_stats(values, size, stride);
+    for (auto ptr = values; ptr < end; ptr += stride) {
+        update(*ptr);
+    }
+}
+
+
+template<class T>
+void StatsRealImag<T>::update(const std::complex<T>* values,
+        size_t size, size_t stride, const bool& parallel)
+{
+    const StatsRealImag<T> block_stats(values, size, stride, parallel);
     update(block_stats);
 }
 

--- a/cxx/isce3/math/Stats.cpp
+++ b/cxx/isce3/math/Stats.cpp
@@ -206,7 +206,7 @@ template<class StatsT>
 StatsT _aggregateStats(std::vector<StatsT>& statsvec)
 {
     StatsT allstats;
-    for (const auto stats : statsvec) {
+    for (const auto& stats : statsvec) {
         allstats.update(stats);
     }
     return allstats;

--- a/cxx/isce3/math/Stats.h
+++ b/cxx/isce3/math/Stats.h
@@ -2,7 +2,6 @@
 #include <isce3/core/Constants.h>
 #include <isce3/core/blockProcessing.h>
 #include <isce3/io/Raster.h>
-#include <optional>
 
 namespace isce3 { namespace math {
 
@@ -79,7 +78,7 @@ struct StatsRealImag {
      *                      ignored when the compiler does not support OpenMP.
      */
     void update(const std::complex<T>* values, size_t size, size_t stride = 1,
-        const bool& parallel = true);
+        bool parallel = true);
 
     /** Initialize from block of data (using Welford's algorithm).
      *
@@ -92,7 +91,7 @@ struct StatsRealImag {
      *                      ignored when the compiler does not support OpenMP.
      */
     StatsRealImag(const std::complex<T>* values, size_t size, size_t stride = 1,
-        const bool& parallel = true);
+        bool parallel = true);
 
     StatsRealImag() = default;
 };

--- a/cxx/isce3/math/Stats.h
+++ b/cxx/isce3/math/Stats.h
@@ -71,7 +71,7 @@ struct StatsRealImag {
      *  update current estimate with Chan's method.
      *
      * @param[in] values    Array of values
-     * @param[in] size      Length of `values`
+     * @param[in] size      Number of entries to access in `values`
      * @param[in] stride    Stride between entries in `values`, such that
      *                      entry `i` is indexed as `values[i * stride]`
      * @param[in] parallel  Whether to compute stats in parallel by equally
@@ -84,7 +84,7 @@ struct StatsRealImag {
     /** Initialize from block of data (using Welford's algorithm).
      *
      * @param[in] values    Array of values
-     * @param[in] size      Length of `values`
+     * @param[in] size      Number of entries to access in `values`
      * @param[in] stride    Stride between entries in `values`, such that
      *                      entry `i` is indexed as `values[i * stride]`
      * @param[in] parallel  Whether to compute stats in parallel by equally

--- a/cxx/isce3/math/Stats.h
+++ b/cxx/isce3/math/Stats.h
@@ -68,7 +68,19 @@ struct StatsRealImag {
     void update(const std::complex<T>& value);
 
     /** Calculate stats of a new block of data using Welford's algorithm and
-     *  update current estimate with Chan's method. */
+     *  update current estimate with Chan's method.
+     *
+     * @param[in] values    Array of values
+     * @param[in] size      Length of `values`
+     * @param[in] stride    Stride between entries in `values`, such that
+     *                      entry `i` is indexed as `values[i * stride]`
+     * @param[in] parallel  Whether to compute stats in parallel by equally
+     *                      dividing the block among threads.  Supplying `true`
+     *                      or `std::nullopt` both signify parallel processing
+     *                      when compiled with OpenMP.  That is, you must
+     *                      explicity opt out of parallel processing by
+     *                      supplying `false`.
+     */
     void update(const std::complex<T>* values, size_t size, size_t stride = 1,
         const std::optional<bool>& parallel = std::nullopt);
 

--- a/cxx/isce3/math/Stats.h
+++ b/cxx/isce3/math/Stats.h
@@ -2,6 +2,7 @@
 #include <isce3/core/Constants.h>
 #include <isce3/core/blockProcessing.h>
 #include <isce3/io/Raster.h>
+#include <optional>
 
 namespace isce3 { namespace math {
 
@@ -68,7 +69,8 @@ struct StatsRealImag {
 
     /** Calculate stats of a new block of data using Welford's algorithm and
      *  update current estimate with Chan's method. */
-    void update(const std::complex<T>* values, size_t size, size_t stride = 1);
+    void update(const std::complex<T>* values, size_t size, size_t stride = 1,
+        const std::optional<bool>& parallel = std::nullopt);
 
     /** Initialize from block of data. */
     StatsRealImag(const std::complex<T>* values, size_t size, size_t stride = 1);

--- a/cxx/isce3/math/Stats.h
+++ b/cxx/isce3/math/Stats.h
@@ -75,17 +75,24 @@ struct StatsRealImag {
      * @param[in] stride    Stride between entries in `values`, such that
      *                      entry `i` is indexed as `values[i * stride]`
      * @param[in] parallel  Whether to compute stats in parallel by equally
-     *                      dividing the block among threads.  Supplying `true`
-     *                      or `std::nullopt` both signify parallel processing
-     *                      when compiled with OpenMP.  That is, you must
-     *                      explicity opt out of parallel processing by
-     *                      supplying `false`.
+     *                      dividing the block among threads.  This argument is
+     *                      ignored when the compiler does not support OpenMP.
      */
     void update(const std::complex<T>* values, size_t size, size_t stride = 1,
-        const std::optional<bool>& parallel = std::nullopt);
+        const bool& parallel = true);
 
-    /** Initialize from block of data. */
-    StatsRealImag(const std::complex<T>* values, size_t size, size_t stride = 1);
+    /** Initialize from block of data (using Welford's algorithm).
+     *
+     * @param[in] values    Array of values
+     * @param[in] size      Length of `values`
+     * @param[in] stride    Stride between entries in `values`, such that
+     *                      entry `i` is indexed as `values[i * stride]`
+     * @param[in] parallel  Whether to compute stats in parallel by equally
+     *                      dividing the block among threads.  This argument is
+     *                      ignored when the compiler does not support OpenMP.
+     */
+    StatsRealImag(const std::complex<T>* values, size_t size, size_t stride = 1,
+        const bool& parallel = true);
 
     StatsRealImag() = default;
 };

--- a/python/extensions/pybind_isce3/math/Stats.cpp
+++ b/python/extensions/pybind_isce3/math/Stats.cpp
@@ -108,12 +108,23 @@ void addbinding(py::class_<StatsRealImag<T>>& pyStatsRealImag)
 
     using ArrayT = py::array_t<std::complex<T>, py::array::c_style>;
 
-    pyStatsRealImag.def(py::init([](ArrayT x) {
-        return StatsRealImag<T>(x.data(), x.size());
+    pyStatsRealImag.def(py::init([](ArrayT x, bool parallel) {
+        return StatsRealImag<T>(x.data(), x.size(), 1, parallel);
     }),
-    "Calculate statistics of a block of data using Welford's algorithm.");
+    py::arg("x"),
+    py::arg("parallel") = true, R"(
+    Calculate statistics of a block of data using Welford's algorithm.
 
-    pyStatsRealImag.def("update", [](StatsRealImag<T>& self, ArrayT x, std::optional<bool> parallel) {
+    Parameters
+    ----------
+    x : array_like
+        Array of complex values
+    parallel : bool, optional
+        Whether to compute stats in parallel by equally dividing the block among
+        threads.  Ignored when library was compiled without OpenMP support.
+    )");
+
+    pyStatsRealImag.def("update", [](StatsRealImag<T>& self, ArrayT x, bool parallel) {
         const auto px = x.data();
         const size_t n = x.size();
         {
@@ -122,7 +133,7 @@ void addbinding(py::class_<StatsRealImag<T>>& pyStatsRealImag)
         }
     },
     py::arg("x"),
-    py::arg("parallel") = py::none(), R"(
+    py::arg("parallel") = true, R"(
     Calculate stats of a new block of data using Welford's algorithm and
     update current estimate with Chan's method.
 
@@ -132,9 +143,7 @@ void addbinding(py::class_<StatsRealImag<T>>& pyStatsRealImag)
         Array of complex values
     parallel : bool, optional
         Whether to compute stats in parallel by equally dividing the block among
-        threads.  Supplying `True` or `None` both signify parallel processing
-        when compiled with OpenMP.  That is, you must explicity opt out of
-        parallel processing by supplying `False`.
+        threads.  Ignored when library was compiled without OpenMP support.
      )");
 
     pyStatsRealImag.def("update", [](StatsRealImag<T>& self,

--- a/python/extensions/pybind_isce3/math/Stats.cpp
+++ b/python/extensions/pybind_isce3/math/Stats.cpp
@@ -122,9 +122,20 @@ void addbinding(py::class_<StatsRealImag<T>>& pyStatsRealImag)
         }
     },
     py::arg("x"),
-    py::arg("parallel") = py::none(),
-    R"(Calculate stats of a new block of data using Welford's algorithm and
-    update current estimate with Chan's method.)");
+    py::arg("parallel") = py::none(), R"(
+    Calculate stats of a new block of data using Welford's algorithm and
+    update current estimate with Chan's method.
+
+    Parameters
+    ----------
+    x : array_like
+        Array of complex values
+    parallel : bool, optional
+        Whether to compute stats in parallel by equally dividing the block among
+        threads.  Supplying `True` or `None` both signify parallel processing
+        when compiled with OpenMP.  That is, you must explicity opt out of
+        parallel processing by supplying `False`.
+     )");
 
     pyStatsRealImag.def("update", [](StatsRealImag<T>& self,
             const StatsRealImag<T>& other) {

--- a/python/extensions/pybind_isce3/math/Stats.cpp
+++ b/python/extensions/pybind_isce3/math/Stats.cpp
@@ -113,14 +113,16 @@ void addbinding(py::class_<StatsRealImag<T>>& pyStatsRealImag)
     }),
     "Calculate statistics of a block of data using Welford's algorithm.");
 
-    pyStatsRealImag.def("update", [](StatsRealImag<T>& self, ArrayT x) {
+    pyStatsRealImag.def("update", [](StatsRealImag<T>& self, ArrayT x, std::optional<bool> parallel) {
         const auto px = x.data();
         const size_t n = x.size();
         {
             py::gil_scoped_release release;
-            self.update(px, n);
+            self.update(px, n, 1, parallel);
         }
     },
+    py::arg("x"),
+    py::arg("parallel") = py::none(),
     R"(Calculate stats of a new block of data using Welford's algorithm and
     update current estimate with Chan's method.)");
 


### PR DESCRIPTION
In the RSLC workflow, the image statistics are computed by the CPU while the GPU focuses the next block. If the GPU is fast enough, the stats calculation can become a bottleneck. This PR enables computing stats in parallel.

The implementation is hidden behind macros to support compilers that don't support OpenMP. I got more than I bargained for after removing trailing whitespace, but I figure may as well leave that commit in.

This PR was approved internally [here](https://github-fn.jpl.nasa.gov/isce-3/isce/pull/2233) by @gmgunter and @gshiroma 