### PR TITLE
Update QA to v15.0.0

### DIFF
--- a/share/nisar/defaults/insar.yaml
+++ b/share/nisar/defaults/insar.yaml
@@ -1595,8 +1595,6 @@ runconfig:
 
                     ionosphere_phase_screen:
 
-                    ionosphere_phase_screen:
-
                         # *** Threshold Percentage Parameters ***
                         # Check for malformed datasets using these threshold percentages.
                         # An exception is raised if the percent of pixels with the corresponding value

--- a/share/nisar/defaults/insar.yaml
+++ b/share/nisar/defaults/insar.yaml
@@ -1184,16 +1184,16 @@ runconfig:
                         # (-1 logs the percentages as INFO, but will not trigger a QA failure.)
 
                         # Percent of NaN pixels per total raster area allowed
-                        # Default: 95.0
-                        nan_threshold: 95.0
+                        # Default: -1
+                        nan_threshold: -1
 
                         # Percent of +/- Inf pixels per total raster area allowed
                         # Default: 95.0
                         inf_threshold: 95.0
 
                         # Percent of Fill-valued pixels per total raster area allowed
-                        # Default: 95.0
-                        fill_threshold: 95.0
+                        # Default: -1
+                        fill_threshold: -1
 
                         # Percent of Near-zero pixels per total raster area allowed
                         # Default: -1
@@ -1201,8 +1201,8 @@ runconfig:
 
                         # Percent of total invalid pixels per total raster area allowed
                         # 'Total invalid pixels' is the sum of NaN, Inf, fill, & (if `zero_is_invalid` is True) near-zero pixels.
-                        # Default: 95.0
-                        total_invalid_threshold: 95.0
+                        # Default: -1
+                        total_invalid_threshold: -1
 
                         # Absolute tolerance for determining if a raster pixel is 'near zero'.
                         # Default: 1e-06
@@ -1595,6 +1595,8 @@ runconfig:
 
                     ionosphere_phase_screen:
 
+                    ionosphere_phase_screen:
+
                         # *** Threshold Percentage Parameters ***
                         # Check for malformed datasets using these threshold percentages.
                         # An exception is raised if the percent of pixels with the corresponding value
@@ -1603,16 +1605,16 @@ runconfig:
                         # (-1 logs the percentages as INFO, but will not trigger a QA failure.)
 
                         # Percent of NaN pixels per total raster area allowed
-                        # Default: 99.0
-                        nan_threshold: 99.0
+                        # Default: -1
+                        nan_threshold: -1
 
                         # Percent of +/- Inf pixels per total raster area allowed
                         # Default: 99.0
                         inf_threshold: 99.0
 
                         # Percent of Fill-valued pixels per total raster area allowed
-                        # Default: 99.0
-                        fill_threshold: 99.0
+                        # Default: -1
+                        fill_threshold: -1
 
                         # Percent of Near-zero pixels per total raster area allowed
                         # Default: -1
@@ -1620,8 +1622,8 @@ runconfig:
 
                         # Percent of total invalid pixels per total raster area allowed
                         # 'Total invalid pixels' is the sum of NaN, Inf, fill, & (if `zero_is_invalid` is True) near-zero pixels.
-                        # Default: 99.0
-                        total_invalid_threshold: 99.0
+                        # Default: -1
+                        total_invalid_threshold: -1
 
                         # Absolute tolerance for determining if a raster pixel is 'near zero'.
                         # Default: 1e-06

--- a/tools/imagesets/oracle8conda/distrib_nisar/Dockerfile
+++ b/tools/imagesets/oracle8conda/distrib_nisar/Dockerfile
@@ -11,7 +11,7 @@ ARG GIT_OAUTH_TOKEN
 RUN cd /opt \
  && git clone https://$GIT_OAUTH_TOKEN@github-fn.jpl.nasa.gov/NISAR-ADT/SoilMoisture \
  && git clone https://github.com/isce-framework/nisarqa.git \
- && cd /opt/nisarqa && git checkout v14.0.1 && rm -rf .git \
+ && cd /opt/nisarqa && git checkout v15.0.0 && rm -rf .git \
  && cd /opt/SoilMoisture && git checkout v0.3.1 && rm -rf .git
 
 FROM $distrib_img


### PR DESCRIPTION
This PR updates QA to V15.0.0.

Two changes:
* Correctly plots GOFF quiver plots with the arrows on the X/Y coordinate grid
* Does not fail in the case of all-NaN RUNW and GUNW `ionospherePhaseScreen` layer