### PR TITLE
Slightly relax CR azimuth tolerance and allow Doppler extrapolation

### DIFF
--- a/python/packages/nisar/cal/corner_reflector.py
+++ b/python/packages/nisar/cal/corner_reflector.py
@@ -389,7 +389,7 @@ def parse_and_filter_corner_reflector_csv(
     return valid_crs
 
 
-def filter_crs_per_az_heading(crs, az_heading, az_atol=np.deg2rad(20.0)):
+def filter_crs_per_az_heading(crs, az_heading, az_atol=np.deg2rad(30.0)):
     """
     Filter corner reflectors per desired azimuth (AZ) orientation within
     a desired absolute tolerance.
@@ -400,10 +400,11 @@ def filter_crs_per_az_heading(crs, az_heading, az_atol=np.deg2rad(20.0)):
         TriangularTrihedralCornerReflector.
     az_heading : float
         Desired AZ/heading angle in radians w.r.t. geographic North.
-    az_atol : float, default=20.0 degrees
+    az_atol : float, default=pi/6 (30 degrees)
         Absolute tolerance in radians when comparing AZ of CRs with
-        `az_heading`. The default is around 0.5 * HBPW of an ideal
-        triangular trihedral CR (HPBW ~ 40 deg).
+        `az_heading`. The default is slightly larger than the half of the
+        half-power beam width (BPBW) of an ideal triangular trihedral CR
+        (HPBW ~ 40 deg).
 
     Yields
     ------

--- a/python/packages/nisar/cal/corner_reflector.py
+++ b/python/packages/nisar/cal/corner_reflector.py
@@ -403,7 +403,7 @@ def filter_crs_per_az_heading(crs, az_heading, az_atol=np.deg2rad(30.0)):
     az_atol : float, default=pi/6 (30 degrees)
         Absolute tolerance in radians when comparing AZ of CRs with
         `az_heading`. The default is slightly larger than the half of the
-        half-power beam width (BPBW) of an ideal triangular trihedral CR
+        half-power beam width (HPBW) of an ideal triangular trihedral CR
         (HPBW ~ 40 deg).
 
     Yields

--- a/python/packages/nisar/workflows/estimate_abscal_factor.py
+++ b/python/packages/nisar/workflows/estimate_abscal_factor.py
@@ -227,6 +227,9 @@ def estimate_abscal_factor(
     # that the focused data was projected onto (always zero Doppler for NISAR
     # radar-domain products).
     native_doppler = rslc.getDopplerCentroid(freq)
+    # Allow extrapolation of LUT so we can do searches whose endpoints may run
+    # out of bounds.
+    native_doppler.bounds_error = False
     image_grid_doppler = isce3.core.LUT2d()
 
     # Reference ellipsoid is assumed to be WGS 84 for corner reflector data and for


### PR DESCRIPTION
I was wondering why the QA PTA results seemed short a few CRs, and the abscal results often seemed to fail. Part of the answer is that we limit the analysis to CRs where the azimuth offset between the LOS vector and CR boresight vector is less than 20 degrees. This is generally a good idea, but several NISAR CRs are oriented roughtly North/South in order to increase compatibility with right-looking sensors and were getting filtered out. I think it's reasonable to extend the default range slightly given that the face is illuminated over ±45° and the geometric optics (GO) model we use is still valid beyond ±20° off-boresight. Here's a plot from Corona _et al_ (DOI [10.1109/MELCON.1996.551596](https://doi.org/10.1109/MELCON.1996.551596))

<img width="516" height="567" alt="Screenshot 2025-10-19 at 12 11 40 PM" src="https://github.com/user-attachments/assets/2506a482-04ce-4ce2-884f-fa740160206a" />

It'd be nice to make the tolerance configurable in all the workflows, but that can come later. It'd also be nice to report the angular offset from boresight in the QA products so that we can use that to filter results in a higher level analysis, but again we can add that later.

The other issue I found is that the abscal tool uses the Doppler LUT to find the LOS at the imaging time. This requires an iterative search, and the initial time bracket defaults to the start/end time of the LUT, which corresponds to start/end time of the observation. The problem is that the slant range at the start/end time may fall outside the LUT, causing the calculation to fail. This is easily fixed by allowing the solver to extrapolate when evaluating the Doppler LUT.