### PR TITLE
RSLC azimuth window

### DIFF
--- a/cxx/isce3/cuda/focus/Backproject.cu
+++ b/cxx/isce3/cuda/focus/Backproject.cu
@@ -42,6 +42,10 @@ using DeviceDEMInterpolator = isce3::cuda::geometry::gpuDEMInterpolator;
 using DeviceOrbitView = isce3::cuda::core::OrbitView;
 using DeviceRadarGeometry = isce3::cuda::container::RadarGeometry;
 
+using HostWindow = isce3::core::ChebyKernel<float>;
+using DeviceWindow= isce3::cuda::core::ChebyKernel<float>;
+using DeviceWindowView = isce3::cuda::core::ChebyKernelView<float>;
+
 template<typename T>
 using DeviceLUT2d = isce3::cuda::core::gpuLUT2d<T>;
 
@@ -406,7 +410,8 @@ __global__ void sumCoherentBatch(
         const double* __restrict__ tau_atm_in,
         const int* __restrict__ kstart_in, const int* __restrict__ kstop_in,
         const size_t n, const double fc, const Kernel kernel,
-        const int batch_start, const int batch_stop, const float pedestal = 1.0f)
+        const int batch_start, const int batch_stop,
+        const std::optional<DeviceWindowView> window = std::nullopt)
 {
     // thread index (1d grid of 1d blocks)
     const auto tid = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
@@ -434,9 +439,8 @@ __global__ void sumCoherentBatch(
     const double dtau = sampling_window.spacing();
     const auto samples = static_cast<size_t>(sampling_window.size());
 
-    const float win0 = 0.5f * (1.0f + pedestal);
-    const float win1 = 1.0f - win0;
-    const float win_freq = 2.0f * M_PI / (kstop - kstart - 1);
+    // scale pulse index to unit range
+    const float kscale = 1.0f / (kstop - kstart - 1);
 
     // loop over lines in batch
     thrust::complex<double> batch_sum = {0., 0.};
@@ -460,8 +464,13 @@ __global__ void sumCoherentBatch(
         ::sincospi(2. * fc * tau, &sin_phi, &cos_phi);
         z *= thrust::complex<double>(cos_phi, sin_phi);
 
-        const float window = win0 - win1 * std::cos(win_freq * (k - kstart));
-        batch_sum += window * z;
+        // assume branch prediction works better than an unnecessary multiply
+        if (window.has_value()) {
+            const auto x = (k - kstart) * kscale - 0.5f;
+            batch_sum += window.value()(x) * z;
+        } else {
+            batch_sum += z;
+        }
     }
 
     // add batch sum to total
@@ -479,7 +488,8 @@ ErrorCode backproject(std::complex<float>* out,
                       const Kernel& kernel, DryTroposphereModel dry_tropo_model,
                       const Rdr2GeoBracketParams& rdr2geo_params,
                       const Geo2RdrBracketParams& geo2rdr_params, int batch,
-                      float* height, float pedestal)
+                      const std::optional<DeviceWindowView> window,
+                      float* height)
 {
     // XXX input reference epoch must match output reference epoch
     if (out_geometry.referenceEpoch() != in_geometry.referenceEpoch()) {
@@ -686,7 +696,7 @@ ErrorCode backproject(std::complex<float>* out,
                 img.data().get(), rc.data().get(), pos.data().get(),
                 vel.data().get(), sampling_window, x.data().get(),
                 tau_atm.data().get(), kstart.data().get(), kstop.data().get(),
-                out_grid_size, fc, kernel, k, k + curr_batch, pedestal);
+                out_grid_size, fc, kernel, k, k + curr_batch, window);
 
         checkCudaErrors(cudaPeekAtLastError());
         checkCudaErrors(cudaStreamSynchronize(cudaStreamDefault));
@@ -709,12 +719,21 @@ ErrorCode backproject(std::complex<float>* out,
                       DryTroposphereModel dry_tropo_model,
                       const Rdr2GeoBracketParams& rdr2geo_params,
                       const Geo2RdrBracketParams& geo2rdr_params, int batch,
-                      float* height, float pedestal)
+                      const std::optional<HostWindow> window,
+                      float* height)
 {
     // copy inputs to device
     const DeviceRadarGeometry d_out_geometry(out_geometry);
     const DeviceRadarGeometry d_in_geometry(in_geometry);
     DeviceDEMInterpolator d_dem(dem);
+    std::optional<DeviceWindow> d_window;
+    std::optional<DeviceWindowView> dv_window = std::nullopt;
+    if (window.has_value()) {
+        // make a device copy held in function scope
+        d_window.emplace(DeviceWindow(window.value()));
+        // get a non-owning view
+        dv_window.emplace(d_window.value());
+    }
     ErrorCode ec;
 
     if (typeid(kernel) == typeid(HostBartlettKernel<float>)) {
@@ -722,35 +741,35 @@ ErrorCode backproject(std::complex<float>* out,
                 dynamic_cast<const HostBartlettKernel<float>&>(kernel));
         ec = backproject(out, d_out_geometry, in, d_in_geometry, d_dem, fc, ds,
                          d_kernel, dry_tropo_model, rdr2geo_params,
-                         geo2rdr_params, batch, height, pedestal);
+                         geo2rdr_params, batch, dv_window, height);
     }
     else if (typeid(kernel) == typeid(HostLinearKernel<float>)) {
         const DeviceLinearKernel<float> d_kernel(
                 dynamic_cast<const HostLinearKernel<float>&>(kernel));
         ec = backproject(out, d_out_geometry, in, d_in_geometry, d_dem, fc, ds,
                          d_kernel, dry_tropo_model, rdr2geo_params,
-                         geo2rdr_params, batch, height, pedestal);
+                         geo2rdr_params, batch, dv_window, height);
     }
     else if (typeid(kernel) == typeid(HostKnabKernel<float>)) {
         const DeviceKnabKernel<float> d_kernel(
                 dynamic_cast<const HostKnabKernel<float>&>(kernel));
         ec = backproject(out, d_out_geometry, in, d_in_geometry, d_dem, fc, ds,
                          d_kernel, dry_tropo_model, rdr2geo_params,
-                         geo2rdr_params, batch, height, pedestal);
+                         geo2rdr_params, batch, dv_window, height);
     }
     else if (typeid(kernel) == typeid(HostTabulatedKernel<float>)) {
         const DeviceTabulatedKernel<float> d_kernel(
                 dynamic_cast<const HostTabulatedKernel<float>&>(kernel));
         ec = backproject(out, d_out_geometry, in, d_in_geometry, d_dem, fc, ds,
                          d_kernel, dry_tropo_model, rdr2geo_params,
-                         geo2rdr_params, batch, height, pedestal);
+                         geo2rdr_params, batch, dv_window, height);
     }
     else if (typeid(kernel) == typeid(HostChebyKernel<float>)) {
         const DeviceChebyKernel<float> d_kernel(
                 dynamic_cast<const HostChebyKernel<float>&>(kernel));
         ec = backproject(out, d_out_geometry, in, d_in_geometry, d_dem, fc, ds,
                          d_kernel, dry_tropo_model, rdr2geo_params,
-                         geo2rdr_params, batch, height, pedestal);
+                         geo2rdr_params, batch, dv_window, height);
     }
     else {
         throw isce3::except::RuntimeError(ISCE_SRCINFO(), "not implemented");

--- a/cxx/isce3/cuda/focus/Backproject.cu
+++ b/cxx/isce3/cuda/focus/Backproject.cu
@@ -406,7 +406,7 @@ __global__ void sumCoherentBatch(
         const double* __restrict__ tau_atm_in,
         const int* __restrict__ kstart_in, const int* __restrict__ kstop_in,
         const size_t n, const double fc, const Kernel kernel,
-        const int batch_start, const int batch_stop)
+        const int batch_start, const int batch_stop, const float pedestal = 1.0f)
 {
     // thread index (1d grid of 1d blocks)
     const auto tid = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
@@ -434,6 +434,10 @@ __global__ void sumCoherentBatch(
     const double dtau = sampling_window.spacing();
     const auto samples = static_cast<size_t>(sampling_window.size());
 
+    const float win0 = 0.5f * (1.0f + pedestal);
+    const float win1 = 1.0f - win0;
+    const float win_freq = 2.0f * M_PI / (kstop - kstart - 1);
+
     // loop over lines in batch
     thrust::complex<double> batch_sum = {0., 0.};
     for (int k = batch_start; k < batch_stop; ++k) {
@@ -456,7 +460,8 @@ __global__ void sumCoherentBatch(
         ::sincospi(2. * fc * tau, &sin_phi, &cos_phi);
         z *= thrust::complex<double>(cos_phi, sin_phi);
 
-        batch_sum += z;
+        const float window = win0 - win1 * std::cos(win_freq * (k - kstart));
+        batch_sum += window * z;
     }
 
     // add batch sum to total
@@ -474,7 +479,7 @@ ErrorCode backproject(std::complex<float>* out,
                       const Kernel& kernel, DryTroposphereModel dry_tropo_model,
                       const Rdr2GeoBracketParams& rdr2geo_params,
                       const Geo2RdrBracketParams& geo2rdr_params, int batch,
-                      float* height)
+                      float* height, float pedestal)
 {
     // XXX input reference epoch must match output reference epoch
     if (out_geometry.referenceEpoch() != in_geometry.referenceEpoch()) {
@@ -681,7 +686,7 @@ ErrorCode backproject(std::complex<float>* out,
                 img.data().get(), rc.data().get(), pos.data().get(),
                 vel.data().get(), sampling_window, x.data().get(),
                 tau_atm.data().get(), kstart.data().get(), kstop.data().get(),
-                out_grid_size, fc, kernel, k, k + curr_batch);
+                out_grid_size, fc, kernel, k, k + curr_batch, pedestal);
 
         checkCudaErrors(cudaPeekAtLastError());
         checkCudaErrors(cudaStreamSynchronize(cudaStreamDefault));
@@ -704,7 +709,7 @@ ErrorCode backproject(std::complex<float>* out,
                       DryTroposphereModel dry_tropo_model,
                       const Rdr2GeoBracketParams& rdr2geo_params,
                       const Geo2RdrBracketParams& geo2rdr_params, int batch,
-                      float* height)
+                      float* height, float pedestal)
 {
     // copy inputs to device
     const DeviceRadarGeometry d_out_geometry(out_geometry);
@@ -717,35 +722,35 @@ ErrorCode backproject(std::complex<float>* out,
                 dynamic_cast<const HostBartlettKernel<float>&>(kernel));
         ec = backproject(out, d_out_geometry, in, d_in_geometry, d_dem, fc, ds,
                          d_kernel, dry_tropo_model, rdr2geo_params,
-                         geo2rdr_params, batch, height);
+                         geo2rdr_params, batch, height, pedestal);
     }
     else if (typeid(kernel) == typeid(HostLinearKernel<float>)) {
         const DeviceLinearKernel<float> d_kernel(
                 dynamic_cast<const HostLinearKernel<float>&>(kernel));
         ec = backproject(out, d_out_geometry, in, d_in_geometry, d_dem, fc, ds,
                          d_kernel, dry_tropo_model, rdr2geo_params,
-                         geo2rdr_params, batch, height);
+                         geo2rdr_params, batch, height, pedestal);
     }
     else if (typeid(kernel) == typeid(HostKnabKernel<float>)) {
         const DeviceKnabKernel<float> d_kernel(
                 dynamic_cast<const HostKnabKernel<float>&>(kernel));
         ec = backproject(out, d_out_geometry, in, d_in_geometry, d_dem, fc, ds,
                          d_kernel, dry_tropo_model, rdr2geo_params,
-                         geo2rdr_params, batch, height);
+                         geo2rdr_params, batch, height, pedestal);
     }
     else if (typeid(kernel) == typeid(HostTabulatedKernel<float>)) {
         const DeviceTabulatedKernel<float> d_kernel(
                 dynamic_cast<const HostTabulatedKernel<float>&>(kernel));
         ec = backproject(out, d_out_geometry, in, d_in_geometry, d_dem, fc, ds,
                          d_kernel, dry_tropo_model, rdr2geo_params,
-                         geo2rdr_params, batch, height);
+                         geo2rdr_params, batch, height, pedestal);
     }
     else if (typeid(kernel) == typeid(HostChebyKernel<float>)) {
         const DeviceChebyKernel<float> d_kernel(
                 dynamic_cast<const HostChebyKernel<float>&>(kernel));
         ec = backproject(out, d_out_geometry, in, d_in_geometry, d_dem, fc, ds,
                          d_kernel, dry_tropo_model, rdr2geo_params,
-                         geo2rdr_params, batch, height);
+                         geo2rdr_params, batch, height, pedestal);
     }
     else {
         throw isce3::except::RuntimeError(ISCE_SRCINFO(), "not implemented");

--- a/cxx/isce3/cuda/focus/Backproject.h
+++ b/cxx/isce3/cuda/focus/Backproject.h
@@ -36,6 +36,7 @@ using isce3::geometry::detail::Rdr2GeoBracketParams;
  * \param[in]  geo2rdr_params  geo2rdr configuration parameters
  * \param[in]  batch           Number of range-compressed data lines per batch
  * \param[out] height          Height of each pixel in meters above ellipsoid
+ * \param[in]  pedestal        Raised cosine window parameter (value at edge)
  *
  * \returns Non-zero error code if geometry fails to converge for any pixel,
  *          and the values for these pixels are set to NaN.
@@ -53,7 +54,7 @@ backproject(std::complex<float>* out,
             DryTroposphereModel dry_tropo_model = DryTroposphereModel::TSX,
             const Rdr2GeoBracketParams& rdr2geo_params = {},
             const Geo2RdrBracketParams& geo2rdr_params = {},
-            int batch = 1024, float* height = nullptr);
+            int batch = 1024, float* height = nullptr, float pedestal = 1.0f);
 
 /**
  * Focus in azimuth via time-domain backprojection
@@ -71,6 +72,7 @@ backproject(std::complex<float>* out,
  * \param[in]  geo2rdr_params  geo2rdr configuration parameters
  * \param[in]  batch           Number of range-compressed data lines per batch
  * \param[out] height          Height of each pixel in meters above ellipsoid
+ * \param[in]  pedestal        Raised cosine window parameter (value at edge)
  *
  * \returns Non-zero error code if geometry fails to converge for any pixel,
  *          and the values for these pixels are set to NaN.
@@ -85,6 +87,6 @@ backproject(std::complex<float>* out,
             DryTroposphereModel dry_tropo_model = DryTroposphereModel::TSX,
             const Rdr2GeoBracketParams& rdr2geo_params = {},
             const Geo2RdrBracketParams& geo2rdr_params = {},
-            int batch = 1024, float* height = nullptr);
+            int batch = 1024, float* height = nullptr, float pedestal = 1.0f);
 
 }}} // namespace isce3::cuda::focus

--- a/cxx/isce3/cuda/focus/Backproject.h
+++ b/cxx/isce3/cuda/focus/Backproject.h
@@ -6,6 +6,7 @@
 #include <isce3/geometry/forward.h>
 
 #include <complex>
+#include <optional>
 
 #include <isce3/core/Kernels.h>
 #include <isce3/error/ErrorCode.h>
@@ -35,8 +36,8 @@ using isce3::geometry::detail::Rdr2GeoBracketParams;
  * \param[in]  rdr2geo_params  rdr2geo configuration parameters
  * \param[in]  geo2rdr_params  geo2rdr configuration parameters
  * \param[in]  batch           Number of range-compressed data lines per batch
+ * \param[in]  window          Fit to apodization window on interval [-0.5, 0.5]
  * \param[out] height          Height of each pixel in meters above ellipsoid
- * \param[in]  pedestal        Raised cosine window parameter (value at edge)
  *
  * \returns Non-zero error code if geometry fails to converge for any pixel,
  *          and the values for these pixels are set to NaN.
@@ -54,7 +55,9 @@ backproject(std::complex<float>* out,
             DryTroposphereModel dry_tropo_model = DryTroposphereModel::TSX,
             const Rdr2GeoBracketParams& rdr2geo_params = {},
             const Geo2RdrBracketParams& geo2rdr_params = {},
-            int batch = 1024, float* height = nullptr, float pedestal = 1.0f);
+            int batch = 1024,
+            const std::optional<isce3::core::ChebyKernel<float>> window = std::nullopt,
+            float* height = nullptr);
 
 /**
  * Focus in azimuth via time-domain backprojection
@@ -71,8 +74,8 @@ backproject(std::complex<float>* out,
  * \param[in]  rdr2geo_params  rdr2geo configuration parameters
  * \param[in]  geo2rdr_params  geo2rdr configuration parameters
  * \param[in]  batch           Number of range-compressed data lines per batch
+ * \param[in]  window          Fit to apodization window on interval [-0.5, 0.5]
  * \param[out] height          Height of each pixel in meters above ellipsoid
- * \param[in]  pedestal        Raised cosine window parameter (value at edge)
  *
  * \returns Non-zero error code if geometry fails to converge for any pixel,
  *          and the values for these pixels are set to NaN.
@@ -87,6 +90,8 @@ backproject(std::complex<float>* out,
             DryTroposphereModel dry_tropo_model = DryTroposphereModel::TSX,
             const Rdr2GeoBracketParams& rdr2geo_params = {},
             const Geo2RdrBracketParams& geo2rdr_params = {},
-            int batch = 1024, float* height = nullptr, float pedestal = 1.0f);
+            int batch = 1024,
+            const std::optional<isce3::core::ChebyKernel<float>> window = std::nullopt,
+            float* height = nullptr);
 
 }}} // namespace isce3::cuda::focus

--- a/cxx/isce3/focus/Backproject.cpp
+++ b/cxx/isce3/focus/Backproject.cpp
@@ -42,7 +42,7 @@ inline std::complex<float> sumCoherent(const std::complex<float>* data,
 {
     using namespace isce3::math::complex_operations;
 
-    float kscale = 1.0f / (kstop - kstart - 1);
+    const float kscale = 1.0f / (kstop - kstart - 1);
 
     // loop over pulses within integration window
     std::complex<double> sum(0., 0.);

--- a/cxx/isce3/focus/Backproject.cpp
+++ b/cxx/isce3/focus/Backproject.cpp
@@ -24,6 +24,7 @@ using namespace isce3::geometry;
 using isce3::error::ErrorCode;
 
 using isce3::container::RadarGeometry;
+using Window = isce3::core::ChebyKernel<float>;
 
 namespace isce3 {
 namespace focus {
@@ -37,13 +38,11 @@ inline std::complex<float> sumCoherent(const std::complex<float>* data,
                                        double tau_atm,
                                        const Kernel<float>& kernel,
                                        int kstart, int kstop,
-                                       float pedestal = 1.0f)
+                                       const std::optional<Window> window = std::nullopt)
 {
     using namespace isce3::math::complex_operations;
 
-    const float win0 = 0.5f * (1.0f + pedestal);
-    const float win1 = 1.0f - win0;
-    const float win_freq = 2.0f * M_PI / (kstop - kstart - 1);
+    float kscale = 1.0f / (kstop - kstart - 1);
 
     // loop over pulses within integration window
     std::complex<double> sum(0., 0.);
@@ -62,11 +61,15 @@ inline std::complex<float> sumCoherent(const std::complex<float>* data,
         double phi = 2. * M_PI * fc * tau;
         s *= std::complex<double>(std::cos(phi), std::sin(phi));
 
-        const float window = win0 - win1 * std::cos(win_freq * (k - kstart));
-
-        // worst-case numerical error increases linearly, accumulate using
-        // double precision to mitigate errors
-        sum += window * s;
+        // assume branch prediction works better than an unnecessary multiply
+        if (window.has_value()) {
+            const auto x = (k - kstart) * kscale - 0.5f;
+            sum += window.value()(x) * s;
+        } else {
+            // worst-case numerical error increases linearly, accumulate using
+            // double precision to mitigate errors
+            sum += s;
+        }
     }
 
     return std::complex<float>(sum);
@@ -79,7 +82,8 @@ backproject(std::complex<float>* out, const RadarGeometry& out_geometry,
         const Kernel<float>& kernel, DryTroposphereModel dry_tropo_model,
         const isce3::geometry::detail::Rdr2GeoBracketParams& r2g_params,
         const isce3::geometry::detail::Geo2RdrBracketParams& g2r_params,
-        float* height, float pedestal)
+        const std::optional<Window> window,
+        float* height)
 {
     static constexpr double c = isce3::core::speed_of_light;
     static constexpr auto nan = std::numeric_limits<float>::quiet_NaN();
@@ -211,7 +215,7 @@ backproject(std::complex<float>* out, const RadarGeometry& out_geometry,
             // integrate pulses
             out[j * out_geometry.gridWidth() + i] =
                     sumCoherent(in, sampling_window, pos, vel, x, fc, tau_atm,
-                                kernel, kstart, kstop, pedestal);
+                                kernel, kstart, kstop, window);
         }
     }
 

--- a/cxx/isce3/focus/Backproject.cpp
+++ b/cxx/isce3/focus/Backproject.cpp
@@ -12,6 +12,7 @@
 #include <isce3/geometry/geometry.h>
 #include <isce3/geometry/rdr2geo_roots.h>
 #include <isce3/geometry/geo2rdr_roots.h>
+#include <isce3/math/complexOperations.h>
 #include <limits>
 #include <string>
 #include <vector>
@@ -35,8 +36,15 @@ inline std::complex<float> sumCoherent(const std::complex<float>* data,
                                        double fc,
                                        double tau_atm,
                                        const Kernel<float>& kernel,
-                                       int kstart, int kstop)
+                                       int kstart, int kstop,
+                                       float pedestal = 1.0f)
 {
+    using namespace isce3::math::complex_operations;
+
+    const float win0 = 0.5f * (1.0f + pedestal);
+    const float win1 = 1.0f - win0;
+    const float win_freq = 2.0f * M_PI / (kstop - kstart - 1);
+
     // loop over pulses within integration window
     std::complex<double> sum(0., 0.);
     for (int k = kstart; k < kstop; ++k) {
@@ -54,9 +62,11 @@ inline std::complex<float> sumCoherent(const std::complex<float>* data,
         double phi = 2. * M_PI * fc * tau;
         s *= std::complex<double>(std::cos(phi), std::sin(phi));
 
+        const float window = win0 - win1 * std::cos(win_freq * (k - kstart));
+
         // worst-case numerical error increases linearly, accumulate using
         // double precision to mitigate errors
-        sum += s;
+        sum += window * s;
     }
 
     return std::complex<float>(sum);
@@ -69,7 +79,7 @@ backproject(std::complex<float>* out, const RadarGeometry& out_geometry,
         const Kernel<float>& kernel, DryTroposphereModel dry_tropo_model,
         const isce3::geometry::detail::Rdr2GeoBracketParams& r2g_params,
         const isce3::geometry::detail::Geo2RdrBracketParams& g2r_params,
-        float* height)
+        float* height, float pedestal)
 {
     static constexpr double c = isce3::core::speed_of_light;
     static constexpr auto nan = std::numeric_limits<float>::quiet_NaN();
@@ -201,7 +211,7 @@ backproject(std::complex<float>* out, const RadarGeometry& out_geometry,
             // integrate pulses
             out[j * out_geometry.gridWidth() + i] =
                     sumCoherent(in, sampling_window, pos, vel, x, fc, tau_atm,
-                                kernel, kstart, kstop);
+                                kernel, kstart, kstop, pedestal);
         }
     }
 

--- a/cxx/isce3/focus/Backproject.h
+++ b/cxx/isce3/focus/Backproject.h
@@ -30,6 +30,7 @@ namespace focus {
  * \param[in]  r2g_params      rdr2geo configuration parameters
  * \param[in]  g2r_params      geo2rdr configuration parameters
  * \param[out] height          Height of each pixel in meters above ellipsoid
+ * \param[in]  pedestal        Raised cosine window parameter (value at edge)
  *
  * \returns Non-zero error code if geometry fails to converge for any pixel,
  *          and the values for these pixels are set to NaN.
@@ -44,7 +45,8 @@ backproject(std::complex<float>* out,
         DryTroposphereModel dry_tropo_model = DryTroposphereModel::TSX,
         const isce3::geometry::detail::Rdr2GeoBracketParams& r2g_params = {},
         const isce3::geometry::detail::Geo2RdrBracketParams& g2r_params = {},
-        float* height = nullptr);
+        float* height = nullptr,
+        float pedestal = 1.0f);
 
 } // namespace focus
 } // namespace isce3

--- a/cxx/isce3/focus/Backproject.h
+++ b/cxx/isce3/focus/Backproject.h
@@ -2,9 +2,11 @@
 
 #include <isce3/container/forward.h>
 #include <isce3/core/forward.h>
+#include <isce3/core/Kernels.h>
 #include <isce3/geometry/forward.h>
 
 #include <complex>
+#include <optional>
 
 #include <isce3/error/ErrorCode.h>
 #include <isce3/geometry/detail/Geo2Rdr.h>
@@ -29,8 +31,8 @@ namespace focus {
  * \param[in]  dry_tropo_model Dry troposphere path delay model
  * \param[in]  r2g_params      rdr2geo configuration parameters
  * \param[in]  g2r_params      geo2rdr configuration parameters
+ * \param[in]  window          Fit to apodization window on interval [-0.5, 0.5]
  * \param[out] height          Height of each pixel in meters above ellipsoid
- * \param[in]  pedestal        Raised cosine window parameter (value at edge)
  *
  * \returns Non-zero error code if geometry fails to converge for any pixel,
  *          and the values for these pixels are set to NaN.
@@ -45,8 +47,8 @@ backproject(std::complex<float>* out,
         DryTroposphereModel dry_tropo_model = DryTroposphereModel::TSX,
         const isce3::geometry::detail::Rdr2GeoBracketParams& r2g_params = {},
         const isce3::geometry::detail::Geo2RdrBracketParams& g2r_params = {},
-        float* height = nullptr,
-        float pedestal = 1.0f);
+        const std::optional<isce3::core::ChebyKernel<float>> window = std::nullopt,
+        float* height = nullptr);
 
 } // namespace focus
 } // namespace isce3

--- a/python/extensions/pybind_isce3/cuda/focus/Backproject.cpp
+++ b/python/extensions/pybind_isce3/cuda/focus/Backproject.cpp
@@ -37,8 +37,8 @@ void addbinding_cuda_backproject(py::module& m)
                 py::dict rdr2geo_params,
                 py::dict geo2rdr_params,
                 int batch,
-                std::optional<py::array_t<float, py::array::c_style>> height,
-                float pedestal) {
+                const std::optional<isce3::core::ChebyKernel<float>> window,
+                std::optional<py::array_t<float, py::array::c_style>> height) {
 
             if (out.ndim() != 2) {
                 throw InvalidArgument(ISCE_SRCINFO(), "output array must be 2-D");
@@ -94,7 +94,7 @@ void addbinding_cuda_backproject(py::module& m)
                 py::gil_scoped_release release;
                 err = backproject(out_data, out_geometry, in_data, in_geometry,
                         dem, fc, ds, kernel, atm, r2gparams, g2rparams, batch,
-                        height_data, pedestal);
+                        window, height_data);
             }
             // TODO bind ErrorCode class.  For now return nonzero on failure.
             return err != ErrorCode::Success;
@@ -114,6 +114,6 @@ void addbinding_cuda_backproject(py::module& m)
             py::arg("rdr2geo_params") = py::dict(),
             py::arg("geo2rdr_params") = py::dict(),
             py::arg("batch") = 1024,
-            py::arg("height") = py::none(),
-            py::arg("pedestal") = 1.0f);
+            py::arg("window") = py::none(),
+            py::arg("height") = py::none());
 }

--- a/python/extensions/pybind_isce3/cuda/focus/Backproject.cpp
+++ b/python/extensions/pybind_isce3/cuda/focus/Backproject.cpp
@@ -37,7 +37,8 @@ void addbinding_cuda_backproject(py::module& m)
                 py::dict rdr2geo_params,
                 py::dict geo2rdr_params,
                 int batch,
-                std::optional<py::array_t<float, py::array::c_style>> height) {
+                std::optional<py::array_t<float, py::array::c_style>> height,
+                float pedestal) {
 
             if (out.ndim() != 2) {
                 throw InvalidArgument(ISCE_SRCINFO(), "output array must be 2-D");
@@ -93,7 +94,7 @@ void addbinding_cuda_backproject(py::module& m)
                 py::gil_scoped_release release;
                 err = backproject(out_data, out_geometry, in_data, in_geometry,
                         dem, fc, ds, kernel, atm, r2gparams, g2rparams, batch,
-                        height_data);
+                        height_data, pedestal);
             }
             // TODO bind ErrorCode class.  For now return nonzero on failure.
             return err != ErrorCode::Success;
@@ -113,5 +114,6 @@ void addbinding_cuda_backproject(py::module& m)
             py::arg("rdr2geo_params") = py::dict(),
             py::arg("geo2rdr_params") = py::dict(),
             py::arg("batch") = 1024,
-            py::arg("height") = py::none());
+            py::arg("height") = py::none(),
+            py::arg("pedestal") = 1.0f);
 }

--- a/python/extensions/pybind_isce3/focus/Backproject.cpp
+++ b/python/extensions/pybind_isce3/focus/Backproject.cpp
@@ -92,8 +92,8 @@ void addbinding_backproject(py::module& m)
                 const std::string& dry_tropo_model,
                 py::dict rdr2geo_params,
                 py::dict geo2rdr_params,
-                std::optional<py::array_t<float, py::array::c_style>> height,
-                float pedestal) {
+                const std::optional<isce3::core::ChebyKernel<float>> window,
+                std::optional<py::array_t<float, py::array::c_style>> height) {
 
             if (out.ndim() != 2) {
                 throw InvalidArgument(ISCE_SRCINFO(), "output array must be 2-D");
@@ -144,8 +144,8 @@ void addbinding_backproject(py::module& m)
             {
                 py::gil_scoped_release release;
                 err = backproject(out_data, out_geometry, in_data, in_geometry,
-                    dem, fc, ds, kernel, atm, r2gparams, g2rparams,
-                    height_data, pedestal);
+                    dem, fc, ds, kernel, atm, r2gparams, g2rparams, window,
+                    height_data);
             }
             // TODO bind ErrorCode class.  For now return nonzero on failure.
             return err != ErrorCode::Success;
@@ -164,6 +164,6 @@ void addbinding_backproject(py::module& m)
             py::arg("dry_tropo_model") = "tsx",
             py::arg("rdr2geo_params") = py::dict(),
             py::arg("geo2rdr_params") = py::dict(),
-            py::arg("height") = py::none(),
-            py::arg("pedestal") = 1.0f);
+            py::arg("window") = py::none(),
+            py::arg("height") = py::none());
 }

--- a/python/extensions/pybind_isce3/focus/Backproject.cpp
+++ b/python/extensions/pybind_isce3/focus/Backproject.cpp
@@ -92,7 +92,8 @@ void addbinding_backproject(py::module& m)
                 const std::string& dry_tropo_model,
                 py::dict rdr2geo_params,
                 py::dict geo2rdr_params,
-                std::optional<py::array_t<float, py::array::c_style>> height) {
+                std::optional<py::array_t<float, py::array::c_style>> height,
+                float pedestal) {
 
             if (out.ndim() != 2) {
                 throw InvalidArgument(ISCE_SRCINFO(), "output array must be 2-D");
@@ -144,7 +145,7 @@ void addbinding_backproject(py::module& m)
                 py::gil_scoped_release release;
                 err = backproject(out_data, out_geometry, in_data, in_geometry,
                     dem, fc, ds, kernel, atm, r2gparams, g2rparams,
-                    height_data);
+                    height_data, pedestal);
             }
             // TODO bind ErrorCode class.  For now return nonzero on failure.
             return err != ErrorCode::Success;
@@ -163,5 +164,6 @@ void addbinding_backproject(py::module& m)
             py::arg("dry_tropo_model") = "tsx",
             py::arg("rdr2geo_params") = py::dict(),
             py::arg("geo2rdr_params") = py::dict(),
-            py::arg("height") = py::none());
+            py::arg("height") = py::none(),
+            py::arg("pedestal") = 1.0f);
 }

--- a/python/packages/isce3/focus/__init__.py
+++ b/python/packages/isce3/focus/__init__.py
@@ -4,4 +4,5 @@ from .sar_duration import (get_sar_duration, get_radar_velocities,
 from .valid_regions import (RadarPoint, RadarBoundingBox,
 	get_focused_sub_swaths, fill_gaps)
 from .calibration_luts import make_los_luts, make_cal_luts
+from .cheby_windows import get_window_approximation, WindowKind
 from .notch import Notch, FrequencyDomain

--- a/python/packages/isce3/focus/cheby_windows.py
+++ b/python/packages/isce3/focus/cheby_windows.py
@@ -2,6 +2,9 @@ from enum import Enum, unique
 import numpy as np
 from isce3.core import KernelF32, ChebyKernelF32
 
+
+# helper classes for fitting
+
 class CosineWindowF32(KernelF32):
     def __init__(self, pedestal_height: float = 1.0):
         width = 1.0
@@ -16,6 +19,7 @@ class CosineWindowF32(KernelF32):
             return np.float32(0)
         return np.float32(self.a0 - self.a1 * np.cos(self.freq * (t + 0.5)))
 
+
 class KaiserWindowF32(KernelF32):
     def __init__(self, beta: float = 0.0):
         width = 1.0
@@ -29,12 +33,33 @@ class KaiserWindowF32(KernelF32):
         x = self.beta * np.sqrt(1 - 4 * t * t)
         return np.float32(np.i0(x) * self.scale)
 
+
 @unique
 class WindowKind(str, Enum):
     KAISER = "kaiser"
     COSINE = "cosine"
 
-def get_window_approximation(kind: WindowKind, shape, order=8) -> ChebyKernelF32:
+
+def get_window_approximation(kind: WindowKind, shape, n=8) -> ChebyKernelF32:
+    """
+    Generate a Chebyshev polynomial that approximates an apodization window.
+
+    Parameters
+    ----------
+    kind : str or WindowKind
+        Either "kaiser" or "cosine" window
+    shape : float
+        Shape parameter of the window.  Pedestal height for raised cosine
+        window or beta for Kaiser window.
+    n : int
+        Number of coefficients in the polynomial.
+
+    Returns
+    -------
+    window : isce3.core.ChebyKernelF32
+        An approximation to the desired apodization window scaled to the
+        domain [-0.5, 0.5].
+    """
     kind = WindowKind(kind)
     if kind == "kaiser":
         win = KaiserWindowF32(shape)
@@ -42,4 +67,4 @@ def get_window_approximation(kind: WindowKind, shape, order=8) -> ChebyKernelF32
         win = CosineWindowF32(shape)
     else:
         assert False, "unhandled WindowKind"
-    return ChebyKernelF32(win, order)
+    return ChebyKernelF32(win, n)

--- a/python/packages/isce3/focus/cheby_windows.py
+++ b/python/packages/isce3/focus/cheby_windows.py
@@ -1,0 +1,45 @@
+from enum import Enum, unique
+import numpy as np
+from isce3.core import KernelF32, ChebyKernelF32
+
+class CosineWindowF32(KernelF32):
+    def __init__(self, pedestal_height: float = 1.0):
+        width = 1.0
+        KernelF32.__init__(self, width)
+        self.pedestal_height = pedestal_height
+        self.a0 = (1.0 + pedestal_height) / 2
+        self.a1 = 1.0 - self.a0
+        self.freq = 2 * np.pi
+
+    def __call__(self, t: float) -> np.float32:
+        if not (-0.5 <= t <= 0.5):
+            return np.float32(0)
+        return np.float32(self.a0 - self.a1 * np.cos(self.freq * (t + 0.5)))
+
+class KaiserWindowF32(KernelF32):
+    def __init__(self, beta: float = 0.0):
+        width = 1.0
+        KernelF32.__init__(self, width)
+        self.beta = beta
+        self.scale = 1.0 / np.i0(beta)
+
+    def __call__(self, t: float) -> np.float32:
+        if not (-0.5 <= t <= 0.5):
+            return np.float32(0)
+        x = self.beta * np.sqrt(1 - 4 * t * t)
+        return np.float32(np.i0(x) * self.scale)
+
+@unique
+class WindowKind(str, Enum):
+    KAISER = "kaiser"
+    COSINE = "cosine"
+
+def get_window_approximation(kind: WindowKind, shape, order=8) -> ChebyKernelF32:
+    kind = WindowKind(kind)
+    if kind == "kaiser":
+        win = KaiserWindowF32(shape)
+    elif kind == "cosine":
+        win = CosineWindowF32(shape)
+    else:
+        assert False, "unhandled WindowKind"
+    return ChebyKernelF32(win, order)

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -27,7 +27,8 @@ import nisar
 import numpy as np
 import isce3
 from isce3.core import DateTime, TimeDelta, LUT2d, Attitude, Orbit
-from isce3.focus import make_los_luts, fill_gaps, make_cal_luts, Notch
+from isce3.focus import (make_los_luts, fill_gaps, make_cal_luts, Notch,
+    get_window_approximation)
 from isce3.geometry import los2doppler
 from isce3.io.gdal import Raster, GDT_CFloat32
 from isce3.product import RadarGridParameters
@@ -1747,10 +1748,8 @@ def focus(runconfig, runconfig_path=""):
 
     rfi_results = defaultdict(list)
 
-    win_kind, pedestal = check_window_input(cfg.processing.azimuth_window,
-        msg="Azimuth window  ")
-    if win_kind != "cosine":
-        raise NotImplementedError("Only cosine window is implemented in azimuth.")
+    azwin = get_window_approximation(*check_window_input(
+        cfg.processing.azimuth_window, msg="Azimuth window  "))
 
     # main processing loop
     for channel_out in common_mode:
@@ -2020,8 +2019,8 @@ def focus(runconfig, runconfig_path=""):
                 err = backproject(z, ogeom, rcfile.data, igeom, dem,
                             channel_out.band.center, azres,
                             kernel, atmos, get_rdr2geo_params(cfg),
-                            get_geo2rdr_params(cfg, orbit), height=hgt,
-                            pedestal=pedestal)
+                            get_geo2rdr_params(cfg, orbit), window=azwin,
+                            height=hgt)
                 if err:
                     log.warning("azcomp block contains some invalid pixels")
                 writer.queue_write(z, block)

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1552,6 +1552,15 @@ def get_focused_sub_swaths(rawlist, out_chan, grid, orbit, doppler, dem, azres,
     return swaths
 
 
+def get_azimuth_window(cfg: Struct):
+    kind, shape = check_window_input(cfg.processing.azimuth_window,
+        msg="Azimuth window  ")
+    if (kind == "cosine" and shape == 1) or (kind == "kaiser" and shape == 0):
+        log.info("Azimuth window disabled based on shape parameter.")
+        return None
+    return get_window_approximation(kind, shape)
+
+
 def focus(runconfig, runconfig_path=""):
     # Strip off two leading namespaces.
     cfg = runconfig.runconfig.groups
@@ -1747,9 +1756,7 @@ def focus(runconfig, runconfig_path=""):
 
 
     rfi_results = defaultdict(list)
-
-    azwin = get_window_approximation(*check_window_input(
-        cfg.processing.azimuth_window, msg="Azimuth window  "))
+    azwin = get_azimuth_window(cfg)
 
     # main processing loop
     for channel_out in common_mode:

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1747,6 +1747,11 @@ def focus(runconfig, runconfig_path=""):
 
     rfi_results = defaultdict(list)
 
+    win_kind, pedestal = check_window_input(cfg.processing.azimuth_window,
+        msg="Azimuth window  ")
+    if win_kind != "cosine":
+        raise NotImplementedError("Only cosine window is implemented in azimuth.")
+
     # main processing loop
     for channel_out in common_mode:
         frequency, pol = channel_out.freq_id, channel_out.pol
@@ -2015,7 +2020,8 @@ def focus(runconfig, runconfig_path=""):
                 err = backproject(z, ogeom, rcfile.data, igeom, dem,
                             channel_out.band.center, azres,
                             kernel, atmos, get_rdr2geo_params(cfg),
-                            get_geo2rdr_params(cfg, orbit), height=hgt)
+                            get_geo2rdr_params(cfg, orbit), height=hgt,
+                            pedestal=pedestal)
                 if err:
                     log.warning("azcomp block contains some invalid pixels")
                 writer.queue_write(z, block)

--- a/share/nisar/defaults/focus.yaml
+++ b/share/nisar/defaults/focus.yaml
@@ -156,8 +156,8 @@ runconfig:
 
             # Azimuth spectral window, optional.  Defaults to no weighting.
             azimuth_window:
-                kind: Kaiser
-                shape: 0.0
+                kind: Cosine
+                shape: 1.0
 
             # Elevation antenna pattern, optional.
             elevation_antenna_pattern:

--- a/tests/python/packages/CMakeLists.txt
+++ b/tests/python/packages/CMakeLists.txt
@@ -10,6 +10,7 @@ isce3/core/llh.py
 isce3/core/orbit.py
 isce3/core/poly2d.py
 isce3/core/resample_block_generators.py
+isce3/focus/cheby_windows.py
 isce3/focus/valid_regions.py
 isce3/focus/notch.py
 isce3/geocode/geocode_slc.py

--- a/tests/python/packages/isce3/focus/cheby_windows.py
+++ b/tests/python/packages/isce3/focus/cheby_windows.py
@@ -1,0 +1,17 @@
+import numpy as np
+from isce3.focus import get_window_approximation
+import pytest
+
+n = 256
+beta = 1.6
+cases = (
+    ("hamming", get_window_approximation("cosine", 0.08), np.hamming(n)),
+    ("hann", get_window_approximation("cosine", 0.0), np.hanning(n)),
+    ("kaiser", get_window_approximation("kaiser", beta), np.kaiser(n, beta)),
+)
+
+@pytest.mark.parametrize("name,cheby,expected", cases)
+def test_window_approximation(name, cheby, expected):
+    t = np.linspace(-0.5, 0.5, len(expected))
+    values = np.array([cheby(ti) for ti in t])
+    np.testing.assert_allclose(values, expected, atol=5e-6, err_msg=name)


### PR DESCRIPTION
There are options in the focus.py configuration file for an azimuth apodization window, but the feature was never actually implemented because the azimuth antenna pattern was considered sufficient. However, the feature is useful in off-nominal scenarios like processing reduced resolution or when dealing with high-contrast scenes.

~~DRAFT STATUS: This PR is currently an ugly hack that only implements a raised cosine window. A Kaiser window would take more work to implement, especially considering that polymorphism is sort of annoying in CUDA. It's also important not to add a bunch of extra calculations to the innermost backprojection loop, though I guess it could be implemented as a post-processing step instead. I'm thinking using a `ChebyKernel` to represent the window might be a reasonably generic and efficient solution, but that'll have to wait a bit.~~

Edit: I changed the implementation to use a polynomial approximation to the window. It also skips the window calculation when possible, so there should be negligible impact on runtime in nominal processing (verified in my limited testing but TBC on a bigger scene).