### PR TITLE
Remove caltone with 2D variation

### DIFF
--- a/python/packages/isce3/focus/__init__.py
+++ b/python/packages/isce3/focus/__init__.py
@@ -1,4 +1,5 @@
 from isce3.ext.isce3.focus import *
+from .caltone import ToneRemover
 from .sar_duration import (get_sar_duration, get_radar_velocities,
 	predict_azimuth_envelope)
 from .valid_regions import (RadarPoint, RadarBoundingBox,

--- a/python/packages/isce3/focus/caltone.py
+++ b/python/packages/isce3/focus/caltone.py
@@ -2,15 +2,24 @@ import numpy as np
 from isce3.signal import cola_windows
 
 class ToneRemover:
+    """
+    Coherently estimate and remove a non-stationary tone-like signal.
+    """
     def __init__(self, frequency, n, window_size=64, dtype=np.complex64):
         """
         Parameters
         ----------
         frequency : float
+            The nominal tone frequency, normalized to radians/sample, e.g.,
             (f_caltone - fc) / fs
+            Note there is no check for aliasing.
         n : int
+            Number of samples in the signal to analyze.
         window_size : int, optional
-        dtype : numpy.dtype
+            Number of samples in each estimation block.  Estimates will be
+            spaced by half the window_size.
+        dtype : numpy.dtype, optional
+            Data type for filter banks.
         """
         self.dtype = dtype
         self.size = n
@@ -23,12 +32,19 @@ class ToneRemover:
             self.wavelets.append((block, analysis, synthesis))
 
     def analyze(self, z):
+        """Estimate the time-varying response of a signal `z` to a
+        tone-like filter bank.  Akin to a single-bin STFT.
+        `z` should be one-dimensional with length self.size.
+        """
         if len(z) != self.size:
             raise ValueError(
                 f"Planned for length={self.size} but got {len(z)}")
         return np.array([w.dot(z[block]) for (block, w, _) in self.wavelets])
 
     def synthesize(self, coeffs):
+        """Generate a continuous time-domain signal given its filter bank
+        response coefficients.  Akin to a single-bin inverse STFT.
+        """
         if len(coeffs) != len(self.wavelets):
             raise ValueError("Need one coefficient per wavelet.")
         z = np.zeros(self.size, self.dtype)
@@ -37,6 +53,9 @@ class ToneRemover:
         return z
 
     def remove_tone(self, z):
+        """Estimate parameters of a time-varying tone and return the signal
+        `z` with the tone subtracted.
+        """
         if z.ndim != 1:
             raise NotImplementedError("Only 1D estimation is implemented")
         coeffs = self.analyze(z)

--- a/python/packages/isce3/focus/caltone.py
+++ b/python/packages/isce3/focus/caltone.py
@@ -1,0 +1,43 @@
+import numpy as np
+from isce3.signal import cola_windows
+
+class ToneRemover:
+    def __init__(self, frequency, n, window_size=64, dtype=np.complex64):
+        """
+        Parameters
+        ----------
+        frequency : float
+            (f_caltone - fc) / fs
+        n : int
+        window_size : int, optional
+        dtype : numpy.dtype
+        """
+        self.dtype = dtype
+        self.size = n
+        # NOTE Use a consistent phase reference across blocks.
+        tone = np.exp(-1j * 2 * np.pi * frequency * np.arange(n))
+        self.wavelets = []
+        for block, window in cola_windows(n, window_size):
+            analysis = (window * tone[block] / np.sum(window)).astype(dtype)
+            synthesis = (window * tone[block]).conjugate().astype(dtype)
+            self.wavelets.append((block, analysis, synthesis))
+
+    def analyze(self, z):
+        if len(z) != self.size:
+            raise ValueError(
+                f"Planned for length={self.size} but got {len(z)}")
+        return np.array([w.dot(z[block]) for (block, w, _) in self.wavelets])
+
+    def synthesize(self, coeffs):
+        if len(coeffs) != len(self.wavelets):
+            raise ValueError("Need one coefficient per wavelet.")
+        z = np.zeros(self.size, self.dtype)
+        for i, (block, _, w) in enumerate(self.wavelets):
+            z[block] += coeffs[i] * w
+        return z
+
+    def remove_tone(self, z):
+        if z.ndim != 1:
+            raise NotImplementedError("Only 1D estimation is implemented")
+        coeffs = self.analyze(z)
+        return z - self.synthesize(coeffs)

--- a/python/packages/isce3/signal/__init__.py
+++ b/python/packages/isce3/signal/__init__.py
@@ -1,4 +1,5 @@
 from isce3.ext.isce3.signal import *
+from .cola_windows import cola_windows
 from .fir_filter_func import (cheby_equi_ripple_filter,
                               design_shaped_lowpass_filter,
                               design_shaped_bandpass_filter,

--- a/python/packages/isce3/signal/cola_windows.py
+++ b/python/packages/isce3/signal/cola_windows.py
@@ -13,7 +13,7 @@ def cola_windows(n: int, window_size: int = 64) -> Iterator[tuple[slice, np.ndar
     n : int
         Length of array to analyze.
     window_size : int, optional
-        Length of analysis blocks.
+        Length of analysis blocks. Must be even-valued. Defaults to 64.
 
     Yields
     -------

--- a/python/packages/isce3/signal/cola_windows.py
+++ b/python/packages/isce3/signal/cola_windows.py
@@ -1,0 +1,40 @@
+import numpy as np
+from typing import Iterator
+
+def cola_windows(n: int, window_size: int = 64) -> Iterator[tuple[slice, np.ndarray]]:
+    """
+    Generate windows with the constant-overlap-add (COLA) property.
+    Hann windows are generated with 50% overlap and sum to one.
+    The first segment is a half window, and final two windows may
+    be partial.
+
+    Parameters
+    ----------
+    n : int
+        Length of array to analyze.
+    window_size : int, optional
+        Length of analysis blocks.
+
+    Yields
+    -------
+    selection : slice
+        Segment to index in data array.
+    window : numpy.ndarray
+        Hann window (possibly partial) for block analysis/synthesis.
+    """
+    if window_size % 2 != 0:
+        raise ValueError("window_size must be even")
+    w0 = np.hanning(window_size + 1)[:window_size]
+    half = window_size // 2
+    for i in range(0, n + half - 1, half):
+        dstart = i - half
+        dend = dstart + window_size
+        wstart = 0
+        wend = window_size
+        if dstart < 0:
+            wstart = -dstart
+            dstart = 0
+        if dend > n:
+            dend = n
+            wend = dend - dstart
+        yield slice(dstart, dend), w0[wstart:wend]

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1805,6 +1805,17 @@ def focus(runconfig, runconfig_path=""):
             if cfg.processing.zero_fill_gaps:
                 log.info("Will fill gaps between sub-swaths with zeros.")
 
+            fs = raw.getChirpParameters(channel_in.freq_id, pol[0])[1]
+            wavelets = isce3.focus.ToneRemover(
+                (cfg.processing.caltone.frequency - channel_in.band.center) / fs,
+                raw_grid.shape[1],
+                cfg.processing.caltone.wavelet_size)
+
+            if cfg.processing.caltone.algorithm == "azimuth_mean":
+                log.info("Will remove azimuth mean from each block")
+            elif cfg.processing.caltone.algorithm == "wavelet":
+                log.info("Will remove wavelet caltone estimate from each pulse")
+
             for i in range(0, raw_grid.shape[0], na):
                 pulse = i + pulse_begin
                 nblock = min(na, rawdata.shape[0] - pulse, raw_mm.shape[0] - i)
@@ -1816,8 +1827,11 @@ def focus(runconfig, runconfig_path=""):
                 z[np.isnan(z)] = 0.0
                 if cfg.processing.zero_fill_gaps:
                     fill_gaps(z, swaths[:, pulse:pulse+nblock, :], 0.0)
-                if cfg.processing.nullify_azimuth_mean:
+                if cfg.processing.caltone.algorithm == "azimuth_mean":
                     z -= z.mean(axis=0)
+                elif cfg.processing.caltone.algorithm == "wavelet":
+                    for k in range(z.shape[0]):
+                        z[k] = wavelets.remove_tone(z[k])
                 raw_mm[block_out] = z
 
             raw_clean, rfi_likelihood = process_rfi(cfg, raw_mm, temp)

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1551,6 +1551,51 @@ def get_focused_sub_swaths(rawlist, out_chan, grid, orbit, doppler, dem, azres,
     return swaths
 
 
+def get_caltone_algorithm(cfg, fc, fs, n, is_dithered):
+    """Helper for configuring caltone removal.
+
+    Parameters
+    ----------
+    cfg : Struct
+        RSLC runconfig data.
+    fc : float
+        Center frequency in Hz.
+    fs : float
+        Sample rate in Hz.
+    n : int
+        Number of samples in raw data.
+    is_dithered : bool
+        Whether we're analyzing a mode with dithered PRI.
+
+    Returns
+    -------
+    algorithm : str in {"azimuth_mean", "wavelet", "none"}
+        What algorithm to use ("auto" is reduced to one of the above)
+    wavelets : isce3.focus.ToneRemover | None
+        Object that can do caltone removal.
+    """
+    algorithm = str(cfg.processing.caltone.algorithm).lower()
+    # In dithered NISAR modes the caltone phase varies across each pulse,
+    # so removing the mean won't work.  Otherwise assume it's fine to remove
+    # azimuth mean in NISAR data since DC is outside the azimuth passband.
+    # For other systems like ALOS that's not such a great assumption.
+    if algorithm == "auto":
+        algorithm = "wavelet" if is_dithered else "azimuth_mean"
+
+    wavelets = None
+    if algorithm == "azimuth_mean":
+        log.info("Will remove azimuth mean from each block.")
+    elif algorithm == "wavelet":
+        log.info("Will remove wavelet caltone estimate from each pulse.")
+        wavelets = isce3.focus.ToneRemover(
+            (cfg.processing.caltone.frequency - fc) / fs,
+            n, cfg.processing.caltone.wavelet_size)
+    else:
+        algorithm = "disabled"
+        log.info("No caltone removal requested.")
+
+    return algorithm, wavelets
+
 def focus(runconfig, runconfig_path=""):
     # Strip off two leading namespaces.
     cfg = runconfig.runconfig.groups
@@ -1806,15 +1851,9 @@ def focus(runconfig, runconfig_path=""):
                 log.info("Will fill gaps between sub-swaths with zeros.")
 
             fs = raw.getChirpParameters(channel_in.freq_id, pol[0])[1]
-            wavelets = isce3.focus.ToneRemover(
-                (cfg.processing.caltone.frequency - channel_in.band.center) / fs,
-                raw_grid.shape[1],
-                cfg.processing.caltone.wavelet_size)
-
-            if cfg.processing.caltone.algorithm == "azimuth_mean":
-                log.info("Will remove azimuth mean from each block")
-            elif cfg.processing.caltone.algorithm == "wavelet":
-                log.info("Will remove wavelet caltone estimate from each pulse")
+            caltone_algorithm, wavelets = get_caltone_algorithm(cfg,
+                channel_in.band.center, fs, raw_grid.shape[1],
+                raw.isDithered(channel_in.freq_id))
 
             for i in range(0, raw_grid.shape[0], na):
                 pulse = i + pulse_begin
@@ -1827,9 +1866,9 @@ def focus(runconfig, runconfig_path=""):
                 z[np.isnan(z)] = 0.0
                 if cfg.processing.zero_fill_gaps:
                     fill_gaps(z, swaths[:, pulse:pulse+nblock, :], 0.0)
-                if cfg.processing.caltone.algorithm == "azimuth_mean":
+                if caltone_algorithm == "azimuth_mean":
                     z -= z.mean(axis=0)
-                elif cfg.processing.caltone.algorithm == "wavelet":
+                elif caltone_algorithm == "wavelet":
                     for k in range(z.shape[0]):
                         z[k] = wavelets.remove_tone(z[k])
                 raw_mm[block_out] = z

--- a/share/nisar/defaults/focus.yaml
+++ b/share/nisar/defaults/focus.yaml
@@ -427,11 +427,15 @@ runconfig:
                 # which is a sensible default for NISAR LSAR.
                 # auto | wavelet | azimuth_mean | disabled
                 algorithm: auto
+
+                # Calibration tone frequency (RF) in Hz.
                 # NOTE Caltone frequency changed for most modes between mode
                 # table v50 and v51, which went went into operations on
                 # 2025-10-17T00:00:00Z.  The v50 frequency is 1216.904297e6 Hz
                 # while the v51 frequency is 1214.882813e6 Hz.
                 frequency: 1214.882813e6
+
+                # Length of constant-overlap add (COLA) window.
                 wavelet_size: 64
 
             # Processing stage switches, mostly for debug.

--- a/share/nisar/defaults/focus.yaml
+++ b/share/nisar/defaults/focus.yaml
@@ -422,9 +422,11 @@ runconfig:
                 # and subtracting it is done in blocks using
                 # rangecomp.block_size
                 # If "wavelet" then subtract an estimate that varies in 2D.
-                # No correction when null.
-                # wavelet | azimuth_mean | null
-                algorithm: azimuth_mean
+                # No correction when "disabled".
+                # Option "auto" means "wavelet" if dithered else "azimuth_mean",
+                # which is a sensible default for NISAR LSAR.
+                # auto | wavelet | azimuth_mean | disabled
+                algorithm: auto
                 # NOTE Caltone frequency changed for most modes between mode
                 # table v50 and v51, which went went into operations on
                 # 2025-10-17T00:00:00Z.  The v50 frequency is 1216.904297e6 Hz

--- a/share/nisar/defaults/focus.yaml
+++ b/share/nisar/defaults/focus.yaml
@@ -415,11 +415,18 @@ runconfig:
             # cal pulses.
             zero_fill_gaps: True
 
-            # If true, subtract the azimuth mean from the raw data, which is
-            # useful when the caltone is nearly constant in azimuth but not
-            # stationary in range.  Calculating the mean and subtracting it is
-            # done in blocks using rangecomp.block_size
-            nullify_azimuth_mean: True
+            caltone:
+                # If "azimuth_mean", subtract the azimuth mean from the raw
+                # data, which is useful when the caltone is nearly constant in
+                # azimuth but not stationary in range.  Calculating the mean
+                # and subtracting it is done in blocks using
+                # rangecomp.block_size
+                # If "wavelet" then subtract an estimate that varies in 2D.
+                # No correction when null.
+                # wavelet | azimuth_mean | null
+                algorithm: azimuth_mean
+                frequency: 1216.904e6
+                wavelet_size: 64
 
             # Processing stage switches, mostly for debug.
             # Any missing stages assumed True

--- a/share/nisar/defaults/focus.yaml
+++ b/share/nisar/defaults/focus.yaml
@@ -425,7 +425,11 @@ runconfig:
                 # No correction when null.
                 # wavelet | azimuth_mean | null
                 algorithm: azimuth_mean
-                frequency: 1216.904e6
+                # NOTE Caltone frequency changed for most modes between mode
+                # table v50 and v51, which went went into operations on
+                # 2025-10-17T00:00:00Z.  The v50 frequency is 1216.904297e6 Hz
+                # while the v51 frequency is 1214.882813e6 Hz.
+                frequency: 1214.882813e6
                 wavelet_size: 64
 
             # Processing stage switches, mostly for debug.

--- a/share/nisar/defaults/focus.yaml
+++ b/share/nisar/defaults/focus.yaml
@@ -430,7 +430,7 @@ runconfig:
 
                 # Calibration tone frequency (RF) in Hz.
                 # NOTE Caltone frequency changed for most modes between mode
-                # table v50 and v51, which went went into operations on
+                # table v50 and v51, which went into operations on
                 # 2025-10-17T00:00:00Z.  The v50 frequency is 1216.904297e6 Hz
                 # while the v51 frequency is 1214.882813e6 Hz.
                 frequency: 1214.882813e6

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -253,11 +253,10 @@ runconfig:
       # If true, fill transmit gaps with zeros to remove loop-back cal pulses.
       zero_fill_gaps: bool(required=False)
 
-      # If true, subtract the azimuth mean from the raw data, which is useful
-      # when the caltone is nearly constant in azimuth but not stationary in
-      # range.  Calculating the mean and subtracting it is done in blocks using
-      # rangecomp.block_size
-      nullify_azimuth_mean: bool(required=False)
+      caltone:
+          frequency: num(min=0, required=False)
+          algorithm: enum('wavelet', 'azimuth_mean', required=False)
+          block_size: num(min=2, required=False)
 
       # Processing stage switches, mostly for debug.
       # Any missing stages assumed True

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -253,10 +253,7 @@ runconfig:
       # If true, fill transmit gaps with zeros to remove loop-back cal pulses.
       zero_fill_gaps: bool(required=False)
 
-      caltone:
-          frequency: num(min=0, required=False)
-          algorithm: enum('wavelet', 'azimuth_mean', required=False)
-          block_size: num(min=2, required=False)
+      caltone: include('caltone_options', required=False)
 
       # Processing stage switches, mostly for debug.
       # Any missing stages assumed True
@@ -283,6 +280,11 @@ notch:
   frequency: num()
   bandwidth: num(min=0.0)
   domain: enum('baseband', 'radio_frequency')
+
+caltone_options:
+  frequency: num(min=0, required=False)
+  algorithm: enum('wavelet', 'azimuth_mean', required=False)
+  block_size: num(min=2, required=False)
 
 spectral_window:
   kind: enum('Kaiser', 'Cosine', required=False)

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -283,7 +283,7 @@ notch:
 
 caltone_options:
   frequency: num(min=0, required=False)
-  algorithm: enum('wavelet', 'azimuth_mean', required=False)
+  algorithm: enum('wavelet', 'azimuth_mean', 'auto', 'disabled', required=False)
   block_size: num(min=2, required=False)
 
 spectral_window:

--- a/tests/python/packages/CMakeLists.txt
+++ b/tests/python/packages/CMakeLists.txt
@@ -22,6 +22,7 @@ isce3/io/background.py
 isce3/matchtemplate/import_ampcor.py
 isce3/matchtemplate/test_ampcor.py
 isce3/product/cf_conventions.py
+isce3/signal/cola_windows.py
 isce3/signal/doppler_est_func.py
 isce3/signal/fir_filter_func.py
 isce3/signal/rfi_freq_null.py

--- a/tests/python/packages/CMakeLists.txt
+++ b/tests/python/packages/CMakeLists.txt
@@ -10,6 +10,7 @@ isce3/core/llh.py
 isce3/core/orbit.py
 isce3/core/poly2d.py
 isce3/core/resample_block_generators.py
+isce3/focus/caltone.py
 isce3/focus/valid_regions.py
 isce3/focus/notch.py
 isce3/geocode/geocode_slc.py

--- a/tests/python/packages/isce3/focus/caltone.py
+++ b/tests/python/packages/isce3/focus/caltone.py
@@ -13,8 +13,8 @@ def test_caltone_removal():
     remover = ToneRemover(f, n)
     estimated = remover.synthesize(remover.analyze(modulated_tone))
 
-    assert all(np.abs(np.abs(estimated) - np.abs(modulated_tone)) < 0.02)
-    assert all(np.abs(np.angle(estimated * modulated_tone.conjugate())) < 0.1)
+    np.testing.assert_array_less(np.abs(np.abs(estimated) - np.abs(modulated_tone)), 0.02)
+    np.testing.assert_array_less(np.abs(np.angle(estimated * modulated_tone.conjugate())), 0.1)
 
     removed = remover.remove_tone(modulated_tone)
-    assert all(np.abs(removed) < 0.1)
+    np.testing.assert_array_less(np.abs(removed), 0.1)

--- a/tests/python/packages/isce3/focus/caltone.py
+++ b/tests/python/packages/isce3/focus/caltone.py
@@ -1,0 +1,20 @@
+import numpy as np
+from isce3.focus import ToneRemover
+
+def test_caltone_removal():
+    f = -0.45  # 5% from Nyquist
+    n = 1013  # prime for partial blocks
+    k = np.arange(n)
+    tone = np.exp(1j * 2 * np.pi * f * k)
+    # slow sinusoidal amplitude and quadratic phase
+    modulation = (1.0 + 0.5 * np.cos(2 * np.pi / n * k)) * np.exp(1j * np.pi * (k / n)**2)
+    modulated_tone = tone * modulation
+
+    remover = ToneRemover(f, n)
+    estimated = remover.synthesize(remover.analyze(modulated_tone))
+
+    assert all(np.abs(np.abs(estimated) - np.abs(modulated_tone)) < 0.02)
+    assert all(np.abs(np.angle(estimated * modulated_tone.conjugate())) < 0.1)
+
+    removed = remover.remove_tone(modulated_tone)
+    assert all(np.abs(removed) < 0.1)

--- a/tests/python/packages/isce3/signal/cola_windows.py
+++ b/tests/python/packages/isce3/signal/cola_windows.py
@@ -1,0 +1,10 @@
+import numpy as np
+import numpy.testing as npt
+from isce3.signal import cola_windows
+
+def test_cola_property():
+    n = 1013  # prime for partial windows
+    x = np.zeros(n)
+    for block, window in cola_windows(n):
+        x[block] += window
+    npt.assert_allclose(x, np.ones(n))


### PR DESCRIPTION
Currently focus.py can remove a fast-time stationary caltone using a parametric notch filter, or it can remove a slow-time stationary caltone by nulling the azimuth mean. This PR adds a the capability to remove a caltone that varies in both directions (though the fast-time variation has to be rather slow to still be considered a tone at all).

The estimator could be considered a single-scale wavelet transform, or a single-bin STFT. The estimation and removal use COLA windows to avoid block-boundary artifacts. This seems to work well for the cases I've examined so far.

Note the config file interface changes. One gotcha is that to disable caltone mitigation you have to set the parameter to "none" or "disabled" or something because `null` will get overridden by the non-null default value. I'll fix that if we end up actually needing this stuff. For now I just want to get the feature out there for testing.