### PR TITLE
Fix compilation with CUDA 13

### DIFF
--- a/cxx/isce3/cuda/except/Error.cpp
+++ b/cxx/isce3/cuda/except/Error.cpp
@@ -25,18 +25,21 @@ static const char* cufftGetErrorString(const cufftResult err) {
             return "CUFFT_INVALID_SIZE";
         case CUFFT_UNALIGNED_DATA:
             return "CUFFT_UNALIGNED_DATA";
+#if defined(CUDART_VERSION) && CUDART_VERSION < 13000
+        // Removed in CUDA 13
         case CUFFT_INCOMPLETE_PARAMETER_LIST:
             return "CUFFT_INCOMPLETE_PARAMETER_LIST";
-        case CUFFT_INVALID_DEVICE:
-            return "CUFFT_INVALID_DEVICE";
         case CUFFT_PARSE_ERROR:
             return "CUFFT_PARSE_ERROR";
+        case CUFFT_LICENSE_ERROR:
+            return "CUFFT_LICENSE_ERROR";
+#endif
+        case CUFFT_INVALID_DEVICE:
+            return "CUFFT_INVALID_DEVICE";
         case CUFFT_NO_WORKSPACE:
             return "CUFFT_NO_WORKSPACE";
         case CUFFT_NOT_IMPLEMENTED:
             return "CUFFT_NOT_IMPLEMENTED";
-        case CUFFT_LICENSE_ERROR:
-            return "CUFFT_LICENSE_ERROR";
         case CUFFT_NOT_SUPPORTED:
             return "CUFFT_NOT_SUPPORTED";
     }

--- a/cxx/isce3/cuda/matchtemplate/pycuampcor/cudaUtil.h
+++ b/cxx/isce3/cuda/matchtemplate/pycuampcor/cudaUtil.h
@@ -104,7 +104,13 @@ inline void gpuDeviceList()
     while (current_device < device_count)
     {
         checkCudaErrors(cudaGetDeviceProperties(&deviceProp, current_device));
-        if (deviceProp.computeMode == cudaComputeModeProhibited)
+        int compute_mode;
+#if defined(CUDART_VERSION) && CUDART_VERSION < 13000
+        compute_mode = deviceProp.computeMode;
+#else
+        checkCudaErrors(cudaDeviceGetAttribute(&compute_mode, cudaDevAttrComputeMode, current_device));
+#endif
+        if (compute_mode == cudaComputeModeProhibited)
         {
             fprintf(stderr, "CUDA Device [%d]: \"%s\" is not available: device is running in <Compute Mode Prohibited> \n", current_device, deviceProp.name);
         }


### PR DESCRIPTION
CUDA 13 removed some deprecated error codes, and now requires using cudaDeviceGetAttribute to access the compute mode. The changes here are guarded behind CUDART_VERSION checks to ensure that builds with previous CUDA versions function the same as before.