### PR TITLE
Bugfix: Update RSLC schema parameter from `block_size` to `wavelet_size`

### DIFF
--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -284,7 +284,7 @@ notch:
 caltone_options:
   frequency: num(min=0, required=False)
   algorithm: enum('wavelet', 'azimuth_mean', 'auto', 'disabled', required=False)
-  block_size: num(min=2, required=False)
+  wavelet_size: num(min=2, required=False)
 
 spectral_window:
   kind: enum('Kaiser', 'Cosine', required=False)


### PR DESCRIPTION
This closes #186 .

Per offline discussion with @bhawkins , the focus.py workflows expects a parameter named "wavelet_size".