### PR TITLE
Update RSLC descriptions

### DIFF
--- a/python/packages/nisar/products/writers/SLC.py
+++ b/python/packages/nisar/products/writers/SLC.py
@@ -247,8 +247,8 @@ def require_lut_axes(group, epoch, t, r, kind):
         t = group[name][:]
     else:
         write_dataset(group, name, np.float64, t,
-            "Zero Doppler time since UTC epoch dimension "
-            "corresponding to " + kind, time_units(epoch))
+            "Vector of zero Doppler azimuth times, measured relative to a "
+            "UTC epoch, corresponding to " + kind, time_units(epoch))
 
     name = "slantRange"
     if name in group:

--- a/python/packages/nisar/products/writers/SLC.py
+++ b/python/packages/nisar/products/writers/SLC.py
@@ -391,8 +391,8 @@ class SLC(h5py.File):
         dset_name = "rangeChirpWeighting"
         if dset_name not in group:
             dset = write_dataset(group, dset_name, np.float32, values,
-                "1-D array in frequency domain for range processing. This is "
-                "used for processing L0b to L1. FFT length=256 (assumed)",
+                "1D array in frequency domain for range processing. This is "
+                "used for processing L0B to L1. FFT length=256 (assumed)",
                 units="1")
             dset.attrs["window_name"] = np.bytes_(window_name)
             dset.attrs["window_shape"] = window_shape
@@ -480,14 +480,14 @@ class SLC(h5py.File):
         name = "azimuthChirpWeighting"
         if name not in g:
             write_dataset(g, name, np.float32, azimuth_envelope,
-                "1-D array in frequency domain for azimuth processing. This is "
-                "used for processing L0b to L1. FFT length=256 (assumed)",
+                "1D array in frequency domain for azimuth processing. This is "
+                "used for processing L0B to L1. FFT length=256 (assumed)",
                 units="1")
         # TODO ref height
         if "referenceTerrainHeight" not in g:
             n = dop.data.shape[0]
             write_dataset(g, "referenceTerrainHeight", np.float32, np.zeros(n),
-                "Reference Terrain Height as a function of time", "meters")
+                "Reference terrain height as a function of time", "meters")
 
         t = dop.y_start + dop.y_spacing * np.arange(dop.data.shape[0])
         r = dop.x_start + dop.x_spacing * np.arange(dop.data.shape[1])
@@ -568,7 +568,8 @@ class SLC(h5py.File):
         d = g.parent.require_dataset("zeroDopplerTime", t.shape, t.dtype, data=t)
         d.attrs["units"] = np.bytes_(time_units(epoch))
         d.attrs["description"] = np.bytes_(
-            "Zero Doppler time since UTC epoch dimension")
+            "Vector of zero Doppler azimuth times measured relative "
+            "to a UTC epoch")
 
         d = g.parent.require_dataset("zeroDopplerTimeSpacing", (), float)
         d[()] = t.spacing
@@ -596,14 +597,14 @@ class SLC(h5py.File):
         write_dataset(g, "acquiredCenterFrequency", float, acquired_fc,
             "Center frequency of the acquisition in hertz. In case of mode "
             "combination, this corresponds to the mode with highest center "
-            "frequency.", "hertz")
+            "frequency", "hertz")
         write_dataset(g, "acquiredRangeBandwidth", float,
             acquired_range_bandwidth, "Acquisition range bandwidth in "
             "hertz. In case of mode combination, this corresponds to mode with "
-            "largest bandwidth.", "hertz")
+            "largest bandwidth", "hertz")
         write_dataset(g, "nominalAcquisitionPRF", float, acquired_prf,
             "Nominal PRF of acquisition. In case of mode combination, this "
-            "corresponds to mode with least nominal PRF.", "hertz")
+            "corresponds to mode with least nominal PRF", "hertz")
         write_dataset(g, "processedAzimuthBandwidth", float, azimuth_bandwidth,
             "Processed azimuth bandwidth in hertz", "hertz")
         write_dataset(g, "processedRangeBandwidth", float, range_bandwidth,
@@ -864,10 +865,10 @@ class SLC(h5py.File):
             "the product")
 
         d = set_string(g, "productLevel", "L1")
