### PR TITLE
Update QA v15.0.1 -> v16.0.0

### DIFF
--- a/share/nisar/defaults/focus.yaml
+++ b/share/nisar/defaults/focus.yaml
@@ -595,6 +595,17 @@ runconfig:
                     # Default: (1024, 1024)
                     tile_shape: [1024, 1024]
 
+                    # True to output one grayscale PNG+KML pair per raster image layer; these
+                    # will be generated in addition to the standard browse image PNG+KML.
+                    # The filename of each additional file will include a suffix noting
+                    # that image's frequency and polarization.
+                    # False to have the primary browse image be the only PNG+KML generated.
+                    # Note: If True, and if the input granule contains only one image,
+                    # then the additional individual PNG will be a duplicate image to the
+                    # primary browse image PNG, but with more descriptive filename.
+                    # Default: False
+                    output_individual_pngs: false
+
                 histogram:
 
                     # Step size to decimate the input array for computing

--- a/share/nisar/defaults/gcov.yaml
+++ b/share/nisar/defaults/gcov.yaml
@@ -669,6 +669,17 @@ runconfig:
                     # Default: (1024, 1024)
                     tile_shape: [1024, 1024]
 
+                    # True to output one grayscale PNG+KML pair per raster image layer; these
+                    # will be generated in addition to the standard browse image PNG+KML.
+                    # The filename of each additional file will include a suffix noting
+                    # that image's frequency and polarization.
+                    # False to have the primary browse image be the only PNG+KML generated.
+                    # Note: If True, and if the input granule contains only one image,
+                    # then the additional individual PNG will be a duplicate image to the
+                    # primary browse image PNG, but with more descriptive filename.
+                    # Default: False
+                    output_individual_pngs: false
+
                 histogram:
 
                     # Step size to decimate the input array for computing

--- a/share/nisar/defaults/gslc.yaml
+++ b/share/nisar/defaults/gslc.yaml
@@ -454,6 +454,17 @@ runconfig:
                     # Default: (1024, 1024)
                     tile_shape: [1024, 1024]
 
+                    # True to output one grayscale PNG+KML pair per raster image layer; these
+                    # will be generated in addition to the standard browse image PNG+KML.
+                    # The filename of each additional file will include a suffix noting
+                    # that image's frequency and polarization.
+                    # False to have the primary browse image be the only PNG+KML generated.
+                    # Note: If True, and if the input granule contains only one image,
+                    # then the additional individual PNG will be a duplicate image to the
+                    # primary browse image PNG, but with more descriptive filename.
+                    # Default: False
+                    output_individual_pngs: false
+
                 histogram:
 
                     # Step size to decimate the input array for computing

--- a/share/nisar/defaults/insar.yaml
+++ b/share/nisar/defaults/insar.yaml
@@ -974,21 +974,6 @@ runconfig:
 
                     browse_png:
 
-                        # The image to use as the basis for the browse image PNG. Options:
-                        # "phase" : Wrapped phase.
-                        # "hsi" : An HSI image with phase information encoded as Hue and
-                        # coherence encoded as Intensity.
-                        # Default: phase
-                        browse_image: phase
-
-                        # Only used if `browse_image` is set to "hsi".
-                        # True to perform histogram equalization on the Intensity channel
-                        # (the coherence magnitude layer) in the browse image PNG.
-                        # False to not apply the equalization.
-                        # See: https://scikit-image.org/docs/stable/auto_examples/color_exposure/plot_equalize.html
-                        # Default: False
-                        equalize_browse: false
-
                         # The maximum number of pixels allowed for the longest
                         # side of the final 2D browse image.
                         # Default: 2048
@@ -1344,21 +1329,6 @@ runconfig:
 
                     browse_png:
 
-                        # The image to use as the basis for the browse image PNG. Options:
-                        # "phase" : (Optionally re-wrapped) unwrapped phase.
-                        # "hsi" : An HSI image with phase information encoded as Hue and
-                        # coherence encoded as Intensity.
-                        # Default: phase
-                        browse_image: phase
-
-                        # Only used if `browse_image` is set to "hsi".
-                        # True to perform histogram equalization on the Intensity channel
-                        # (the coherence magnitude layer) in the browse image PNG.
-                        # False to not apply the equalization.
-                        # See: https://scikit-image.org/docs/stable/auto_examples/color_exposure/plot_equalize.html
-                        # Default: False
-                        equalize_browse: false
-
                         # The maximum number of pixels allowed for the longest
                         # side of the final 2D browse image.
                         # Default: 2048
@@ -1367,7 +1337,6 @@ runconfig:
                         # The multiple of pi to rewrap the unwrapped phase image
                         # when generating the browse PNG. If None, no rewrapping will occur.
                         # Ex: If 3 is provided, the image is rewrapped to the interval [0, 3pi).
