### PR TITLE
AZ Blocked DC Removal in Doppler Est Workflow 

### DIFF
--- a/python/packages/nisar/pointing/doppler_lut_from_raw.py
+++ b/python/packages/nisar/pointing/doppler_lut_from_raw.py
@@ -114,9 +114,11 @@ def doppler_lut_from_raw(raw, *, freq_band='A', txrx_pol=None,
         of beams or RX channels. By default, all beams are included
         in the polyfitting of Doppler over entire swath of DM2 products.
     duration_dc_remove_az: float or None, default=0.5
-        Max AZ-block duration in (seconds) to remove DC in order to mitigate
-        internal calibration signal such as Caltone that can bias Doppler
-        estimation. If None, no DC removal in AZ.
+        Approximate AZ-block duration in (seconds) to remove DC in order to
+        mitigate internal calibration signal such as Caltone that can bias
+        Doppler estimation. Must be a positive value not greater than
+        `az_block_dur`! Its value may be modified to make it an integer
+        fraction of `az_block_dur`! If None, no DC removal in AZ.
     out_path : str, default='.'
         Output directory for dumping PNG files, if `plot` is True.
     plot : bool, default=False
@@ -246,7 +248,24 @@ def doppler_lut_from_raw(raw, *, freq_band='A', txrx_pol=None,
     logger.info(f'PRF -> {prf:.3f} (Hz)')
 
     if duration_dc_remove_az is not None:
-        nrgl_dc_rm = int(prf * duration_dc_remove_az)
+        # check allowable min/max value for AZ DC removal duration.
+        if (not (duration_dc_remove_az > 0.0) or
+                duration_dc_remove_az > az_block_dur):
+            raise ValueError(
+                f'"duration_dc_remove_az" {duration_dc_remove_az} (sec) must '
+                'be a positive value not greater than "az_block_dur" '
+                f'{az_block_dur} (sec)!'
+            )
+        # Now force DC-removal duration to be an integer
+        # fraction of Doppler duration
+        n_ratio = round(az_block_dur / duration_dc_remove_az)
+        dur_dc_rm_az_new = az_block_dur / n_ratio
+        logger.warning(
+            'To force "duration_dc_remove_az" to be an integer fraction of '
+            f'"az_block_dur" {az_block_dur} (sec), it is modified from '
+            f'{duration_dc_remove_az} (sec) to {dur_dc_rm_az_new} (sec)!'
+        )
+        nrgl_dc_rm = int(prf * dur_dc_rm_az_new)
         logger.info('Number range lines used in AZ-blocked '
                     f'DC removal -> {nrgl_dc_rm}')
     else:

--- a/python/packages/nisar/pointing/doppler_lut_from_raw.py
+++ b/python/packages/nisar/pointing/doppler_lut_from_raw.py
@@ -2,6 +2,7 @@
 Function to generate Doppler LUT2d from Raw L0B data.
 """
 import os
+from collections.abc import Iterator
 import numpy as np
 from scipy import fft
 try:
@@ -24,6 +25,7 @@ def doppler_lut_from_raw(raw, *, freq_band='A', txrx_pol=None,
                          rangeline_limit=None, time_interval=2.0,
                          dop_method='CDE', subband=False,
                          polyfit_deg=3, polyfit=False, exclude_beams=None,
+                         duration_dc_remove_az=0.5,
                          out_path='.', plot=False, logger=None):
     """Generates 2-D Doppler LUT as a function of slant range and azimuth time.
 
@@ -111,6 +113,10 @@ def doppler_lut_from_raw(raw, *, freq_band='A', txrx_pol=None,
         The beam number is in the range [1, N], where N is the number
         of beams or RX channels. By default, all beams are included
         in the polyfitting of Doppler over entire swath of DM2 products.
+    duration_dc_remove_az: float or None, default=0.5
+        Max AZ-block duration in (seconds) to remove DC in order to mitigate
+        internal calibration signal such as Caltone that can bias Doppler
+        estimation. If None, no DC removal in AZ.
     out_path : str, default='.'
         Output directory for dumping PNG files, if `plot` is True.
     plot : bool, default=False
@@ -238,6 +244,11 @@ def doppler_lut_from_raw(raw, *, freq_band='A', txrx_pol=None,
     logger.info(f'Chirp pulsewidth -> {pulsewidth * 1e6:.2f} (us)')
     logger.info(f'Chirp center frequency -> {centerfreq * 1e-6:.2f} (MHz)')
     logger.info(f'PRF -> {prf:.3f} (Hz)')
+
+    if duration_dc_remove_az is not None:
+        nrgl_dc_rm = int(prf * duration_dc_remove_az)
+        logger.info('Number range lines used in AZ-blocked '
+                    f'DC removal -> {nrgl_dc_rm}')
 
     # Get raw dataset
     raw_dset = raw.getRawDataset(freq_band, txrx_pol)
@@ -521,7 +532,9 @@ def doppler_lut_from_raw(raw, *, freq_band='A', txrx_pol=None,
         # Remove DC in AZ to mitigate internal cal signals such as
         # Caltone and its intermods that can largely bias Doppler
         # centroid est.
-        echo -= np.nanmean(echo, axis=0)
+        if duration_dc_remove_az is not None:
+            for slice_rm_dc in _slice_gen(num_lines, nrgl_dc_rm):
+                echo[slice_rm_dc] -= np.nanmean(echo[slice_rm_dc], axis=0)
 
         # create a mask for invalid/bad range bins for any reason
         # invalid values are either nan or zero but this does not include
@@ -919,3 +932,33 @@ def _form_mask_valid_range(tot_rgbs, rgb_valid_sbsw):
     for start_stop in rgb_valid_sbsw:
         msk_valid_rg[slice(*start_stop)] = True
     return msk_valid_rg
+
+
+def _slice_gen(
+        n_smp: int, n_smp_blk: int, idx_start: int = 0) -> Iterator[slice]:
+    """slice generator.
+
+    Parameters
+    ----------
+    n_smp : int
+        Total number of samples
+    n_smp_blk : int
+        Number of samples per full block
+    idx_start : int, default=0
+        Start index
+
+    Yields
+    ------
+    slice
+        slice object for each block.
+        The last block can have more
+        number of samples than `n_smp_blk`!
+
+    """
+    n_blk = n_smp // n_smp_blk
+    i_start = idx_start
+    for n in range(n_blk - 1):
+        i_stop = i_start + n_smp_blk
+        yield slice(i_start, i_stop)
+        i_start = i_stop
+    yield slice(i_start, idx_start + n_smp)

--- a/python/packages/nisar/pointing/doppler_lut_from_raw.py
+++ b/python/packages/nisar/pointing/doppler_lut_from_raw.py
@@ -518,6 +518,10 @@ def doppler_lut_from_raw(raw, *, freq_band='A', txrx_pol=None,
                     )
         else:  # single channel
             echo = raw_dset[slice_line]
+        # Remove DC in AZ to mitigate internal cal signals such as
+        # Caltone and its intermods that can largely bias Doppler
+        # centroid est.
+        echo -= np.nanmean(echo, axis=0)
 
         # create a mask for invalid/bad range bins for any reason
         # invalid values are either nan or zero but this does not include

--- a/python/packages/nisar/pointing/doppler_lut_from_raw.py
+++ b/python/packages/nisar/pointing/doppler_lut_from_raw.py
@@ -17,6 +17,7 @@ from isce3.antenna import Frame
 from isce3.geometry import DEMInterpolator
 from isce3.signal import form_single_tap_dbf_echo
 from nisar.log import set_logger
+from isce3.focus import fill_gaps
 
 
 def doppler_lut_from_raw(raw, *, freq_band='A', txrx_pol=None,
@@ -550,6 +551,9 @@ def doppler_lut_from_raw(raw, *, freq_band='A', txrx_pol=None,
                     )
         else:  # single channel
             echo = raw_dset[slice_line]
+        # zero fill TX gap regions in particular for DM2 case
+        # where it is filled with strong TX chirp.
+        fill_gaps(echo, valid_sbsw_all[:, slice_line])
         # Remove DC in AZ to mitigate internal cal signals such as
         # Caltone and its intermods that can largely bias Doppler
         # centroid est.

--- a/python/packages/nisar/pointing/doppler_lut_from_raw.py
+++ b/python/packages/nisar/pointing/doppler_lut_from_raw.py
@@ -249,6 +249,8 @@ def doppler_lut_from_raw(raw, *, freq_band='A', txrx_pol=None,
         nrgl_dc_rm = int(prf * duration_dc_remove_az)
         logger.info('Number range lines used in AZ-blocked '
                     f'DC removal -> {nrgl_dc_rm}')
+    else:
+        logger.warning('No blocked DC removal in AZ!')
 
     # Get raw dataset
     raw_dset = raw.getRawDataset(freq_band, txrx_pol)

--- a/python/packages/nisar/workflows/gen_doppler_range_product.py
+++ b/python/packages/nisar/workflows/gen_doppler_range_product.py
@@ -124,6 +124,11 @@ def cmd_line_parser():
                            'Default is entire L0B duration starting from '
                            '`time-start`.')
                      )
+    prs.add_argument('--duration-dc-remove-az', type=float, default=0.5,
+                     help=('Time duration (seconds) of AZ blocks for DC '
+                           'removal in AZ in order to mitigate Caltone and '
+                           'internal signal biasing Doppler Est. ')
+                     )
     return prs.parse_args()
 
 

--- a/python/packages/nisar/workflows/gen_doppler_range_product.py
+++ b/python/packages/nisar/workflows/gen_doppler_range_product.py
@@ -74,11 +74,11 @@ def cmd_line_parser():
                      help='Number of range bins to be averaged in Doppler '
                      'Estimator block. Shall be equal or larger than 1.')
     prs.add_argument('-a', '--az_block_dur', type=float, dest='az_block_dur',
-                     default=4.0,
+                     default=10.0,
                      help='Azimuth block duration in seconds defining time-'
                      'domain correlator length used in Doppler estimator.')
     prs.add_argument('-t', '--time_interval', type=float, dest='time_interval',
-                     default=2.0,
+                     default=5.0,
                      help='Time stamp interval between azimuth blocks in '
                      'seconds. Must not be larger than "az_block_dur".')
     prs.add_argument('-m', '--method', type=str, dest='dop_method',

--- a/python/packages/nisar/workflows/gen_doppler_range_product.py
+++ b/python/packages/nisar/workflows/gen_doppler_range_product.py
@@ -97,8 +97,8 @@ def cmd_line_parser():
                      help='Plot Doppler centroids and save them in '
                      '*.png files at the specified output path')
     prs.add_argument('-o', '--out', type=str, dest='out_path', default='.',
-                     help='Output directory to dump Doppler product as well as'
-                     'PNG plots.')
+                     help='Output directory to dump Doppler product as well '
+                     'as PNG plots.')
     prs.add_argument('--orbit', type=str, dest='orbit_file',
                      help='Filename of an external orbit XML file. The orbit '
                      'data will be used in place of those in L0B. Default is '

--- a/python/packages/nisar/workflows/gen_doppler_range_product.py
+++ b/python/packages/nisar/workflows/gen_doppler_range_product.py
@@ -127,7 +127,10 @@ def cmd_line_parser():
     prs.add_argument('--duration-dc-remove-az', type=float, default=0.5,
                      help=('Time duration (seconds) of AZ blocks for DC '
                            'removal in AZ in order to mitigate Caltone and '
-                           'internal signal biasing Doppler Est. ')
+                           'internal signal biasing Doppler Est. Must be a '
+                           'positive value not greater than `az_block_dur`! '
+                           'Its value may be modified to make it an integer '
+                           'fraction of `az_block_dur`.')
                      )
     return prs.parse_args()
 

--- a/tests/python/packages/nisar/pointing/doppler_lut_from_raw.py
+++ b/tests/python/packages/nisar/pointing/doppler_lut_from_raw.py
@@ -245,7 +245,7 @@ class TestDopplerLutFromRaw:
         dop_lut, _, _, _, _, _, _ = doppler_lut_from_raw(
             self.raw_obj, az_block_dur=self.az_block_dur,
             time_interval=self.time_interval, polyfit=True,
-            duration_dc_remove_az=1.0)
+            duration_dc_remove_az=0.7)
         # validate Doppler LUT axes, shape, statistics
         self._validate_doppler_lut(
             dop_lut, num_rgb_avg=8,

--- a/tests/python/packages/nisar/pointing/doppler_lut_from_raw.py
+++ b/tests/python/packages/nisar/pointing/doppler_lut_from_raw.py
@@ -229,7 +229,8 @@ class TestDopplerLutFromRaw:
         # estimate Doppler LUT
         dop_lut, _, _, _, _, _, dop_flt_coef = doppler_lut_from_raw(
             self.raw_obj, az_block_dur=self.az_block_dur,
-            time_interval=self.time_interval, subband=True)
+            time_interval=self.time_interval, subband=True,
+            duration_dc_remove_az=None)
         # validate Doppler LUT axes, shape, statistics
         self._validate_doppler_lut(dop_lut, num_rgb_avg=8,
                                    err_msg=' in joint time-frequency approach')
@@ -243,7 +244,8 @@ class TestDopplerLutFromRaw:
         # estimate Doppler LUTf
         dop_lut, _, _, _, _, _, _ = doppler_lut_from_raw(
             self.raw_obj, az_block_dur=self.az_block_dur,
-            time_interval=self.time_interval, polyfit=True)
+            time_interval=self.time_interval, polyfit=True,
+            duration_dc_remove_az=1.0)
         # validate Doppler LUT axes, shape, statistics
         self._validate_doppler_lut(
             dop_lut, num_rgb_avg=8,

--- a/tests/python/packages/nisar/workflows/gen_doppler_range_product.py
+++ b/tests/python/packages/nisar/workflows/gen_doppler_range_product.py
@@ -45,6 +45,7 @@ class TestGenDopplerRangeProduct:
         plot=True, out_path='.', orbit_file=None,
         attitude_file=None, exclude_beams=None,
         time_start=0, time_dur_max=None,
+        duration_dc_remove_az=0.5,
         antenna_file=os.path.join(iscetest.data, ant_alos1))
 
     # set input arguments for DBF NISAR case
@@ -55,6 +56,7 @@ class TestGenDopplerRangeProduct:
         subband=False, polyfit=True, polyfit_deg=3, plot=False,
         out_path='.', exclude_beams=None,
         time_start=0.0, time_dur_max=None,
+        duration_dc_remove_az=0.5,
         orbit_file=os.path.join(iscetest.data, sub_dir, orb_nisar),
         attitude_file=os.path.join(iscetest.data, sub_dir, att_nisar),
         antenna_file=os.path.join(iscetest.data, sub_dir, ant_nisar))
