### PR TITLE
Refactor Topo multithreading to reduce synchronization overhead (MCR #90132)

### DIFF
--- a/cxx/isce3/geometry/Topo.cpp
+++ b/cxx/isce3/geometry/Topo.cpp
@@ -176,62 +176,73 @@ topo(Raster & demRaster, TopoLayers & layers)
         // Reset output block sizes in layers
         layers.setBlockSize(blockLength, _radarGrid.width());
 
-        // Allocate vector for storing satellite position for each line
-        std::vector<Vec3> satPosition(blockLength);
+        // Pre-compute some values that only need to be computed once per
+        // range line.
+        auto sensingTime = std::vector<double>(blockLength);
+        auto satPosition = std::vector<Vec3>(blockLength);
+        auto satVelocity = std::vector<Vec3>(blockLength);
+        auto satSpeed = std::vector<double>(blockLength);
+        auto TCNbases = std::vector<Basis>(blockLength);
 
-        // For each line in block
-        double tline;
+        #pragma omp parallel for
         for (size_t blockLine = 0; blockLine < blockLength; ++blockLine) {
-
-            if (blockLine % std::max((int) (blockLength / 100), 1) == 0)
-                printf("\rTopo progress (block %d/%d): %d%%",
-                       (int) block + 1, (int) nBlocks,
-                       (int) (blockLine * 1e2 / blockLength)),
-                       fflush(stdout);
-
             // Global line index
             size_t line = lineStart + blockLine;
 
             // Initialize orbital data for this azimuth line
-            Basis TCNbasis;
-            Vec3 pos, vel;
-            _initAzimuthLine(line, tline, pos, vel, TCNbasis);
+            auto& vel = satVelocity[blockLine];
+            _initAzimuthLine(line, sensingTime[blockLine],
+                    satPosition[blockLine], vel, TCNbases[blockLine]);
+            satSpeed[blockLine] = vel.norm();
+        }
 
-            satPosition[blockLine] = pos;
+        #pragma omp parallel
+        {
+            // Thread-local count of the total number of rdr2geo calls that
+            // converged successfully.
+            size_t totalconv_thread = 0;
 
-            // Compute velocity magnitude
-            const double satVmag = vel.norm();
+            // Initialize LLH to middle of input DEM and average height
+            Vec3 llh = demInterp.midLonLat();
 
-            // For each slant range bin
-            #pragma omp parallel for reduction(+:totalconv)
-            for (size_t rbin = 0; rbin < _radarGrid.width(); ++rbin) {
+            #pragma omp for collapse(2)
+            for (size_t blockLine = 0; blockLine < blockLength; ++blockLine) {
+                for (size_t rbin = 0; rbin < _radarGrid.width(); ++rbin) {
 
-                // Get current slant range
-                const double rng = _radarGrid.slantRange(rbin);
+                    // Get current slant range
+                    const double rng = _radarGrid.slantRange(rbin);
 
-                // Get current Doppler value
-                const double dopfact = (0.5 * _radarGrid.wavelength()
-                                     * (_doppler.eval(tline, rng) / satVmag)) * rng;
+                    // Get current Doppler value
+                    const auto tline = sensingTime[blockLine];
+                    const auto satVmag = satSpeed[blockLine];
+                    const double dopfact = (0.5 * _radarGrid.wavelength() *
+                                            (_doppler.eval(tline, rng) / satVmag)) *
+                                           rng;
 
-                // Store slant range bin data in Pixel
-                Pixel pixel(rng, dopfact, rbin);
+                    // Store slant range bin data in Pixel
+                    Pixel pixel(rng, dopfact, rbin);
 
-                // Initialize LLH to middle of input DEM and average height
-                Vec3 llh = demInterp.midLonLat();
+                    // Perform rdr->geo iterations
+                    const auto& pos = satPosition[blockLine];
+                    const auto& vel = satVelocity[blockLine];
+                    const auto& TCNbasis = TCNbases[blockLine];
+                    int geostat = rdr2geo(pixel, TCNbasis, pos, vel, _ellipsoid,
+                                          demInterp, llh, _radarGrid.lookSide(),
+                                          _threshold, _numiter, _extraiter);
+                    totalconv_thread += geostat;
 
-                // Perform rdr->geo iterations
-                int geostat = rdr2geo(
-                    pixel, TCNbasis, pos, vel, _ellipsoid, demInterp, llh,
-                    _radarGrid.lookSide(), _threshold, _numiter, _extraiter);
-                totalconv += geostat;
+                    // Save data in output arrays
+                    _setOutputTopoLayers(llh, layers, blockLine, pixel, pos, vel,
+                                         TCNbasis, demInterp);
+                }
+            }
 
-                // Save data in output arrays
-                _setOutputTopoLayers(llh, layers, blockLine, pixel, pos, vel,
-                        TCNbasis, demInterp);
-
-            } // end OMP for loop pixels in block
-        } // end for loop lines in block
-        printf("\rTopo progress (block %d/%d): 100%%\n",
+            // Collect the total number of converged rdr2geo calls from among all
+            // threads.
+            #pragma omp atomic
+            totalconv += totalconv_thread;
+        }
+        printf("\rTopo progress (block %d/%d): Done\n",
                (int) block + 1, (int) nBlocks), fflush(stdout);
 
         // Compute layover/shadow masks for the block
@@ -600,9 +611,9 @@ computeDEMBounds(Raster & demRaster, DEMInterpolator & demInterp, size_t lineOff
 }
 
 void isce3::geometry::Topo::
-_setOutputTopoLayers(Vec3 & targetLLH, TopoLayers & layers, size_t line,
-                     Pixel & pixel, Vec3& pos, Vec3& vel, Basis & TCNbasis,
-                     DEMInterpolator & demInterp)
+_setOutputTopoLayers(const Vec3& targetLLH, TopoLayers & layers, size_t line,
+                     const Pixel& pixel, const Vec3& pos, const Vec3& vel,
+                     const Basis& TCNbasis, const DEMInterpolator& demInterp)
 {
     const double degrees = 180.0 / M_PI;
 

--- a/cxx/isce3/geometry/Topo.cpp
+++ b/cxx/isce3/geometry/Topo.cpp
@@ -1,6 +1,7 @@
 #include "Topo.h"
 
 #include <algorithm>
+#include <cassert>
 #include <chrono>
 #include <cmath>
 #include <cstdio>
@@ -176,25 +177,14 @@ topo(Raster & demRaster, TopoLayers & layers)
         // Reset output block sizes in layers
         layers.setBlockSize(blockLength, _radarGrid.width());
 
-        // Pre-compute some values that only need to be computed once per
-        // range line.
-        auto sensingTime = std::vector<double>(blockLength);
-        auto satPosition = std::vector<Vec3>(blockLength);
-        auto satVelocity = std::vector<Vec3>(blockLength);
-        auto satSpeed = std::vector<double>(blockLength);
-        auto TCNbases = std::vector<Basis>(blockLength);
+        // Allocate vector for storing satellite position for each line
+        std::vector<Vec3> satPosition(blockLength);
 
-        #pragma omp parallel for
-        for (size_t blockLine = 0; blockLine < blockLength; ++blockLine) {
-            // Global line index
-            size_t line = lineStart + blockLine;
-
-            // Initialize orbital data for this azimuth line
-            auto& vel = satVelocity[blockLine];
-            _initAzimuthLine(line, sensingTime[blockLine],
-                    satPosition[blockLine], vel, TCNbases[blockLine]);
-            satSpeed[blockLine] = vel.norm();
-        }
+        // Get the midpoint of the DEM block in LLH coordinates.
+        // This should always be safe since the call to `computeDEMBounds()`
+        // above loads a block of the DEM raster.
+        assert(demInterp.hasRaster());
+        const auto dem_midpoint = demInterp.midLonLat();
 
         #pragma omp parallel
         {
@@ -202,38 +192,55 @@ topo(Raster & demRaster, TopoLayers & layers)
             // converged successfully.
             size_t totalconv_thread = 0;
 
-            #pragma omp for collapse(2)
+            // For each line in block
+            #pragma omp for
             for (size_t blockLine = 0; blockLine < blockLength; ++blockLine) {
+                // Global line index
+                size_t line = lineStart + blockLine;
+
+                // Initialize orbital data for this azimuth line
+                Basis TCNbasis;
+                double tline;
+                Vec3 pos, vel;
+                _initAzimuthLine(line, tline, pos, vel, TCNbasis);
+
+                satPosition[blockLine] = pos;
+
+                // Compute velocity magnitude
+                const double satVmag = vel.norm();
+
+                // Initialize LLH to middle of input DEM block and average height.
+                auto llh = dem_midpoint;
+
                 for (size_t rbin = 0; rbin < _radarGrid.width(); ++rbin) {
 
                     // Get current slant range
                     const double rng = _radarGrid.slantRange(rbin);
 
                     // Get current Doppler value
-                    const auto tline = sensingTime[blockLine];
-                    const auto satVmag = satSpeed[blockLine];
-                    const double dopfact = (0.5 * _radarGrid.wavelength() *
-                                            (_doppler.eval(tline, rng) / satVmag)) *
-                                           rng;
+                    const double dopfact = (0.5 * _radarGrid.wavelength()
+                                         * (_doppler.eval(tline, rng) / satVmag))
+                                         * rng;
 
                     // Store slant range bin data in Pixel
                     Pixel pixel(rng, dopfact, rbin);
 
-                    // Initialize LLH to middle of input DEM and average height
-                    Vec3 llh = demInterp.midLonLat();
-
                     // Perform rdr->geo iterations
-                    const auto& pos = satPosition[blockLine];
-                    const auto& vel = satVelocity[blockLine];
-                    const auto& TCNbasis = TCNbases[blockLine];
-                    int geostat = rdr2geo(pixel, TCNbasis, pos, vel, _ellipsoid,
-                                          demInterp, llh, _radarGrid.lookSide(),
-                                          _threshold, _numiter, _extraiter);
+                    int geostat = rdr2geo(
+                        pixel, TCNbasis, pos, vel, _ellipsoid, demInterp, llh,
+                        _radarGrid.lookSide(), _threshold, _numiter, _extraiter);
                     totalconv_thread += geostat;
 
                     // Save data in output arrays
                     _setOutputTopoLayers(llh, layers, blockLine, pixel, pos, vel,
                                          TCNbasis, demInterp);
+
+                    // If rdr2geo failed to converge, re-initialize the LLH estimate for
+                    // the next iteration. Otherwise, reuse the current solution as the
+                    // initial guess for the next range bin.
+                    if (geostat == 0) {
+                        llh = dem_midpoint;
+                    }
                 }
             }
 

--- a/cxx/isce3/geometry/Topo.cpp
+++ b/cxx/isce3/geometry/Topo.cpp
@@ -202,9 +202,6 @@ topo(Raster & demRaster, TopoLayers & layers)
             // converged successfully.
             size_t totalconv_thread = 0;
 
-            // Initialize LLH to middle of input DEM and average height
-            Vec3 llh = demInterp.midLonLat();
-
             #pragma omp for collapse(2)
             for (size_t blockLine = 0; blockLine < blockLength; ++blockLine) {
                 for (size_t rbin = 0; rbin < _radarGrid.width(); ++rbin) {
@@ -221,6 +218,9 @@ topo(Raster & demRaster, TopoLayers & layers)
 
                     // Store slant range bin data in Pixel
                     Pixel pixel(rng, dopfact, rbin);
+
+                    // Initialize LLH to middle of input DEM and average height
+                    Vec3 llh = demInterp.midLonLat();
 
                     // Perform rdr->geo iterations
                     const auto& pos = satPosition[blockLine];

--- a/cxx/isce3/geometry/Topo.cpp
+++ b/cxx/isce3/geometry/Topo.cpp
@@ -183,7 +183,7 @@ topo(Raster & demRaster, TopoLayers & layers)
         // Get the midpoint of the DEM block in LLH coordinates.
         // This should always be safe since the call to `computeDEMBounds()`
         // above loads a block of the DEM raster.
-        assert(demInterp.hasRaster());
+        assert(demInterp.haveRaster());
         const auto dem_midpoint = demInterp.midLonLat();
 
         #pragma omp parallel

--- a/cxx/isce3/geometry/Topo.h
+++ b/cxx/isce3/geometry/Topo.h
@@ -370,14 +370,14 @@ private:
      * @param[in] TCNbasis basis for the line under consideration
      * @param[in] demInterp DEM interpolator object used to compute local slope
      */
-    void _setOutputTopoLayers(isce3::core::Vec3 &,
-                              TopoLayers &,
-                              size_t,
-                              isce3::core::Pixel &,
-                              isce3::core::Vec3& pos,
-                              isce3::core::Vec3& vel,
-                              isce3::core::Basis &,
-                              DEMInterpolator &);
+    void _setOutputTopoLayers(const isce3::core::Vec3& llh,
+                              TopoLayers& layers,
+                              size_t line,
+                              const isce3::core::Pixel& pixel,
+                              const isce3::core::Vec3& pos,
+                              const isce3::core::Vec3& vel,
+                              const isce3::core::Basis& TCNbasis,
+                              const DEMInterpolator& demInterp);
 
     /** Main entry point for the module; internal creation of topo rasters */
     template<typename T> void _topo(T& dem, const std::string& outdir);

--- a/python/extensions/pybind_isce3/geometry/rdr2geo.cpp
+++ b/python/extensions/pybind_isce3/geometry/rdr2geo.cpp
@@ -229,13 +229,13 @@ void addbinding(py::class_<Topo>& pyRdr2Geo)
             (meters or degrees)
         height_raster: isce3.io.Raster
             Output raster for height above ellipsoid (meters)
-        incidence_raster: isce3.io.Raster
+        incidence_angle_raster: isce3.io.Raster
             Output raster for incidence angle (degrees) computed from vertical
             at target
         heading_angle_raster: isce3.io.Raster
             Output raster for azimuth angle (degrees) computed anti-clockwise
             from EAST (Right hand rule)
-        local_incidence_raster: isce3.io.Raster
+        local_incidence_angle_raster: isce3.io.Raster
             Output raster for local incidence angle (degrees) at target
         local_psi_raster: isce3.io.Raster
             Output raster for local projection angle (degrees) at target

--- a/tests/cxx/isce3/geometry/topo/topo.cpp
+++ b/tests/cxx/isce3/geometry/topo/topo.cpp
@@ -55,12 +55,14 @@ TEST(TopoTest, CheckResults) {
     isce3::io::Raster testRaster("topo.vrt");
 
     // Open reference topo raster
+    // XXX: Topo produces 11 layers but this raster only has 7 layers. The remaining
+    // layers are untested.
     std::string ref_filename = TESTDATA_DIR "topo/topo.vrt";
     std::cout << "reference file:" << ref_filename << std::endl;
     isce3::io::Raster refRaster(ref_filename);
 
     // The associated tolerances
-    std::vector<double> tols{1.0e-5, 1.0e-5, 0.15, 1.0e-4, 1.0e-4, 0.02, 0.02};
+    std::vector<double> tols{1.0e-4, 1.0e-5, 0.15, 1.0e-3, 1.0e-4, 0.02, 0.02};
 
     // The directories where the data are
     std::string test_dir = "./";
@@ -95,7 +97,7 @@ TEST(TopoTest, CheckResults) {
             }
         }
         // Normalize the error and check
-        ASSERT_TRUE((error / count) < tols[k]);
+        ASSERT_LT((error / count), tols[k]);
     }
 }
 

--- a/tests/python/extensions/pybind/geometry/rdr2geo.py
+++ b/tests/python/extensions/pybind/geometry/rdr2geo.py
@@ -93,7 +93,7 @@ def unit_test_params():
     dem_interp.compute_min_max_mean_height()
 
     # golden data layer tolerances
-    params.tols = [1.0e-5, 1.0e-5, 0.15, 1.0e-4, 1.0e-4, 0.02, 0.02]
+    params.tols = [1.0e-4, 1.0e-5, 0.15, 1.0e-3, 1.0e-4, 0.02, 0.02]
 
     # tolerances for east/north ground to satellite ENU unit vector layers
     # use same tolerance as heading angle since the computations are similar
@@ -189,6 +189,8 @@ def test_validate(unit_test_params):
     validate generated results
     """
     # load reference topo raster
+    # XXX: Topo produces 11 layers but this raster only has 7 layers. The
+    # remaining layers are untested.
     ref_ds = gdal.Open(
         os.path.join(iscetest.data, "topo/topo.vrt"), gdal.GA_ReadOnly
     )


### PR DESCRIPTION
This PR refactors the multi-threading strategy used by `Topo::topo()` to reduce latencies due to thread synchronization.

The previous implementation was designed to iterate over azimuth lines in serial and only parallelized over range samples within each azimuth line. I think this approach might've been chosen because there are a few values that only need to be computed once per azimuth line (e.g. the platform speed) and then can be reused by each thread.

This parallelization strategy introduces lots of latency due to thread synchronization overhead, though. Profiling the Topo runtime using `py-spy record --native` (a sampling profiler) shows that threads spend as much as 30% of the overall runtime in a function called `do_wait`.

This update refactors the `Topo::topo()` method to parallelize over lines instead.

I've also modified the implementation such that each call to `rdr2geo` uses the previous result of `rdr2geo` as its initial guess, which should typically reduce the number of iterations required for `rdr2geo` to converge. Previously, the implementation used the center point of the DEM interpolator as the initial guess for each call to `rdr2geo`.

I removed the "Topo progress" messages that printed the percent of completed azimuth lines within the current block, since they interfered with the new parallelization strategy (and were probably unnecessarily frequent anyway, IMO). There is still a status message indicating when each Topo block completes processing.

These updates significantly improve the overall runtime of the Topo module. On nisar-adt-rtc-1 (an r7i.4xlarge instance), the Topo runtime for generating Static Layers sample products at 20m x 20m posting decreased by ~38% (N=3). On nisar-adt-dev-3 (a g4dn.48xlarge instance, the runtime decreased by ~43% (N=3).