### PR TITLE
Modify the RSLC processing information to record the L0B granule id

### DIFF
--- a/.mm/isce3.cxx.tests
+++ b/.mm/isce3.cxx.tests
@@ -4,7 +4,7 @@
 # the C++ tests
 isce3.cxx.tests.stem := cxx/isce3
 isce3.cxx.tests.prerequisites := isce3.lib
-isce3.cxx.tests.extern := isce3.lib gdal hdf5 mpi eigen fftw pyre gtest
+isce3.cxx.tests.extern := isce3.lib gdal hdf5 eigen fftw pyre gtest
 
 #if there is cuda
 ifdef cuda.dir

--- a/.mm/isce3.ext
+++ b/.mm/isce3.ext
@@ -7,7 +7,7 @@ isce3.ext.stem := isce3
 isce3.ext.pkg := isce3.pkg
 isce3.ext.wraps := isce3.lib
 isce3.ext.capsule :=
-isce3.ext.extern := gdal hdf5 mpi eigen fftw pyre pybind11 python
+isce3.ext.extern := gdal hdf5 eigen fftw pyre pybind11 python
 
 # if there is cuda
 ifdef cuda.dir

--- a/.mm/isce3.lib
+++ b/.mm/isce3.lib
@@ -4,7 +4,7 @@
 # the isce3 lib
 isce3.lib.root := cxx/isce3/
 isce3.lib.stem := isce3
-isce3.lib.extern := gdal hdf5 mpi eigen fftw pyre
+isce3.lib.extern := gdal hdf5 eigen fftw pyre
 # if we have cuda
 ifdef cuda.dir
   # add it to the pile of external dependencies

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1397,7 +1397,7 @@ def set_input_file_metadata(cfg: Struct, slc: SLC, runconfig_path: str = ""):
     anc = cfg.dynamic_ancillary_file_group
     value_or_blank = lambda x: x if x is not None else ""
     slc.set_inputs(
-        l0bGranules=pthlib.PurePath(cfg.input_file_group.input_file_path).name,
+        l0bGranules=pathlib.PurePath(cfg.input_file_group.input_file_path).name,
         orbitFiles=[value_or_blank(anc.orbit)],
         attitudeFiles=[value_or_blank(anc.pointing)],
         auxcalFiles=[value_or_blank(x) for x in (anc.external_calibration,

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1397,7 +1397,7 @@ def set_input_file_metadata(cfg: Struct, slc: SLC, runconfig_path: str = ""):
     anc = cfg.dynamic_ancillary_file_group
     value_or_blank = lambda x: x if x is not None else ""
     slc.set_inputs(
-        l0bGranules=pathlib.PurePath(cfg.input_file_group.input_file_path).name,
+        l0bGranules=[pathlib.PosixPath(f).name for f in cfg.input_file_group.input_file_path],
         orbitFiles=[value_or_blank(anc.orbit)],
         attitudeFiles=[value_or_blank(anc.pointing)],
         auxcalFiles=[value_or_blank(x) for x in (anc.external_calibration,

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -41,6 +41,7 @@ import tempfile
 from typing import Union, Optional, Callable, Iterable, overload
 from isce3.io import Raster as RasterIO
 from io import StringIO
+import pathlib
 
 
 # TODO some CSV logger
@@ -1396,7 +1397,7 @@ def set_input_file_metadata(cfg: Struct, slc: SLC, runconfig_path: str = ""):
     anc = cfg.dynamic_ancillary_file_group
     value_or_blank = lambda x: x if x is not None else ""
     slc.set_inputs(
-        l0bGranules=cfg.input_file_group.input_file_path,
+        l0bGranules=pthlib.PurePath(cfg.input_file_group.input_file_path).name,
         orbitFiles=[value_or_blank(anc.orbit)],
         attitudeFiles=[value_or_blank(anc.pointing)],
         auxcalFiles=[value_or_blank(x) for x in (anc.external_calibration,


### PR DESCRIPTION
The contents `science.LSAR.RSLC.metadata.processingInformation.inputs.l0bGranules` now reflect the granule id of the L0B that was focused, rather than the path to the input file in the processing system