@@ -67,6 +69,7 @@ class TestGenDopplerRangeProduct:
         subband=False, polyfit=True, polyfit_deg=3, exclude_beams=[3],
         plot=False, out_path='.', orbit_file=None, attitude_file=None,
         time_start=0.0, time_dur_max=None,
+        duration_dc_remove_az=0.5,
         antenna_file=os.path.join(iscetest.data, subdir_dm2, ant_dm2),
         dem_file=os.path.join(iscetest.data, subdir_dm2, dem_dm2))
 
@@ -90,6 +93,11 @@ class TestGenDopplerRangeProduct:
         self.args_nisar.time_start = 0.1
         self.args_nisar.time_interval = 0.2
         self.args_nisar.time_dur_max = 1.3
+        gen_doppler_range_product(self.args_nisar)
+
+    def test_no_az_dc_removal(self):
+        # use NISAR DBF set for this test
+        self.args_nisar.duration_dc_remove_az = None
         gen_doppler_range_product(self.args_nisar)
 
     def test_dm2_dem_ant(self):


### PR DESCRIPTION
To mitigate large internal signal such as loud Caltone which can bias Doppler centroid estimation, the option for DC removal in along track is introduced in Doppler estimator workflow. 
The DC removal in AZ is done in blocking and the duration of the block is set by user in seconds regardless of PRF.
Optionally, it can be done by windowed/smoothed notch filtering in AZ spectrum by using inverse raised -cosine with proper width/size as shown in [here](https://github.jpl.nasa.gov/NISAR-L0B-STUFF/l0b_with_mitigated_tone).