### PR TITLE
Bugfix: Make each subgroup independently optional in QA schemas

### DIFF
--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -474,30 +474,38 @@ qa_validation_options:
   metadata_luts_fail_if_all_nan: bool(required=False)
 
 qa_reports_options:
-  backscatter_img:
-    linear_units: bool(required=False)
-    nlooks_freqa: list(int(min=1), min=2, max=2, required=False)
-    nlooks_freqb: list(int(min=1), min=2, max=2, required=False)
-    longest_side_max: int(min=1, required=False)
-    percentile_for_clipping: list(num(min=0.0, max=100.0), min=2, max=2, required=False)
-    gamma: num(min=0.0, required=False)
-    nan_color_in_pdf: str(required=False)
-    tile_shape: list(int(min=-1), min=2, max=2, required=False)
-    output_individual_pngs: bool(required=False)
-  histogram:
-    decimation_ratio: list(int(min=1), min=2, max=2, required=False)
-    backscatter_histogram_bin_edges_range: list(num(), min=2, max=2, required=False)
-    phase_histogram_y_axis_range: list(any(num(), null()), min=2, max=2, required=False)
-    phs_in_radians: bool(required=False)
-    tile_shape: list(int(min=-1), min=2, max=2, required=False)
-  range_spectra:
-    az_decimation: int(min=1, required=False)
-    hz_to_mhz: bool(required=False)
-    tile_height: int(min=-1, required=False)
-  azimuth_spectra:
-    num_columns: int(min=-1, required=False)
-    hz_to_mhz: bool(required=False)
-    tile_width: int(min=-1, required=False)
+  backscatter_img: include('backscatter_img_options', required=False)
+  histogram: include('histogram_options', required=False)
+  range_spectra: include('range_spectra_options', required=False)
+  azimuth_spectra: include('azimuth_spectra_options', required=False)
+
+backscatter_img_options:
+  linear_units: bool(required=False)
+  nlooks_freqa: list(int(min=1), min=2, max=2, required=False)
+  nlooks_freqb: list(int(min=1), min=2, max=2, required=False)
+  longest_side_max: int(min=1, required=False)
+  percentile_for_clipping: list(num(min=0.0, max=100.0), min=2, max=2, required=False)
+  gamma: num(min=0.0, required=False)
+  nan_color_in_pdf: str(required=False)
+  tile_shape: list(int(min=-1), min=2, max=2, required=False)
+  output_individual_pngs: bool(required=False)
+
+histogram_options:
+  decimation_ratio: list(int(min=1), min=2, max=2, required=False)
+  backscatter_histogram_bin_edges_range: list(num(), min=2, max=2, required=False)
+  phase_histogram_y_axis_range: list(any(num(), null()), min=2, max=2, required=False)
+  phs_in_radians: bool(required=False)
+  tile_shape: list(int(min=-1), min=2, max=2, required=False)
+
+range_spectra_options:
+  az_decimation: int(min=1, required=False)
+  hz_to_mhz: bool(required=False)
+  tile_height: int(min=-1, required=False)
+
+azimuth_spectra_options:
+  num_columns: int(min=-1, required=False)
+  hz_to_mhz: bool(required=False)
+  tile_width: int(min=-1, required=False)
 
 absolute_radiometric_calibration_options:
   nchip: int(min=1, required=False)

--- a/share/nisar/schemas/gcov.yaml
+++ b/share/nisar/schemas/gcov.yaml
@@ -284,22 +284,26 @@ qa_validation_options:
     metadata_luts_fail_if_all_nan: bool(required=False)
 
 qa_reports_options:
-    backscatter_img:
-        linear_units: bool(required=False)
-        nlooks_freqa: list(int(min=1), min=2, max=2, required=False)
-        nlooks_freqb: list(int(min=1), min=2, max=2, required=False)
-        longest_side_max: int(min=1, required=False)
-        percentile_for_clipping: list(num(min=0.0, max=100.0), min=2, max=2, required=False)
-        gamma: num(min=0.0, required=False)
-        nan_color_in_pdf: str(required=False)
-        tile_shape: list(int(min=-1), min=2, max=2, required=False)
-        output_individual_pngs: bool(required=False)
-    histogram:
-        decimation_ratio: list(int(min=1), min=2, max=2, required=False)
-        backscatter_histogram_bin_edges_range: list(num(), min=2, max=2, required=False)
-        phase_histogram_y_axis_range: list(any(num(), null()), min=2, max=2, required=False)
-        phs_in_radians: bool(required=False)
-        tile_shape: list(int(min=-1), min=2, max=2, required=False)
+    backscatter_img: include('backscatter_img_options', required=False)
+    histogram: include('histogram_options', required=False)
+
+backscatter_img_options:
+    linear_units: bool(required=False)
+    nlooks_freqa: list(int(min=1), min=2, max=2, required=False)
+    nlooks_freqb: list(int(min=1), min=2, max=2, required=False)
+    longest_side_max: int(min=1, required=False)
+    percentile_for_clipping: list(num(min=0.0, max=100.0), min=2, max=2, required=False)
+    gamma: num(min=0.0, required=False)
+    nan_color_in_pdf: str(required=False)
+    tile_shape: list(int(min=-1), min=2, max=2, required=False)
+    output_individual_pngs: bool(required=False)
+
+histogram_options:
+    decimation_ratio: list(int(min=1), min=2, max=2, required=False)
+    backscatter_histogram_bin_edges_range: list(num(), min=2, max=2, required=False)
+    phase_histogram_y_axis_range: list(any(num(), null()), min=2, max=2, required=False)
+    phs_in_radians: bool(required=False)
+    tile_shape: list(int(min=-1), min=2, max=2, required=False)
 
 log_nfo:
     # Path to log file