-
                         # Default: 7
                         rewrap: 7
 
@@ -1763,21 +1732,6 @@ runconfig:
 
                     browse_png:
 
-                        # The image to use as the basis for the browse image PNG. Options:
-                        # "phase" : (Optionally re-wrapped) unwrapped phase.
-                        # "hsi" : An HSI image with phase information encoded as Hue and
-                        # coherence encoded as Intensity.
-                        # Default: phase
-                        browse_image: phase
-
-                        # Only used if `browse_image` is set to "hsi".
-                        # True to perform histogram equalization on the Intensity channel
-                        # (the coherence magnitude layer) in the browse image PNG.
-                        # False to not apply the equalization.
-                        # See: https://scikit-image.org/docs/stable/auto_examples/color_exposure/plot_equalize.html
-                        # Default: False
-                        equalize_browse: false
-
                         # The maximum number of pixels allowed for the longest
                         # side of the final 2D browse image.
                         # Default: 2048
@@ -1786,7 +1740,6 @@ runconfig:
                         # The multiple of pi to rewrap the unwrapped phase image
                         # when generating the browse PNG. If None, no rewrapping will occur.
                         # Ex: If 3 is provided, the image is rewrapped to the interval [0, 3pi).
-
                         # Default: 7
                         rewrap: 7
 

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -472,6 +472,7 @@ qa_reports_options:
     gamma: num(min=0.0, required=False)
     nan_color_in_pdf: str(required=False)
     tile_shape: list(int(min=-1), min=2, max=2, required=False)
+    output_individual_pngs: bool(required=False)
   histogram:
     decimation_ratio: list(int(min=1), min=2, max=2, required=False)
     backscatter_histogram_bin_edges_range: list(num(), min=2, max=2, required=False)

--- a/share/nisar/schemas/gcov.yaml
+++ b/share/nisar/schemas/gcov.yaml
@@ -293,6 +293,7 @@ qa_reports_options:
         gamma: num(min=0.0, required=False)
         nan_color_in_pdf: str(required=False)
         tile_shape: list(int(min=-1), min=2, max=2, required=False)
+        output_individual_pngs: bool(required=False)
     histogram:
         decimation_ratio: list(int(min=1), min=2, max=2, required=False)
         backscatter_histogram_bin_edges_range: list(num(), min=2, max=2, required=False)

--- a/share/nisar/schemas/gslc.yaml
+++ b/share/nisar/schemas/gslc.yaml
@@ -236,6 +236,7 @@ qa_reports_options:
         gamma: num(min=0.0, required=False)
         nan_color_in_pdf: str(required=False)
         tile_shape: list(int(min=-1), min=2, max=2, required=False)
+        output_individual_pngs: bool(required=False)
     histogram:
         decimation_ratio: list(int(min=1), min=2, max=2, required=False)
         backscatter_histogram_bin_edges_range: list(num(), min=2, max=2, required=False)

--- a/share/nisar/schemas/insar.yaml
+++ b/share/nisar/schemas/insar.yaml
@@ -953,13 +953,9 @@ qa_cc_options:
     max_num_cc: int(min=0.0, required=False)
 
 qa_browse_png_wrapped_options:
-    browse_image: enum('phase', 'hsi', required=False)
-    equalize_browse: bool(required=False)
     longest_side_max: int(min=1, required=False)
 
 qa_browse_png_unwrapped_options:
-    browse_image: enum('phase', 'hsi', required=False)
-    equalize_browse: bool(required=False)
     longest_side_max: int(min=1, required=False)
     rewrap: num(min=0.0, required=False)
 

--- a/tools/imagesets/oracle8conda/distrib_nisar/Dockerfile
+++ b/tools/imagesets/oracle8conda/distrib_nisar/Dockerfile
@@ -11,7 +11,7 @@ ARG GIT_OAUTH_TOKEN
 RUN cd /opt \
  && git clone https://$GIT_OAUTH_TOKEN@github-fn.jpl.nasa.gov/NISAR-ADT/SoilMoisture \
  && git clone https://github.com/isce-framework/nisarqa.git \
- && cd /opt/nisarqa && git checkout v15.0.1 && rm -rf .git \
+ && cd /opt/nisarqa && git checkout v16.0.0 && rm -rf .git \
  && cd /opt/SoilMoisture && git checkout v0.3.2 && rm -rf .git
 
 FROM $distrib_img


### PR DESCRIPTION
This PR updates QA v15.0.1 -> v16.0.0.

Highlights:
* RSLC/GSLC/GCOV: Adds ability for QA to output one grayscale PNG+KML pair per raster image layer
* RIFG/RUNW/GUNW: Removes HSI plots 
    - See: https://github.com/isce-framework/nisarqa/issues/78
* Bugfixes