### PR TITLE
Fix interferometry baseline

### DIFF
--- a/python/packages/nisar/workflows/baseline.py
+++ b/python/packages/nisar/workflows/baseline.py
@@ -350,78 +350,78 @@ def compute_baseline(ref_rngs,
         A component of the baseline perpendicular to the los vector
         from the reference sensor position to the target.
     """
-
+    info_channel = journal.info("baseline.compute_baseline")
     proj = isce3.core.make_projection(epsg_code)
-    meta_rows, meta_cols = ref_rngs.shape
 
     # Initialize output arrays
-    par_baseline_array = np.full((meta_rows, meta_cols),
-                                 np.nan, dtype=np.float32)
-    perp_baseline_array = np.full((meta_rows, meta_cols),
-                                  np.nan, dtype=np.float32)
+    par_baseline_array = np.full(
+        ref_rngs.shape, np.nan, dtype=np.float32)
+    perp_baseline_array = np.full(
+        ref_rngs.shape, np.nan, dtype=np.float32)
 
-    for row_ind in range(meta_rows):
-        for col_ind in range(meta_cols):
-            ref_azt = ref_azts[row_ind, col_ind]
-            ref_rng = ref_rngs[row_ind, col_ind]
-            sec_azt = sec_azts[row_ind, col_ind]
-            sec_rng = sec_rngs[row_ind, col_ind]
+    for row_ind, col_ind in np.ndindex(ref_rngs.shape):
+        ref_azt = ref_azts[row_ind, col_ind]
+        ref_rng = ref_rngs[row_ind, col_ind]
+        sec_azt = sec_azts[row_ind, col_ind]
+        sec_rng = sec_rngs[row_ind, col_ind]
 
-            x = coord_set[0, row_ind, col_ind]
-            y = coord_set[1, row_ind, col_ind]
-            h = coord_set[2, row_ind, col_ind]
+        x = coord_set[0, row_ind, col_ind]
+        y = coord_set[1, row_ind, col_ind]
+        h = coord_set[2, row_ind, col_ind]
 
-            lon, lat, h = proj.inverse(np.array([x, y, h]))
-            target_xyz = ellipsoid.lon_lat_to_xyz(
-                np.array([lon, lat, h]))
+        lon, lat, h = proj.inverse(np.array([x, y, h]))
+        target_xyz = ellipsoid.lon_lat_to_xyz(
+            np.array([lon, lat, h]))
 
-            if not np.isnan(ref_azt):
-                ref_xyz, ref_vel = ref_orbit.interpolate(ref_azt)
-                # get the sensor position at the sec_aztime
-                # on the secondary orbit
-                sec_xyz, _ = sec_orbit.interpolate(sec_azt)
-    
-                los_vec = target_xyz - ref_xyz
-                los_norm = np.linalg.norm(los_vec)
-                if los_norm == 0 or not np.isfinite(los_norm):
-                    continue
-                los_unit_vec = los_vec / los_norm
-                baseline_vec = sec_xyz - ref_xyz
+        if not np.isnan(ref_azt):
+            ref_xyz, ref_vel = ref_orbit.interpolate(ref_azt)
+            # get the sensor position at the sec_aztime
+            # on the secondary orbit
+            sec_xyz, _ = sec_orbit.interpolate(sec_azt)
 
-                # Along track components
-                vnorm = np.linalg.norm(ref_vel)
-                if vnorm > 0 and np.isfinite(vnorm):
-                    vhat = ref_vel / vnorm
-                    baseline_along = float(np.dot(baseline_vec, vhat))
-                    baseline_vec_comp = baseline_vec - baseline_along * vhat
-                else:
-                    # Fallback if velocity is degenerate
-                    baseline_vec_comp = baseline_vec
+            los_vec = target_xyz - ref_xyz
+            los_norm = np.linalg.norm(los_vec)
+            if los_norm == 0 or not np.isfinite(los_norm):
+                continue
+            los_unit_vec = los_vec / los_norm
+            baseline_vec = sec_xyz - ref_xyz
 
-                # compute the baseline (magnitude of compensated vector; optional)
-                baseline = np.linalg.norm(baseline_vec_comp)
-
-                # Parallel (LOS) component using compensated baseline
-                parallel_baseline = float(np.dot(baseline_vec_comp,
-                                                 los_unit_vec))
-
-                # Perpendicular component magnitude using compensated baseline
-                perp_baseline_temp = float(
-                    np.linalg.norm(
-                        baseline_vec_comp - parallel_baseline * los_unit_vec))
-
-                # Sign using compensated baseline (right-looking positive)
-                direction = np.sign(
-                    np.dot(np.cross(ref_vel, los_unit_vec),
-                           baseline_vec_comp)) or 1.0
-                perpendicular_baseline = direction * perp_baseline_temp
-
-                perp_baseline_array[row_ind, col_ind] = perpendicular_baseline
-                par_baseline_array[row_ind, col_ind] = parallel_baseline
+            # Along track components
+            vnorm = np.linalg.norm(ref_vel)
+            if vnorm > 0 and np.isfinite(vnorm):
+                vhat = ref_vel / vnorm
+                baseline_along = float(np.dot(baseline_vec, vhat))
+                baseline_vec_comp = baseline_vec - baseline_along * vhat
             else:
-                perp_baseline_array[row_ind, col_ind] = np.nan
-                par_baseline_array[row_ind, col_ind] = np.nan
+                # Fallback if velocity is degenerate
+                baseline_vec_comp = baseline_vec
+                info_channel.log(
+                    "Reference velocity is zero or invalid; "
+                    "skipping along-track compensation."
+                )
+            # compute the baseline (magnitude of compensated vector)
+            baseline = np.linalg.norm(baseline_vec_comp)
 
+            # Parallel (LOS) component using compensated baseline
+            parallel_baseline = float(np.dot(baseline_vec_comp,
+                                             los_unit_vec))
+
+            # Perpendicular component magnitude using compensated baseline
+            perp_baseline_temp = float(
+                np.linalg.norm(
+                    baseline_vec_comp - parallel_baseline * los_unit_vec))
+
+            # Sign using compensated baseline (right-looking positive)
+            direction = np.sign(
+                np.dot(np.cross(ref_vel, los_unit_vec),
+                       baseline_vec_comp)) or 1.0
+            perpendicular_baseline = direction * perp_baseline_temp
+
+            perp_baseline_array[row_ind, col_ind] = perpendicular_baseline
+            par_baseline_array[row_ind, col_ind] = parallel_baseline
+        else:
+            perp_baseline_array[row_ind, col_ind] = np.nan
+            par_baseline_array[row_ind, col_ind] = np.nan
 
     return par_baseline_array, perp_baseline_array
 

--- a/python/packages/nisar/workflows/baseline.py
+++ b/python/packages/nisar/workflows/baseline.py
@@ -390,7 +390,7 @@ def compute_baseline(ref_rngs,
             vnorm = np.linalg.norm(ref_vel)
             if vnorm > 0 and np.isfinite(vnorm):
                 vhat = ref_vel / vnorm
-                baseline_along = float(np.dot(baseline_vec, vhat))
+                baseline_along = np.dot(baseline_vec, vhat)
                 baseline_vec_comp = baseline_vec - baseline_along * vhat
             else:
                 # Fallback if velocity is degenerate
@@ -403,13 +403,12 @@ def compute_baseline(ref_rngs,
             baseline = np.linalg.norm(baseline_vec_comp)
 
             # Parallel (LOS) component using compensated baseline
-            parallel_baseline = float(np.dot(baseline_vec_comp,
-                                             los_unit_vec))
+            parallel_baseline = np.dot(baseline_vec_comp,
+                                       los_unit_vec)
 
             # Perpendicular component magnitude using compensated baseline
-            perp_baseline_temp = float(
-                np.linalg.norm(
-                    baseline_vec_comp - parallel_baseline * los_unit_vec))
+            perp_baseline_temp = np.linalg.norm(
+                    baseline_vec_comp - parallel_baseline * los_unit_vec)
 
             # Sign using compensated baseline (right-looking positive)
             direction = np.sign(

--- a/python/packages/nisar/workflows/baseline.py
+++ b/python/packages/nisar/workflows/baseline.py
@@ -357,6 +357,8 @@ def compute_baseline(ref_rngs,
     # Initialize output arrays
     perp_baseline_array = np.zeros([meta_rows, meta_cols])
     par_baseline_array = np.zeros([meta_rows, meta_cols])
+    target_xyz = np.empty((meta_rows, meta_cols, 3),
+                          dtype=np.float64)
 
     for row_ind in range(meta_rows):
         for col_ind in range(meta_cols):
@@ -364,13 +366,14 @@ def compute_baseline(ref_rngs,
             ref_rng = ref_rngs[row_ind, col_ind]
             sec_azt = sec_azts[row_ind, col_ind]
             sec_rng = sec_rngs[row_ind, col_ind]
-            target_proj = np.array([coord_set[0, row_ind, col_ind],
-                                    coord_set[1, row_ind, col_ind],
-                                    coord_set[2, row_ind, col_ind]])
 
-            target_llh = proj.inverse(target_proj)
+            x = coord_set[0, row_ind, col_ind]
+            y = coord_set[1, row_ind, col_ind]
+            h = coord_set[2, row_ind, col_ind]
 
-            target_xyz = ellipsoid.lon_lat_to_xyz(target_llh)
+            lon, lat, h = proj.inverse(np.array([x, y, h]))
+            target_xyz[row_ind, col_ind, :] = ellipsoid.lon_lat_to_xyz(
+                np.array([lon, lat, h]))
 
             if not np.isnan(ref_azt):
                 ref_xyz, ref_vel = ref_orbit.interpolate(ref_azt)
@@ -378,34 +381,25 @@ def compute_baseline(ref_rngs,
                 # on the secondary orbit
                 sec_xyz, _ = sec_orbit.interpolate(sec_azt)
 
+                los_vec = target_xyz[row_ind, col_ind, :] - ref_xyz
+                los_norm = np.linalg.norm(los_vec)
+                if los_norm == 0 or not np.isfinite(los_norm):
+                    continue
+                los_unit_vec = los_vec / los_norm
+                baseline_vec = sec_xyz - ref_xyz
+
                 # compute the baseline
-                baseline = np.linalg.norm(sec_xyz - ref_xyz)
+                baseline = np.linalg.norm(baseline_vec)
+                print('baseline', baseline)
+                parallel_baseline = float(np.dot(baseline_vec, los_unit_vec))
+                perp_baseline_temp = float(
+                    np.linalg.norm(
+                        baseline_vec - parallel_baseline * los_unit_vec))
 
-                # compute the cosine of the angle between the baseline vector
-                # and the reference LOS vector (reference sensor to target)
-                if baseline == 0:
-                    cos_vbase_los = 1
-                else:
-                    cos_vbase_los = (ref_rng ** 2 + baseline ** 2
-                                     - sec_rng ** 2) / (
-                                    2.0 * ref_rng * baseline)
-
-                # project the baseline to LOS to get the parallel component
-                # of the baseline (i.e., parallel to the LOS direction)
-                # parallel baseline in reference LOS direction is positive
-                parallel_baseline = baseline * cos_vbase_los
-
-                # project the baseline to the normal to
-                # the reference LOS direction
-                perp_baseline_temp = baseline * np.sqrt(1 - cos_vbase_los ** 2)
-
-                # get the direction sign of the perpendicular baseline.
-                # positive perpendicular baseline is defined
-                # at below to LOS vector
                 direction = np.sign(
-                    np.dot(np.cross(target_xyz - ref_xyz,
-                                    sec_xyz - ref_xyz),
-                           ref_vel))
+                    np.dot(np.cross(ref_vel,
+                                    los_unit_vec),
+                           baseline_vec)) or 1.0
                 perpendicular_baseline = direction * perp_baseline_temp
 
                 perp_baseline_array[row_ind, col_ind] = perpendicular_baseline

--- a/python/packages/nisar/workflows/baseline.py
+++ b/python/packages/nisar/workflows/baseline.py
@@ -359,8 +359,6 @@ def compute_baseline(ref_rngs,
                                  np.nan, dtype=np.float32)
     perp_baseline_array = np.full((meta_rows, meta_cols),
                                   np.nan, dtype=np.float32)
-    target_xyz = np.empty((meta_rows, meta_cols, 3),
-                          dtype=np.float64)
 
     for row_ind in range(meta_rows):
         for col_ind in range(meta_cols):
@@ -374,7 +372,7 @@ def compute_baseline(ref_rngs,
             h = coord_set[2, row_ind, col_ind]
 
             lon, lat, h = proj.inverse(np.array([x, y, h]))
-            target_xyz[row_ind, col_ind, :] = ellipsoid.lon_lat_to_xyz(
+            target_xyz = ellipsoid.lon_lat_to_xyz(
                 np.array([lon, lat, h]))
 
             if not np.isnan(ref_azt):
@@ -382,8 +380,8 @@ def compute_baseline(ref_rngs,
                 # get the sensor position at the sec_aztime
                 # on the secondary orbit
                 sec_xyz, _ = sec_orbit.interpolate(sec_azt)
-
-                los_vec = target_xyz[row_ind, col_ind, :] - ref_xyz
+    
+                los_vec = target_xyz - ref_xyz
                 los_norm = np.linalg.norm(los_vec)
                 if los_norm == 0 or not np.isfinite(los_norm):
                     continue

--- a/python/packages/nisar/workflows/baseline.py
+++ b/python/packages/nisar/workflows/baseline.py
@@ -355,8 +355,10 @@ def compute_baseline(ref_rngs,
     meta_rows, meta_cols = ref_rngs.shape
 
     # Initialize output arrays
-    perp_baseline_array = np.zeros([meta_rows, meta_cols])
-    par_baseline_array = np.zeros([meta_rows, meta_cols])
+    par_baseline_array = np.full((meta_rows, meta_cols),
+                                 np.nan, dtype=np.float32)
+    perp_baseline_array = np.full((meta_rows, meta_cols),
+                                  np.nan, dtype=np.float32)
     target_xyz = np.empty((meta_rows, meta_cols, 3),
                           dtype=np.float64)
 
@@ -390,7 +392,6 @@ def compute_baseline(ref_rngs,
 
                 # compute the baseline
                 baseline = np.linalg.norm(baseline_vec)
-                print('baseline', baseline)
                 parallel_baseline = float(np.dot(baseline_vec, los_unit_vec))
                 perp_baseline_temp = float(
                     np.linalg.norm(

--- a/python/packages/nisar/workflows/baseline.py
+++ b/python/packages/nisar/workflows/baseline.py
@@ -388,17 +388,32 @@ def compute_baseline(ref_rngs,
                 los_unit_vec = los_vec / los_norm
                 baseline_vec = sec_xyz - ref_xyz
 
-                # compute the baseline
-                baseline = np.linalg.norm(baseline_vec)
-                parallel_baseline = float(np.dot(baseline_vec, los_unit_vec))
+                # Along track components
+                vnorm = np.linalg.norm(ref_vel)
+                if vnorm > 0 and np.isfinite(vnorm):
+                    vhat = ref_vel / vnorm
+                    baseline_along = float(np.dot(baseline_vec, vhat))
+                    baseline_vec_comp = baseline_vec - baseline_along * vhat
+                else:
+                    # Fallback if velocity is degenerate
+                    baseline_vec_comp = baseline_vec
+
+                # compute the baseline (magnitude of compensated vector; optional)
+                baseline = np.linalg.norm(baseline_vec_comp)
+
+                # Parallel (LOS) component using compensated baseline
+                parallel_baseline = float(np.dot(baseline_vec_comp,
+                                                 los_unit_vec))
+
+                # Perpendicular component magnitude using compensated baseline
                 perp_baseline_temp = float(
                     np.linalg.norm(
-                        baseline_vec - parallel_baseline * los_unit_vec))
+                        baseline_vec_comp - parallel_baseline * los_unit_vec))
 
+                # Sign using compensated baseline (right-looking positive)
                 direction = np.sign(
-                    np.dot(np.cross(ref_vel,
-                                    los_unit_vec),
-                           baseline_vec)) or 1.0
+                    np.dot(np.cross(ref_vel, los_unit_vec),
+                           baseline_vec_comp)) or 1.0
                 perpendicular_baseline = direction * perp_baseline_temp
 
                 perp_baseline_array[row_ind, col_ind] = perpendicular_baseline
@@ -406,6 +421,7 @@ def compute_baseline(ref_rngs,
             else:
                 perp_baseline_array[row_ind, col_ind] = np.nan
                 par_baseline_array[row_ind, col_ind] = np.nan
+
 
     return par_baseline_array, perp_baseline_array
 


### PR DESCRIPTION
This PR addresses the issue in the baseline. 

From the real NISAR interferometric pair, we found that the estimated baseline was higher than the expected. (expected : 117m, estimated :~ 2 km). The PR introduces the along-track baseline and compensate it while computing the perp and parallel baselines. 

From this PR, the estimated baseline is close to the expected and confirmed with real NISAR data. 
The PR was copied from internal [PR](https://github-fn.jpl.nasa.gov/isce-3/isce/pull/1930) with some modifications.