### PR TITLE
add `output_individual_pngs` to QA runconfig schemas and defaults

### DIFF
--- a/share/nisar/defaults/focus.yaml
+++ b/share/nisar/defaults/focus.yaml
@@ -595,6 +595,17 @@ runconfig:
                     # Default: (1024, 1024)
                     tile_shape: [1024, 1024]
 
+                    # True to output one grayscale PNG+KML pair per raster image layer;
+                    # these will be generated in addition to the standard browse image
+                    # PNG+KML. The filename of each additional file will include a
+                    # suffix noting that image's frequency and polarization. False to
+                    # have the primary browse image be the only PNG+KML generated.
+                    # Note: If True, and if the input granule contains only one image,
+                    # then the additional individual PNG will be a duplicate image to
+                    # the primary browse image PNG, but with more descriptive filename.
+                    # Default: False
+                    output_individual_pngs: false
+
                 histogram:
 
                     # Step size to decimate the input array for computing

--- a/share/nisar/defaults/gcov.yaml
+++ b/share/nisar/defaults/gcov.yaml
@@ -669,6 +669,17 @@ runconfig:
                     # Default: (1024, 1024)
                     tile_shape: [1024, 1024]
 
+                    # True to output one grayscale PNG+KML pair per raster image layer;
+                    # these will be generated in addition to the standard browse image
+                    # PNG+KML. The filename of each additional file will include a
+                    # suffix noting that image's frequency and polarization. False to
+                    # have the primary browse image be the only PNG+KML generated.
+                    # Note: If True, and if the input granule contains only one image,
+                    # then the additional individual PNG will be a duplicate image to
+                    # the primary browse image PNG, but with more descriptive filename.
+                    # Default: False
+                    output_individual_pngs: false
+
                 histogram:
 
                     # Step size to decimate the input array for computing

--- a/share/nisar/defaults/gslc.yaml
+++ b/share/nisar/defaults/gslc.yaml
@@ -454,6 +454,17 @@ runconfig:
                     # Default: (1024, 1024)
                     tile_shape: [1024, 1024]
 
+                    # True to output one grayscale PNG+KML pair per raster image layer;
+                    # these will be generated in addition to the standard browse image
+                    # PNG+KML. The filename of each additional file will include a
+                    # suffix noting that image's frequency and polarization. False to
+                    # have the primary browse image be the only PNG+KML generated.
+                    # Note: If True, and if the input granule contains only one image,
+                    # then the additional individual PNG will be a duplicate image to
+                    # the primary browse image PNG, but with more descriptive filename.
+                    # Default: False
+                    output_individual_pngs: false
+
                 histogram:
 
                     # Step size to decimate the input array for computing

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -472,6 +472,7 @@ qa_reports_options:
     gamma: num(min=0.0, required=False)
     nan_color_in_pdf: str(required=False)
     tile_shape: list(int(min=-1), min=2, max=2, required=False)
+    output_individual_pngs: bool(required=False)
   histogram:
     decimation_ratio: list(int(min=1), min=2, max=2, required=False)
     backscatter_histogram_bin_edges_range: list(num(), min=2, max=2, required=False)

--- a/share/nisar/schemas/gcov.yaml
+++ b/share/nisar/schemas/gcov.yaml
@@ -293,6 +293,7 @@ qa_reports_options:
         gamma: num(min=0.0, required=False)
         nan_color_in_pdf: str(required=False)
         tile_shape: list(int(min=-1), min=2, max=2, required=False)
+        output_individual_pngs: bool(required=False)
     histogram:
         decimation_ratio: list(int(min=1), min=2, max=2, required=False)
         backscatter_histogram_bin_edges_range: list(num(), min=2, max=2, required=False)

--- a/share/nisar/schemas/gslc.yaml
+++ b/share/nisar/schemas/gslc.yaml
@@ -236,6 +236,7 @@ qa_reports_options:
         gamma: num(min=0.0, required=False)
         nan_color_in_pdf: str(required=False)
         tile_shape: list(int(min=-1), min=2, max=2, required=False)
+        output_individual_pngs: bool(required=False)
     histogram:
         decimation_ratio: list(int(min=1), min=2, max=2, required=False)
         backscatter_histogram_bin_edges_range: list(num(), min=2, max=2, required=False)


### PR DESCRIPTION
This PR adds the new `output_individual_pngs` runconfig parameter from QA to the ISCE3 runconfig schemas and defaults files.