-        d.attrs["description"] = np.bytes_("Product level. L0A: Unprocessed "
-            "instrument data; L0B: Reformatted, unprocessed instrument data; "
-            "L1: Processed instrument data in radar coordinates system; and "
-            "L2: Processed instrument data in geocoded coordinates system")
+        d.attrs["description"] = np.bytes_('Product level. "L0A": Unprocessed '
+            'instrument data; "L0B": Reformatted, unprocessed instrument data; '
+            '"L1": Processed instrument data in radar coordinates system; and '
+            '"L2": Processed instrument data in geocoded coordinates system')
 
         d = set_string(g, "radarBand", self.band[0])
         d.attrs["description"] = np.bytes_('Acquired frequency band, '
@@ -875,11 +876,14 @@ class SLC(h5py.File):
 
         d = set_string(g, "processingType", processing_type)
         d.attrs["description"] = np.bytes_(
-            "Nominal (or) Urgent (or) Custom (or) Undefined")
+            'Processing pipeline used to generate this granule. '
+            '"Nominal": standard production system; "Urgent": time-sensitive '
+            'processing in response to urgent response events; "Custom": '
+            'user-initiated processing outside the nominal production system')
 
         d = set_string(g, "isDithered", str(is_dithered))
         d.attrs["description"] = np.bytes_('"True" if the pulse timing was '
-            'varied (dithered) during acquisition, "False" otherwise.')
+            'varied (dithered) during acquisition, "False" otherwise')
 
         d = set_string(g, "isFullFrame", str(is_full_frame))
         d.attrs["description"] = np.bytes_('"True" if the product fully covers '
@@ -890,7 +894,7 @@ class SLC(h5py.File):
         d = set_string(g, "isMixedMode", str(is_mixed_mode))
         d.attrs["description"] = np.bytes_('"True" if this product is a '
             'composite of data collected in multiple radar modes, '
-            '"False" otherwise.')
+            '"False" otherwise')
 
         d = set_string(g, "compositeReleaseId", composite_release_id)
         d.attrs["description"] = np.bytes_("Unique version identifier of the "

--- a/python/packages/nisar/workflows/h5_prep.py
+++ b/python/packages/nisar/workflows/h5_prep.py
@@ -1042,25 +1042,35 @@ def add_geolocation_grid_cubes_to_hdf5(hdf5_obj, cube_group_name, radar_grid,
         cube_group, 'losUnitVectorX', np.float32, cube_shape,
         zds=zds, yds=yds, xds=xds,
         long_name='LOS unit vector X',
-        descr='East component of unit vector of LOS from target to sensor',
+        descr='East component of the line-of-sight (LOS) unit vector, defined from ' \
+              'the target to the sensor, expressed in the east-north-up (ENU) coordinate ' \
+              'system with its origin at the target location',
         units='1', valid_min=-1.0, valid_max=1.0, **create_dataset_kwargs)
     los_unit_vector_y_raster = _get_raster_from_hdf5_ds(
         cube_group, 'losUnitVectorY', np.float32, cube_shape,
         zds=zds, yds=yds, xds=xds,
         long_name='LOS unit vector Y',
-        descr='North component of unit vector of LOS from target to sensor',
+        descr='North component of the line-of-sight (LOS) unit vector, defined from ' \
+              'the target to the sensor, expressed in the east-north-up (ENU) coordinate ' \
+              'system with its origin at the target location',
         units='1', valid_min=-1.0, valid_max=1.0, **create_dataset_kwargs)
     along_track_unit_vector_x_raster = _get_raster_from_hdf5_ds(
         cube_group, 'alongTrackUnitVectorX', np.float32, cube_shape,
         zds=zds, yds=yds, xds=xds,
         long_name='Along-track unit vector X',
-        descr='East component of unit vector along ground track',
+        descr='East component of the along-track unit vector at the target ' \
+              'location, expressed in the east-north-up (ENU) coordinate ' \
+              'system and projected onto the horizontal plane ' \
+              '(i.e., excluding the up component)',
         units='1', valid_min=-1.0, valid_max=1.0, **create_dataset_kwargs)
     along_track_unit_vector_y_raster = _get_raster_from_hdf5_ds(
         cube_group, 'alongTrackUnitVectorY', np.float32, cube_shape,
         zds=zds, yds=yds, xds=xds,
         long_name='Along-track unit vector Y',
-        descr='North component of unit vector along ground track',
+        descr='North component of the along-track unit vector at the target ' \
+              'location, expressed in the east-north-up (ENU) coordinate ' \
+              'system and projected onto the horizontal plane ' \
+              '(i.e., excluding the up component)',
         units='1', valid_min=-1.0, valid_max=1.0, **create_dataset_kwargs)
     elevation_angle_raster = _get_raster_from_hdf5_ds(
         cube_group, 'elevationAngle', np.float32, cube_shape,


### PR DESCRIPTION
The QA XML Checker has identified several RSLC datasets where the description is inconsistent between the HDF5 and the XML.

This PR updates ISCE3 to output RSLC HDF5s with correct descriptions.

Note: I have not tested this branch; it'd be good to generate a quick HDF5 to make sure nothing broke!

Here are the logged ERRORs that this PR should resolve:

```
2026-01-01 10:36:10.306, ERROR, QA, 999998, /opt/conda/lib/python3.12/site-packages/nisarqa/validate/xml_spec_checker/checks.py:1006, "Differing descriptions detected: XML: "Vector of zero Doppler azimuth times, measured relative to a UTC epoch, corresponding to calibration elevationAntennaPattern records", HDF5: "Zero Doppler time since UTC epoch dimension corresponding to calibration elevationAntennaPattern records": Dataset /science/LSAR/RSLC/metadata/calibrationInformation/frequencyA/elevationAntennaPattern/zeroDopplerTime"
2026-01-01 10:36:10.306, ERROR, QA, 999998, /opt/conda/lib/python3.12/site-packages/nisarqa/validate/xml_spec_checker/checks.py:1006, "Differing descriptions detected: XML: "Vector of zero Doppler azimuth times, measured relative to a UTC epoch, corresponding to calibration noiseEquivalentBackscatter records", HDF5: "Zero Doppler time since UTC epoch dimension corresponding to calibration noiseEquivalentBackscatter records": Dataset /science/LSAR/RSLC/metadata/calibrationInformation/frequencyA/noiseEquivalentBackscatter/zeroDopplerTime"
2026-01-01 10:36:10.307, ERROR, QA, 999998, /opt/conda/lib/python3.12/site-packages/nisarqa/validate/xml_spec_checker/checks.py:1006, "Differing descriptions detected: XML: "Vector of zero Doppler azimuth times, measured relative to a UTC epoch, corresponding to calibration elevationAntennaPattern records", HDF5: "Zero Doppler time since UTC epoch dimension corresponding to calibration elevationAntennaPattern records": Dataset /science/LSAR/RSLC/metadata/calibrationInformation/frequencyB/elevationAntennaPattern/zeroDopplerTime"
2026-01-01 10:36:10.308, ERROR, QA, 999998, /opt/conda/lib/python3.12/site-packages/nisarqa/validate/xml_spec_checker/checks.py:1006, "Differing descriptions detected: XML: "Vector of zero Doppler azimuth times, measured relative to a UTC epoch, corresponding to calibration noiseEquivalentBackscatter records", HDF5: "Zero Doppler time since UTC epoch dimension corresponding to calibration noiseEquivalentBackscatter records": Dataset /science/LSAR/RSLC/metadata/calibrationInformation/frequencyB/noiseEquivalentBackscatter/zeroDopplerTime"
2026-01-01 10:36:10.308, ERROR, QA, 999998, /opt/conda/lib/python3.12/site-packages/nisarqa/validate/xml_spec_checker/checks.py:1006, "Differing descriptions detected: XML: "Vector of zero Doppler azimuth times, measured relative to a UTC epoch, corresponding to calibration records", HDF5: "Zero Doppler time since UTC epoch dimension corresponding to calibration records": Dataset /science/LSAR/RSLC/metadata/calibrationInformation/geometry/zeroDopplerTime"
2026-01-01 10:36:10.313, ERROR, QA, 999998, /opt/conda/lib/python3.12/site-packages/nisarqa/validate/xml_spec_checker/checks.py:1006, "Differing descriptions detected: XML: "Vector of zero Doppler azimuth times, measured relative to a UTC epoch, corresponding to processing information records", HDF5: "Zero Doppler time since UTC epoch dimension corresponding to processing information records": Dataset /science/LSAR/RSLC/metadata/processingInformation/parameters/frequencyA/zeroDopplerTime"
2026-01-01 10:36:10.314, ERROR, QA, 999998, /opt/conda/lib/python3.12/site-packages/nisarqa/validate/xml_spec_checker/checks.py:1006, "Differing descriptions detected: XML: "Vector of zero Doppler azimuth times, measured relative to a UTC epoch, corresponding to processing information records", HDF5: "Zero Doppler time since UTC epoch dimension corresponding to processing information records": Dataset /science/LSAR/RSLC/metadata/processingInformation/parameters/frequencyB/zeroDopplerTime"
2026-01-01 10:36:10.315, ERROR, QA, 999998, /opt/conda/lib/python3.12/site-packages/nisarqa/validate/xml_spec_checker/checks.py:1006, "Differing descriptions detected: XML: "Vector of zero Doppler azimuth times, measured relative to a UTC epoch, corresponding to processing information records", HDF5: "Zero Doppler time since UTC epoch dimension corresponding to processing information records": Dataset /science/LSAR/RSLC/metadata/processingInformation/parameters/zeroDopplerTime"
2026-01-01 10:36:10.310, ERROR, QA, 999998, /opt/conda/lib/python3.12/site-packages/nisarqa/validate/xml_spec_checker/checks.py:1006, "Differing descriptions detected: XML: "Vector of zero Doppler azimuth times, measured relative to a UTC epoch, corresponding to the geolocation grid", HDF5: "Zero Doppler time since UTC epoch values corresponding to the geolocation grid": Dataset /science/LSAR/RSLC/metadata/geolocationGrid/zeroDopplerTime"


2026-01-01 10:36:10.308, ERROR, QA, 999998, /opt/conda/lib/python3.12/site-packages/nisarqa/validate/xml_spec_checker/checks.py:1006, "Differing descriptions detected: XML: "East component of the along-track unit vector at the target location, expressed in the east-north-up (ENU) coordinate system and projected onto the horizontal plane (i.e., excluding the up component)", HDF5: "East component of unit vector along ground track": Dataset /science/LSAR/RSLC/metadata/geolocationGrid/alongTrackUnitVectorX"
2026-01-01 10:36:10.308, ERROR, QA, 999998, /opt/conda/lib/python3.12/site-packages/nisarqa/validate/xml_spec_checker/checks.py:1006, "Differing descriptions detected: XML: "North component of the along-track unit vector at the target location, expressed in the east-north-up (ENU) coordinate system and projected onto the horizontal plane (i.e., excluding the up component)", HDF5: "North component of unit vector along ground track": Dataset /science/LSAR/RSLC/metadata/geolocationGrid/alongTrackUnitVectorY"

2026-01-01 10:36:10.309, ERROR, QA, 999998, /opt/conda/lib/python3.12/site-packages/nisarqa/validate/xml_spec_checker/checks.py:1006, "Differing descriptions detected: XML: "East component of the line-of-sight (LOS) unit vector, defined from the target to the sensor, expressed in the east-north-up (ENU) coordinate system with its origin at the target location", HDF5: "East component of unit vector of LOS from target to sensor": Dataset /science/LSAR/RSLC/metadata/geolocationGrid/losUnitVectorX"
2026-01-01 10:36:10.309, ERROR, QA, 999998, /opt/conda/lib/python3.12/site-packages/nisarqa/validate/xml_spec_checker/checks.py:1006, "Differing descriptions detected: XML: "North component of the line-of-sight (LOS) unit vector, defined from the target to the sensor, expressed in the east-north-up (ENU) coordinate system with its origin at the target location", HDF5: "North component of unit vector of LOS from target to sensor": Dataset /science/LSAR/RSLC/metadata/geolocationGrid/losUnitVectorY"

2026-01-01 10:36:10.313, ERROR, QA, 999998, /opt/conda/lib/python3.12/site-packages/nisarqa/validate/xml_spec_checker/checks.py:1006, "Differing descriptions detected: XML: "1D array in frequency domain for azimuth processing. This is used for processing L0B to L1. FFT length=256 (assumed)", HDF5: "1-D array in frequency domain for azimuth processing. This is used for processing L0b to L1. FFT length=256 (assumed)": Dataset /science/LSAR/RSLC/metadata/processingInformation/parameters/azimuthChirpWeighting"
2026-01-01 10:36:10.314, ERROR, QA, 999998, /opt/conda/lib/python3.12/site-packages/nisarqa/validate/xml_spec_checker/checks.py:1006, "Differing descriptions detected: XML: "1D array in frequency domain for range processing. This is used for processing L0B to L1. FFT length=256 (assumed)", HDF5: "1-D array in frequency domain for range processing. This is used for processing L0b to L1. FFT length=256 (assumed)": Dataset /science/LSAR/RSLC/metadata/processingInformation/parameters/rangeChirpWeighting"

2026-01-01 10:36:10.314, ERROR, QA, 999998, /opt/conda/lib/python3.12/site-packages/nisarqa/validate/xml_spec_checker/checks.py:1006, "Differing descriptions detected: XML: "Reference terrain height as a function of time", HDF5: "Reference Terrain Height as a function of time": Dataset /science/LSAR/RSLC/metadata/processingInformation/parameters/referenceTerrainHeight"

2026-01-01 10:36:10.315, ERROR, QA, 999998, /opt/conda/lib/python3.12/site-packages/nisarqa/validate/xml_spec_checker/checks.py:1006, "Differing descriptions detected: XML: "Center frequency of the acquisition in hertz. In case of mode combination, this corresponds to the mode with highest center frequency", HDF5: "Center frequency of the acquisition in hertz. In case of mode combination, this corresponds to the mode with highest center frequency.": Dataset /science/LSAR/RSLC/swaths/frequencyA/acquiredCenterFrequency"
2026-01-01 10:36:10.316, ERROR, QA, 999998, /opt/conda/lib/python3.12/site-packages/nisarqa/validate/xml_spec_checker/checks.py:1006, "Differing descriptions detected: XML: "Center frequency of the acquisition in hertz. In case of mode combination, this corresponds to the mode with highest center frequency", HDF5: "Center frequency of the acquisition in hertz. In case of mode combination, this corresponds to the mode with highest center frequency.": Dataset /science/LSAR/RSLC/swaths/frequencyB/acquiredCenterFrequency"

2026-01-01 10:36:10.315, ERROR, QA, 999998, /opt/conda/lib/python3.12/site-packages/nisarqa/validate/xml_spec_checker/checks.py:1006, "Differing descriptions detected: XML: "Acquisition range bandwidth in hertz. In case of mode combination, this corresponds to mode with largest bandwidth", HDF5: "Acquisition range bandwidth in hertz. In case of mode combination, this corresponds to mode with largest bandwidth.": Dataset /science/LSAR/RSLC/swaths/frequencyA/acquiredRangeBandwidth"
2026-01-01 10:36:10.317, ERROR, QA, 999998, /opt/conda/lib/python3.12/site-packages/nisarqa/validate/xml_spec_checker/checks.py:1006, "Differing descriptions detected: XML: "Acquisition range bandwidth in hertz. In case of mode combination, this corresponds to mode with largest bandwidth", HDF5: "Acquisition range bandwidth in hertz. In case of mode combination, this corresponds to mode with largest bandwidth.": Dataset /science/LSAR/RSLC/swaths/frequencyB/acquiredRangeBandwidth"

2026-01-01 10:36:10.315, ERROR, QA, 999998, /opt/conda/lib/python3.12/site-packages/nisarqa/validate/xml_spec_checker/checks.py:1006, "Differing descriptions detected: XML: "Nominal PRF of acquisition. In case of mode combination, this corresponds to mode with least nominal PRF", HDF5: "Nominal PRF of acquisition. In case of mode combination, this corresponds to mode with least nominal PRF.": Dataset /science/LSAR/RSLC/swaths/frequencyA/nominalAcquisitionPRF"
2026-01-01 10:36:10.317, ERROR, QA, 999998, /opt/conda/lib/python3.12/site-packages/nisarqa/validate/xml_spec_checker/checks.py:1006, "Differing descriptions detected: XML: "Nominal PRF of acquisition. In case of mode combination, this corresponds to mode with least nominal PRF", HDF5: "Nominal PRF of acquisition. In case of mode combination, this corresponds to mode with least nominal PRF.": Dataset /science/LSAR/RSLC/swaths/frequencyB/nominalAcquisitionPRF"

2026-01-01 10:36:10.319, ERROR, QA, 999998, /opt/conda/lib/python3.12/site-packages/nisarqa/validate/xml_spec_checker/checks.py:1006, "Differing descriptions detected: XML: ""True" if the pulse timing was varied (dithered) during acquisition, "False" otherwise", HDF5: ""True" if the pulse timing was varied (dithered) during acquisition, "False" otherwise.": Dataset /science/LSAR/identification/isDithered"
2026-01-01 10:36:10.319, ERROR, QA, 999998, /opt/conda/lib/python3.12/site-packages/nisarqa/validate/xml_spec_checker/checks.py:1006, "Differing descriptions detected: XML: ""True" if this product is a composite of data collected in multiple radar modes, "False" otherwise", HDF5: ""True" if this product is a composite of data collected in multiple radar modes, "False" otherwise.": Dataset /science/LSAR/identification/isMixedMode"

2026-01-01 10:36:10.321, ERROR, QA, 999998, /opt/conda/lib/python3.12/site-packages/nisarqa/validate/xml_spec_checker/checks.py:1006, "Differing descriptions detected: XML: "Processing pipeline used to generate this granule. "Nominal": standard production system; "Urgent": time-sensitive processing in response to urgent response events; "Custom": user-initiated processing outside the nominal production system", HDF5: "Nominal (or) Urgent (or) Custom (or) Undefined": Dataset /science/LSAR/identification/processingType"


2026-01-01 10:36:10.321, ERROR, QA, 999998, /opt/conda/lib/python3.12/site-packages/nisarqa/validate/xml_spec_checker/checks.py:1006, "Differing descriptions detected: XML: "Product level. "L0A": Unprocessed instrument data; "L0B": Reformatted, unprocessed instrument data; "L1": Processed instrument data in radar coordinates system; and "L2": Processed instrument data in geocoded coordinates system", HDF5: "Product level. L0A: Unprocessed instrument data; L0B: Reformatted, unprocessed instrument data; L1: Processed instrument data in radar coordinates system; and L2: Processed instrument data in geocoded coordinates system": Dataset /science/LSAR/identification/productLevel"

2026-01-01 10:36:10.317, ERROR, QA, 999998, /opt/conda/lib/python3.12/site-packages/nisarqa/validate/xml_spec_checker/checks.py:1006, "Differing descriptions detected: XML: "Vector of zero Doppler azimuth times measured relative to a UTC epoch", HDF5: "Zero Doppler time since UTC epoch dimension": Dataset /science/LSAR/RSLC/swaths/zeroDopplerTime"

```