### PR TITLE
Fix the decimating offset for frequency B interferogram

### DIFF
--- a/python/packages/isce3/signal/interpolate_by_range.py
+++ b/python/packages/isce3/signal/interpolate_by_range.py
@@ -59,19 +59,13 @@ def decimate_freq_a_array(
     left_missing = min(left_missing, total_missing)
     right_missing = min(right_missing, total_missing - left_missing)
 
-    if left_missing > 0:
-        pad_left = np.zeros(
-            (decimated_array.shape[0], left_missing),
-            dtype=decimated_array.dtype
+    if left_missing > 0 or right_missing > 0:
+        decimated_array = np.pad(
+            decimated_array,
+            pad_width=((0, 0), (left_missing, right_missing)),
+            mode="constant",
+            constant_values=0,
         )
-        decimated_array = np.concatenate([pad_left, decimated_array], axis=1)
-
-    if right_missing > 0:
-        pad_right = np.zeros(
-            (decimated_array.shape[0], right_missing),
-            dtype=decimated_array.dtype
-        )
-        decimated_array = np.concatenate([decimated_array, pad_right], axis=1)
 
     return decimated_array
 

--- a/python/packages/isce3/signal/interpolate_by_range.py
+++ b/python/packages/isce3/signal/interpolate_by_range.py
@@ -30,16 +30,17 @@ def decimate_freq_a_array(
     spacing_side = slant_side[1] - slant_side[0]
 
     # make sure stride is at least 1
-    resampling_scale_factor = max(1,
-                                  int(np.round(spacing_side / spacing_main)))
+    resampling_scale_factor = max(
+        1, int(np.round(spacing_side / spacing_main))
+    )
 
     n_side = len(slant_side)
 
     # slice whatever overlaps (no shifting); then pad left/right as needed
     end_excl = min(width, first_index + n_side * resampling_scale_factor)
-    decimated_array = target_runw[:,
-                                  first_index:end_excl:resampling_scale_factor]
-
+    decimated_array = target_runw[
+        :, first_index:end_excl:resampling_scale_factor
+    ]
     # how many side samples fall outside main on each side?
     # (assumes increasing slant arrays)
     left_missing = int(

--- a/python/packages/isce3/signal/interpolate_by_range.py
+++ b/python/packages/isce3/signal/interpolate_by_range.py
@@ -1,26 +1,27 @@
 import numpy as np
 
+
 def decimate_freq_a_array(
         slant_main,
         slant_side,
         target_runw):
-    """decimate target_runw of main band to have same size with side band
-    assuming slant_main and slant_side are evenly spaced
+    """Decimate target_runw of main band to have same size as side band,
+    assuming slant_main and slant_side are evenly spaced.
 
     Parameters
     ----------
     slant_main : numpy.ndarray
-        slant range array of frequency A band
+        Slant range array of frequency A band
     slant_side : numpy.ndarray
-        slant range array of frequency B band
+        Slant range array of frequency B band
     target_runw : numpy.ndarray
-        RUNW array of frequency A band
-        width of target_runw should be same with length of slant_main
+        RUNW array of frequency A band.
+        Width of target_runw should be same as length of slant_main.
 
     Returns
     -------
     decimated_array : numpy.ndarray
-        decimated RUNW array
+        Decimated RUNW array with width == len(slant_side).
     """
     _, width = target_runw.shape
 
@@ -28,16 +29,51 @@ def decimate_freq_a_array(
     spacing_main = slant_main[1] - slant_main[0]
     spacing_side = slant_side[1] - slant_side[0]
 
-    resampling_scale_factor = int(np.round(spacing_side / spacing_main))
+    # make sure stride is at least 1
+    resampling_scale_factor = max(1,
+                                  int(np.round(spacing_side / spacing_main)))
 
-    x_cand = np.arange(1, width + 1)
+    n_side = len(slant_side)
 
-    # find the maximum of the multiple of resampling_scale_factor
-    decimate_width_end = np.max(x_cand[x_cand % resampling_scale_factor == 0])
-    decimated_array = target_runw[
-        :, first_index:decimate_width_end:resampling_scale_factor]
+    # slice whatever overlaps (no shifting); then pad left/right as needed
+    end_excl = min(width, first_index + n_side * resampling_scale_factor)
+    decimated_array = target_runw[:,
+                                  first_index:end_excl:resampling_scale_factor]
+
+    # how many side samples fall outside main on each side?
+    # (assumes increasing slant arrays)
+    left_missing = int(
+        np.ceil(
+            max(0.0, (slant_main[0] - slant_side[0]) / spacing_side)
+        )
+    )
+    right_missing = int(
+        np.ceil(
+            max(0.0, (slant_side[-1] - slant_main[-1]) / spacing_side)
+        )
+    )
+
+    # clamp in case both sides miss (very long slant_side)
+    total_missing = max(0, n_side - decimated_array.shape[1])
+    left_missing = min(left_missing, total_missing)
+    right_missing = min(right_missing, total_missing - left_missing)
+
+    if left_missing > 0:
+        pad_left = np.zeros(
+            (decimated_array.shape[0], left_missing),
+            dtype=decimated_array.dtype
+        )
+        decimated_array = np.concatenate([pad_left, decimated_array], axis=1)
+
+    if right_missing > 0:
+        pad_right = np.zeros(
+            (decimated_array.shape[0], right_missing),
+            dtype=decimated_array.dtype
+        )
+        decimated_array = np.concatenate([decimated_array, pad_right], axis=1)
 
     return decimated_array
+
 
 def interpolate_freq_b_array(
         slant_main,

--- a/python/packages/nisar/workflows/ionosphere.py
+++ b/python/packages/nisar/workflows/ionosphere.py
@@ -168,7 +168,7 @@ def decimate_freq_a_offset(iono_insar_cfg, original_dict):
         resample_type = 'coarse'
     decimated_offset_dir = offsets_dir
 
-    # Instantiate a RSLC object to get slant range for frequency A and B
+    # Instantiate a RSLC Swath object to get slant range for frequency A and B
     slc_swath_obj_freqa = isce3.product.Swath(ref_slc_path, 'A')
     slc_swath_obj_freqb = isce3.product.Swath(ref_slc_path, 'B')
 

--- a/python/packages/nisar/workflows/ionosphere.py
+++ b/python/packages/nisar/workflows/ionosphere.py
@@ -155,51 +155,27 @@ def decimate_freq_a_offset(iono_insar_cfg, original_dict):
         - output_runw
         - offsets_dir
     """
-    # InSAR scratch path
-    scratch_path = pathlib.Path(original_dict['scratch_path'])
-    # ionosphere scratch path
-    iono_dir_path = pathlib.Path(iono_insar_cfg['product_path_group'][
-                'scratch_path'])
     # parameters
     blocksize = iono_insar_cfg['processing']['ionosphere_phase_correction'][
                 'lines_per_block']
-    freq_pols = iono_insar_cfg['processing']['input_subset'][
-                'list_of_frequencies']
-    runw_freq_a_str = original_dict['output_runw']
-    runw_freq_b_str = iono_insar_cfg['product_path_group']['sas_output_file']
+
     offsets_dir = original_dict['offsets_dir']
 
+    ref_slc_path = original_dict['reference_rslc_file']
     if iono_insar_cfg['processing']['fine_resample']['enabled']:
         resample_type = 'fine'
     else:
         resample_type = 'coarse'
     decimated_offset_dir = offsets_dir
 
-    # Instantiate a RUNW object to get path to RUNW datasets
-    runw_obj = RUNWGroupsPaths()
+    # Instantiate a RSLC object to get slant range for frequency A and B
+    slc_swath_obj_freqa = isce3.product.Swath(ref_slc_path, 'A')
+    slc_swath_obj_freqb = isce3.product.Swath(ref_slc_path, 'B')
 
-    # Set up for decimation
-    swath_path = runw_obj.SwathsPath
-    dest_freq_path = f"{swath_path}/frequencyA"
-    dest_freq_path_b = f"{swath_path}/frequencyB"
-    rslant_path_a = f"{dest_freq_path}/interferogram/slantRange"
-    rslant_path_b = f"{dest_freq_path_b}/interferogram/slantRange"
-    rspc_path_a = f"{dest_freq_path}/interferogram/slantRangeSpacing"
-    rspc_path_b = f"{dest_freq_path_b}/interferogram/slantRangeSpacing"
-
-    # Read slant range array from main and side bands
-    with HDF5OptimizedReader(
-            name=runw_freq_a_str, mode='r',
-            libver='latest', swmr=True) as src_main_h5, \
-        HDF5OptimizedReader(
-            name=runw_freq_b_str, mode='r',
-            libver='latest', swmr=True) as src_side_h5:
-
-        # Read slant range block from HDF5
-        main_slant = np.array(src_main_h5[rslant_path_a])
-        side_slant = np.array(src_side_h5[rslant_path_b])
-        spacing_main = np.array(src_main_h5[rspc_path_a])
-        spacing_side = np.array(src_side_h5[rspc_path_b])
+    main_slant = np.array(slc_swath_obj_freqa.slant_range)
+    spacing_main = slc_swath_obj_freqa.range_pixel_spacing
+    side_slant = np.array(slc_swath_obj_freqb.slant_range)
+    spacing_side = slc_swath_obj_freqb.range_pixel_spacing
 
     resampling_scale_factor = float(int(np.round(spacing_side / spacing_main)))
     if resample_type == 'coarse':


### PR DESCRIPTION
**Summary**
This PR fixes an issue in decimating the offset used to generate the frequency-\ B interferogram.

**Details**
The frequency B interferogram, which is required for ionospheric estimation, was previously generated from a decimated offset computed using the RUNW slant ranges of frequencies A and B.
However, because the RUNW product is multi-looked, its slant range array is shorter than that of the RSLC. This mismatch caused errors in the decimation process, leading to incorrect ionospheric estimates.

**Fix**
Instead of using the slant ranges from the RUNW product, this PR now reads the slant ranges directly from the RSLC, ensuring proper alignment and accurate ionospheric estimation. 
