### PR TITLE
Allow non-integer margin in `stage_dem` and `stage_watermask`

### DIFF
--- a/python/packages/nisar/workflows/stage_dem.py
+++ b/python/packages/nisar/workflows/stage_dem.py
@@ -39,8 +39,8 @@ def cmdLineParse():
     parser.add_argument('-f', '--path', type=str, action='store',
                         dest='filepath', default='file',
                         help='Filepath to user DEM.')
-    parser.add_argument('-m', '--margin', type=int, action='store',
-                        default=5, help='Margin for DEM bounding box (km)')
+    parser.add_argument('-m', '--margin', type=float, action='store',
+                        default=5.0, help='Margin for DEM bounding box (km)')
     parser.add_argument('-b', '--bbox', type=float, nargs=4,
                         help=('Spatial bounding box as minX, minY, maxX, maxY '
                              'in Spatial Reference System specified by epsg. '
@@ -764,7 +764,7 @@ def check_aws_connection(version='1.2'):
         raise ValueError(errmsg)
 
 
-def apply_margin_to_geographic_box(polygon, margin_in_km=5):
+def apply_margin_to_geographic_box(polygon, margin_in_km=5.0):
     '''
     Assuming the polygon is in epsg 4326
     Convert margin from km to degrees and
@@ -798,7 +798,7 @@ def apply_margin_to_geographic_box(polygon, margin_in_km=5):
     return poly_with_margin
 
 
-def apply_margin_to_projected_box(polygon, margin_in_km=5):
+def apply_margin_to_projected_box(polygon, margin_in_km=5.0):
     '''
     Assuming the polygon is in UTM or Polar Stereo
     add a margin in km to the polygon

--- a/python/packages/nisar/workflows/stage_watermask.py
+++ b/python/packages/nisar/workflows/stage_watermask.py
@@ -41,8 +41,8 @@ def cmdLineParse():
     parser.add_argument('-f', '--path', type=str, action='store',
                         dest='filepath', default='file',
                         help='Filepath to user water mask.')
-    parser.add_argument('-m', '--margin', type=int, action='store',
-                        default=5, help='Margin for water mask bounding box (km)')
+    parser.add_argument('-m', '--margin', type=float, action='store',
+                        default=5.0, help='Margin for water mask bounding box (km)')
     parser.add_argument('-v', '--version', type=str, action='store',
                         dest='version', default='0.5',
                         help='Version for water mask')
@@ -575,7 +575,7 @@ def check_aws_connection(version):
         raise ValueError(errmsg)
 
 
-def apply_margin_polygon(polygon, margin_in_km=5):
+def apply_margin_polygon(polygon, margin_in_km=5.0):
     '''
     Convert margin from km to degrees and
     apply to polygon


### PR DESCRIPTION
Update `stage_dem.py` and `stage_watermask.py` to allow specifying a non-integer-valued `--margin` option.

h/t @rad-eng-59 who [suggested](https://github.com/isce-framework/isce3/pull/88#issuecomment-3198470037) this improvement.