### PR TITLE
Update QA version from 15.0.0 to 15.0.1

### DIFF
--- a/tools/imagesets/oracle8conda/distrib_nisar/Dockerfile
+++ b/tools/imagesets/oracle8conda/distrib_nisar/Dockerfile
@@ -11,7 +11,7 @@ ARG GIT_OAUTH_TOKEN
 RUN cd /opt \
  && git clone https://$GIT_OAUTH_TOKEN@github-fn.jpl.nasa.gov/NISAR-ADT/SoilMoisture \
  && git clone https://github.com/isce-framework/nisarqa.git \
- && cd /opt/nisarqa && git checkout v15.0.0 && rm -rf .git \
+ && cd /opt/nisarqa && git checkout v15.0.1 && rm -rf .git \
  && cd /opt/SoilMoisture && git checkout v0.3.1 && rm -rf .git
 
 FROM $distrib_img


### PR DESCRIPTION
This PR updates QA from v15.0.0 to v15.0.1.

This update allows QA to be compatible with [ISCE3's NumPy v1.26.4](https://github.com/isce-framework/nisarqa/pull/75#:~:text=ISCE3%20builds%20with-,NumPy%201.26.4,-%2C%20we%20need%20update).