--- a/share/nisar/schemas/gslc.yaml
+++ b/share/nisar/schemas/gslc.yaml
@@ -227,22 +227,26 @@ qa_validation_options:
     metadata_luts_fail_if_all_nan: bool(required=False)
 
 qa_reports_options:
-    backscatter_img:
-        linear_units: bool(required=False)
-        nlooks_freqa: list(int(min=1), min=2, max=2, required=False)
-        nlooks_freqb: list(int(min=1), min=2, max=2, required=False)
-        longest_side_max: int(min=1, required=False)
-        percentile_for_clipping: list(num(min=0.0, max=100.0), min=2, max=2, required=False)
-        gamma: num(min=0.0, required=False)
-        nan_color_in_pdf: str(required=False)
-        tile_shape: list(int(min=-1), min=2, max=2, required=False)
-        output_individual_pngs: bool(required=False)
-    histogram:
-        decimation_ratio: list(int(min=1), min=2, max=2, required=False)
-        backscatter_histogram_bin_edges_range: list(num(), min=2, max=2, required=False)
-        phase_histogram_y_axis_range: list(any(num(), null()), min=2, max=2, required=False)
-        phs_in_radians: bool(required=False)
-        tile_shape: list(int(min=-1), min=2, max=2, required=False)
+    backscatter_img: include('backscatter_img_options', required=False)
+    histogram: include('histogram_options', required=False)
+
+backscatter_img_options:
+    linear_units: bool(required=False)
+    nlooks_freqa: list(int(min=1), min=2, max=2, required=False)
+    nlooks_freqb: list(int(min=1), min=2, max=2, required=False)
+    longest_side_max: int(min=1, required=False)
+    percentile_for_clipping: list(num(min=0.0, max=100.0), min=2, max=2, required=False)
+    gamma: num(min=0.0, required=False)
+    nan_color_in_pdf: str(required=False)
+    tile_shape: list(int(min=-1), min=2, max=2, required=False)
+    output_individual_pngs: bool(required=False)
+
+histogram_options:
+    decimation_ratio: list(int(min=1), min=2, max=2, required=False)
+    backscatter_histogram_bin_edges_range: list(num(), min=2, max=2, required=False)
+    phase_histogram_y_axis_range: list(any(num(), null()), min=2, max=2, required=False)
+    phs_in_radians: bool(required=False)
+    tile_shape: list(int(min=-1), min=2, max=2, required=False)
 
 point_target_analyzer_options:
     nchip: int(min=1, required=False)


### PR DESCRIPTION
In PGE, for parameters under the `qa > qa_reports` subgroup, if a user updates only one parameter (e.g. `qa > qa_reports > backscatter_img > output_individual_pngs = true`), then PGE's schema validator throws this error:

```
File “/opt/conda/lib/python3.12/site-packages/yamale/yamale.py”, line 45, in validate
  raise YamaleError(results)
yamale.yamale_error.YamaleError: Error validating data ‘/pge/run/runconfig_rslc_ref.yaml’ with schema ‘/opt/pge/l1_l2/rslc_runconfig_schema.yaml’
	[runconfig.groups.qa.qa](http://runconfig.groups.qa.qa/)_reports.histogram: Required field missing
	[runconfig.groups.qa.qa](http://runconfig.groups.qa.qa/)_reports.range_spectra: Required field missing
	[runconfig.groups.qa.qa](http://runconfig.groups.qa.qa/)_reports.azimuth_spectra: Required field missing
```

This PR resolves that issue by breaking each sub-subgroup into it's own optional section. (It makes more sense if one reviews the code. ;) ).