### PR TITLE
add one missing line in ionosphere filter

### DIFF
--- a/python/packages/isce3/atmosphere/ionosphere_filter.py
+++ b/python/packages/isce3/atmosphere/ionosphere_filter.py
@@ -950,6 +950,7 @@ def remove_small_components(image, min_cluster_pixels):
         raise ValueError("min_cluster_pixels cannot be negative")
 
     valid_mask = ~np.isnan(image)
+    n_valid = int(valid_mask.sum())
 
     if min_cluster_pixels == 0:
         info_channel.log("min_cluster_pixels == 0 → "


### PR DESCRIPTION
This PR adds one missing line in the ionosphere filter by restoring a missing line removed in #51 that caused the ionosphere filter to misbehave. This PR corrects the bug.