### PR TITLE
Update InSAR descriptions

### DIFF
--- a/python/packages/nisar/products/insar/GOFF_writer.py
+++ b/python/packages/nisar/products/insar/GOFF_writer.py
@@ -125,7 +125,7 @@ class GOFFWriter(ROFFWriter, L2InSARWriter):
                  " the most significant digit represents the water flag of that pixel in the reference RSLC,"
                  " where 1 is water and 0 is non-water;"
                  " the second digit represents the subswath number of that pixel in the reference RSLC;"
-                 " the least-significant digit represents the subswath number of that pixel in the secondary RSLC."
+                 " the least significant digit represents the subswath number of that pixel in the secondary RSLC."
                  " A value of 0 in either subswath digit indicates an invalid sample in the corresponding RSLC"),
                 grid_mapping=grids_val,
                 xds=xds,

--- a/python/packages/nisar/products/insar/GUNW_writer.py
+++ b/python/packages/nisar/products/insar/GUNW_writer.py
@@ -298,7 +298,7 @@ class GUNWWriter(RUNWWriter, RIFGWriter, L2InSARWriter):
                      " the most significant digit represents the water flag of that pixel in the reference RSLC,"
                      " where 1 is water and 0 is non-water;"
                      " the second digit represents the subswath number of that pixel in the reference RSLC;"
-                     " the least-significant digit represents the subswath number of that pixel in the secondary RSLC."
+                     " the least significant digit represents the subswath number of that pixel in the secondary RSLC."
                      " A value of 0 in either subswath digit indicates an invalid sample in the corresponding RSLC"),
                     grid_mapping=grids_val,
                     xds=xds,

--- a/python/packages/nisar/products/insar/InSAR_L1_writer.py
+++ b/python/packages/nisar/products/insar/InSAR_L1_writer.py
@@ -402,7 +402,7 @@ class L1InSARWriter(InSARBaseWriter):
                 DatasetParams(
                     "zeroDopplerTime",
                     offset_zero_doppler_time,
-                    "Zero Doppler azimuth time since UTC epoch vector",
+                    "Vector of zero Doppler azimuth times measured relative to a UTC epoch",
                     {'units': zero_dopp_time_units},
                 ),
                 DatasetParams(
@@ -607,7 +607,7 @@ class L1InSARWriter(InSARBaseWriter):
                 DatasetParams(
                     "zeroDopplerTime",
                     igram_zero_doppler_time,
-                    "Zero Doppler azimuth time since UTC epoch vector",
+                    "Vector of zero Doppler azimuth times measured relative to a UTC epoch",
                     {'units': zero_dopp_time_units},
                 ),
                 DatasetParams(
@@ -714,7 +714,7 @@ class L1InSARWriter(InSARBaseWriter):
                                                  " subswath number of that pixel in the secondary RSLC,"
                                                  " and the most significant digit represents"
                                                  " the subswath number of that pixel in the reference RSLC."
-                                                 " A value of '0' in either digit indicates an invalid sample"
+                                                 " A value of 0 in either digit indicates an invalid sample"
                                                  " in the corresponding RSLC"),
                                     fill_value=255)
             igram_group['mask'].attrs['valid_min'] = 0

--- a/python/packages/nisar/products/insar/InSAR_L2_writer.py
+++ b/python/packages/nisar/products/insar/InSAR_L2_writer.py
@@ -131,14 +131,14 @@ class L2InSARWriter(L1InSARWriter):
         slant_range_raster = _get_raster_from_hdf5_ds(
             cube_group, 'secondarySlantRange', np.float64, cube_shape,
             zds=zds, yds=yds, xds=xds,
-            long_name='slant-range',
+            long_name='Slant range',
             descr='Slant range of the secondary RSLC in meters',
             units='meters', **create_dataset_kwargs)
         azimuth_time_raster = _get_raster_from_hdf5_ds(
             cube_group, 'secondaryZeroDopplerAzimuthTime', np.float64, cube_shape,
             zds=zds, yds=yds, xds=xds,
-            long_name='zero-Doppler azimuth time',
-            descr='Zero Doppler azimuth time in seconds since UTC epoch of the reference RSLC image',
+            long_name='Zero Doppler azimuth time',
+            descr='Zero Doppler azimuth time in seconds since UTC epoch of the secondary RSLC image',
             units=az_coord_units, **create_dataset_kwargs)
 
         isce3.geometry.make_radar_grid_cubes(radar_grid, geogrid, heights,
@@ -221,7 +221,8 @@ class L2InSARWriter(L1InSARWriter):
         radar_grid['zeroDopplerAzimuthTime'].attrs['units'] = \
             zero_dopp_azimuth_time_units
         radar_grid['zeroDopplerAzimuthTime'].attrs['description'] = \
-            to_bytes("Zero doppler azimuth time of the reference RSLC image")
+            to_bytes("Zero Doppler azimuth time in seconds since UTC epoch " \
+                     "of the reference RSLC image")
 
         # Rename the dataset names
         radar_grid.move('slantRange','referenceSlantRange')

--- a/python/packages/nisar/products/insar/InSAR_base_writer.py
+++ b/python/packages/nisar/products/insar/InSAR_base_writer.py
@@ -384,7 +384,7 @@ class InSARBaseWriter(h5py.File):
                 np.bytes_(rfi_mitigation),
                 (
                     f'Algorithm used for radio frequency interference (RFI) mitigation in ' \
-                      'the {rslc_name} RSLC, either "ST-EVD" or "FDNF" (or "disabled" if no RFI ' \
+                      f'the {rslc_name} RSLC, either "ST-EVD" or "FDNF" (or "disabled" if no RFI ' \
                       'mitigation was applied)'
                 ),
             ),

--- a/python/packages/nisar/products/insar/InSAR_base_writer.py
+++ b/python/packages/nisar/products/insar/InSAR_base_writer.py
@@ -1219,10 +1219,10 @@ class InSARBaseWriter(h5py.File):
                 "productLevel",
                 self.product_info.ProductLevel,
                 (
-                    "Product level. L0A: Unprocessed instrument data; L0B:"
-                    " Reformatted, unprocessed instrument data; L1: Processed"
-                    " instrument data in radar coordinates system; and L2:"
-                    " Processed instrument data in geocoded coordinates system"
+                    'Product level. "L0A": Unprocessed instrument data; "L0B":'
+                    ' Reformatted, unprocessed instrument data; "L1": Processed'
+                    ' instrument data in radar coordinates system; and "L2":'
+                    ' Processed instrument data in geocoded coordinates system'
                 ),
             ),
             DatasetParams(

--- a/python/packages/nisar/workflows/h5_prep.py
+++ b/python/packages/nisar/workflows/h5_prep.py
@@ -827,7 +827,7 @@ def add_radar_grid_cubes_to_hdf5(hdf5_obj, cube_group_name, geogrid,
     azimuth_time_raster = _get_raster_from_hdf5_ds(
         cube_group, 'zeroDopplerAzimuthTime', np.float64, cube_shape,
         zds=zds, yds=yds, xds=xds,
-        long_name='Zero-Doppler azimuth time',
+        long_name='Zero Doppler azimuth time',
         descr='Zero Doppler azimuth time in seconds since UTC epoch',
         units=az_coord_units, **create_dataset_kwargs)
     incidence_angle_raster = _get_raster_from_hdf5_ds(

--- a/python/packages/nisar/workflows/h5_prep.py
+++ b/python/packages/nisar/workflows/h5_prep.py
@@ -1152,7 +1152,8 @@ def set_create_geolocation_grid_coordinates(hdf5_obj, root_ds, radar_grid,
     coordinates_list.append(rg_dataset)
 
     # Zero-doppler time
-    descr = "Zero Doppler time since UTC epoch values corresponding to the geolocation grid"
+    descr = ("Vector of zero Doppler azimuth times, measured relative " +
+             "to a UTC epoch, corresponding to the geolocation grid")
     az_dataset_name = os.path.join(root_ds, 'zeroDopplerTime')
     if az_dataset_name in hdf5_obj:
         del hdf5_obj[az_dataset_name]


### PR DESCRIPTION
The QA XML Checker has identified several InSAR datasets where the description is inconsistent between the HDF5 and the XML.

This PR updates ISCE3 to output InSAR HDF5s with correct descriptions.

Note: I have not tested this branch; it'd be good to generate a quick HDF5s to make sure nothing broke!

Here are the logged ERRORs that this PR should resolve:

RIFG:
```
"Differing descriptions detected: XML: "East component of the along-track unit vector at the target location, expressed in the east-north-up (ENU) coordinate system and projected onto the horizontal plane (i.e., excluding the up component)", HDF5: "East component of unit vector along ground track": Dataset /science/LSAR/RIFG/metadata/geolocationGrid/alongTrackUnitVectorX"
"Differing descriptions detected: XML: "North component of the along-track unit vector at the target location, expressed in the east-north-up (ENU) coordinate system and projected onto the horizontal plane (i.e., excluding the up component)", HDF5: "North component of unit vector along ground track": Dataset /science/LSAR/RIFG/metadata/geolocationGrid/alongTrackUnitVectorY"
"Differing descriptions detected: XML: "East component of the line-of-sight (LOS) unit vector, defined from the target to the sensor, expressed in the east-north-up (ENU) coordinate system with its origin at the target location", HDF5: "East component of unit vector of LOS from target to sensor": Dataset /science/LSAR/RIFG/metadata/geolocationGrid/losUnitVectorX"
"Differing descriptions detected: XML: "North component of the line-of-sight (LOS) unit vector, defined from the target to the sensor, expressed in the east-north-up (ENU) coordinate system with its origin at the target location", HDF5: "North component of unit vector of LOS from target to sensor": Dataset /science/LSAR/RIFG/metadata/geolocationGrid/losUnitVectorY"
"Differing descriptions detected: XML: "Vector of zero Doppler azimuth times, measured relative to a UTC epoch, corresponding to the geolocation grid", HDF5: "Zero Doppler time since UTC epoch values corresponding to the geolocation grid": Dataset /science/LSAR/RIFG/metadata/geolocationGrid/zeroDopplerTime"
"Differing descriptions detected: XML: "Algorithm used for radio frequency interference (RFI) mitigation in the reference RSLC, either "ST-EVD" or "FDNF" (or "disabled" if no RFI mitigation was applied)", HDF5: "Algorithm used for radio frequency interference (RFI) mitigation in the {rslc_name} RSLC, either "ST-EVD" or "FDNF" (or "disabled" if no RFI mitigation was applied)": Dataset /science/LSAR/RIFG/metadata/processingInformation/parameters/reference/rfiMitigation"
"Differing descriptions detected: XML: "Algorithm used for radio frequency interference (RFI) mitigation in the reference RSLC, either "ST-EVD" or "FDNF" (or "disabled" if no RFI mitigation was applied)", HDF5: "Algorithm used for radio frequency interference (RFI) mitigation in the {rslc_name} RSLC, either "ST-EVD" or "FDNF" (or "disabled" if no RFI mitigation was applied)": Dataset /science/LSAR/RIFG/metadata/processingInformation/parameters/secondary/rfiMitigation"
"Differing descriptions detected: XML: "Mask indicating the subswaths of valid samples in the reference RSLC and geometrically-coregistered secondary RSLC. Each pixel value is a two-digit number: the least significant digit represents the subswath number of that pixel in the secondary RSLC, and the most significant digit represents the subswath number of that pixel in the reference RSLC. A value of 0 in either digit indicates an invalid sample in the corresponding RSLC", HDF5: "Mask indicating the subswaths of valid samples in the reference RSLC and geometrically-coregistered secondary RSLC. Each pixel value is a two-digit number: the least significant digit represents the subswath number of that pixel in the secondary RSLC, and the most significant digit represents the subswath number of that pixel in the reference RSLC. A value of '0' in either digit indicates an invalid sample in the corresponding RSLC": Dataset /science/LSAR/RIFG/swaths/frequencyA/interferogram/mask"
"Differing descriptions detected: XML: "Vector of zero Doppler azimuth times measured relative to a UTC epoch", HDF5: "Zero Doppler azimuth time since UTC epoch vector": Dataset /science/LSAR/RIFG/swaths/frequencyA/interferogram/zeroDopplerTime"
"Differing descriptions detected: XML: "Vector of zero Doppler azimuth times measured relative to a UTC epoch", HDF5: "Zero Doppler azimuth time since UTC epoch vector": Dataset /science/LSAR/RIFG/swaths/frequencyA/pixelOffsets/zeroDopplerTime"
"Differing descriptions detected: XML: "Product level. "L0A": Unprocessed instrument data; "L0B": Reformatted, unprocessed instrument data; "L1": Processed instrument data in radar coordinates system; and "L2": Processed instrument data in geocoded coordinates system", HDF5: "Product level. L0A: Unprocessed instrument data; L0B: Reformatted, unprocessed instrument data; L1: Processed instrument data in radar coordinates system; and L2: Processed instrument data in geocoded coordinates system": Dataset /science/LSAR/identification/productLevel"
```

RUNW:
```
"Differing descriptions detected: XML: "East component of the along-track unit vector at the target location, expressed in the east-north-up (ENU) coordinate system and projected onto the horizontal plane (i.e., excluding the up component)", HDF5: "East component of unit vector along ground track": Dataset /science/LSAR/RUNW/metadata/geolocationGrid/alongTrackUnitVectorX"
"Differing descriptions detected: XML: "North component of the along-track unit vector at the target location, expressed in the east-north-up (ENU) coordinate system and projected onto the horizontal plane (i.e., excluding the up component)", HDF5: "North component of unit vector along ground track": Dataset /science/LSAR/RUNW/metadata/geolocationGrid/alongTrackUnitVectorY"
"Differing descriptions detected: XML: "East component of the line-of-sight (LOS) unit vector, defined from the target to the sensor, expressed in the east-north-up (ENU) coordinate system with its origin at the target location", HDF5: "East component of unit vector of LOS from target to sensor": Dataset /science/LSAR/RUNW/metadata/geolocationGrid/losUnitVectorX"
"Differing descriptions detected: XML: "North component of the line-of-sight (LOS) unit vector, defined from the target to the sensor, expressed in the east-north-up (ENU) coordinate system with its origin at the target location", HDF5: "North component of unit vector of LOS from target to sensor": Dataset /science/LSAR/RUNW/metadata/geolocationGrid/losUnitVectorY"
"Differing descriptions detected: XML: "Algorithm used for radio frequency interference (RFI) mitigation in the reference RSLC, either "ST-EVD" or "FDNF" (or "disabled" if no RFI mitigation was applied)", HDF5: "Algorithm used for radio frequency interference (RFI) mitigation in the {rslc_name} RSLC, either "ST-EVD" or "FDNF" (or "disabled" if no RFI mitigation was applied)": Dataset /science/LSAR/RUNW/metadata/processingInformation/parameters/reference/rfiMitigation"
"Differing descriptions detected: XML: "Algorithm used for radio frequency interference (RFI) mitigation in the secondary RSLC, either "ST-EVD" or "FDNF" (or "disabled" if no RFI mitigation was applied)", HDF5: "Algorithm used for radio frequency interference (RFI) mitigation in the {rslc_name} RSLC, either "ST-EVD" or "FDNF" (or "disabled" if no RFI mitigation was applied)": Dataset /science/LSAR/RUNW/metadata/processingInformation/parameters/secondary/rfiMitigation"
"Differing descriptions detected: XML: "Vector of zero Doppler azimuth times, measured relative to a UTC epoch, corresponding to the geolocation grid", HDF5: "Zero Doppler time since UTC epoch values corresponding to the geolocation grid": Dataset /science/LSAR/RUNW/metadata/geolocationGrid/zeroDopplerTime"
"Differing descriptions detected: XML: "Mask indicating the subswaths of valid samples in the reference RSLC and geometrically-coregistered secondary RSLC. Each pixel value is a two-digit number: the least significant digit represents the subswath number of that pixel in the secondary RSLC, and the most significant digit represents the subswath number of that pixel in the reference RSLC. A value of 0 in either digit indicates an invalid sample in the corresponding RSLC", HDF5: "Mask indicating the subswaths of valid samples in the reference RSLC and geometrically-coregistered secondary RSLC. Each pixel value is a two-digit number: the least significant digit represents the subswath number of that pixel in the secondary RSLC, and the most significant digit represents the subswath number of that pixel in the reference RSLC. A value of '0' in either digit indicates an invalid sample in the corresponding RSLC": Dataset /science/LSAR/RUNW/swaths/frequencyA/interferogram/mask"
"Differing descriptions detected: XML: "Vector of zero Doppler azimuth times measured relative to a UTC epoch", HDF5: "Zero Doppler azimuth time since UTC epoch vector": Dataset /science/LSAR/RUNW/swaths/frequencyA/interferogram/zeroDopplerTime"
"Differing descriptions detected: XML: "Vector of zero Doppler azimuth times measured relative to a UTC epoch", HDF5: "Zero Doppler azimuth time since UTC epoch vector": Dataset /science/LSAR/RUNW/swaths/frequencyA/pixelOffsets/zeroDopplerTime"
"Differing descriptions detected: XML: "Product level. "L0A": Unprocessed instrument data; "L0B": Reformatted, unprocessed instrument data; "L1": Processed instrument data in radar coordinates system; and "L2": Processed instrument data in geocoded coordinates system", HDF5: "Product level. L0A: Unprocessed instrument data; L0B: Reformatted, unprocessed instrument data; L1: Processed instrument data in radar coordinates system; and L2: Processed instrument data in geocoded coordinates system": Dataset /science/LSAR/identification/productLevel"
```

GUNW:
```
"Differing descriptions detected: XML: "Algorithm used for radio frequency interference (RFI) mitigation in the reference RSLC, either "ST-EVD" or "FDNF" (or "disabled" if no RFI mitigation was applied)", HDF5: "Algorithm used for radio frequency interference (RFI) mitigation in the {rslc_name} RSLC, either "ST-EVD" or "FDNF" (or "disabled" if no RFI mitigation was applied)": Dataset /science/LSAR/GUNW/metadata/processingInformation/parameters/reference/rfiMitigation"
"Differing descriptions detected: XML: "Algorithm used for radio frequency interference (RFI) mitigation in the secondary RSLC, either "ST-EVD" or "FDNF" (or "disabled" if no RFI mitigation was applied)", HDF5: "Algorithm used for radio frequency interference (RFI) mitigation in the {rslc_name} RSLC, either "ST-EVD" or "FDNF" (or "disabled" if no RFI mitigation was applied)": Dataset /science/LSAR/GUNW/metadata/processingInformation/parameters/secondary/rfiMitigation"
"Differing descriptions detected: XML: "Zero Doppler azimuth time in seconds since UTC epoch of the reference RSLC image", HDF5: "Zero doppler azimuth time of the reference RSLC image": Dataset /science/LSAR/GUNW/metadata/radarGrid/referenceZeroDopplerAzimuthTime"
"Attributes found in HDF5 but not XML: {'grid_mapping', 'long_name'} - Dataset /science/LSAR/GUNW/metadata/radarGrid/referenceZeroDopplerAzimuthTime"
"Attributes found in HDF5 but not XML: {'grid_mapping', 'long_name'} - Dataset /science/LSAR/GUNW/metadata/radarGrid/secondaryZeroDopplerAzimuthTime"
"Differing descriptions detected: XML: "Zero Doppler azimuth time in seconds since UTC epoch of the secondary RSLC image", HDF5: "Zero Doppler azimuth time in seconds since UTC epoch of the reference RSLC image": Dataset /science/LSAR/GUNW/metadata/radarGrid/secondaryZeroDopplerAzimuthTime"
"Differing descriptions detected: XML: "Product level. "L0A": Unprocessed instrument data; "L0B": Reformatted, unprocessed instrument data; "L1": Processed instrument data in radar coordinates system; and "L2": Processed instrument data in geocoded coordinates system", HDF5: "Product level. L0A: Unprocessed instrument data; L0B: Reformatted, unprocessed instrument data; L1: Processed instrument data in radar coordinates system; and L2: Processed instrument data in geocoded coordinates system": Dataset /science/LSAR/identification/productLevel"
```

ROFF:
```
"Differing descriptions detected: XML: "East component of the along-track unit vector at the target location, expressed in the east-north-up (ENU) coordinate system and projected onto the horizontal plane (i.e., excluding the up component)", HDF5: "East component of unit vector along ground track": Dataset /science/LSAR/ROFF/metadata/geolocationGrid/alongTrackUnitVectorX"
"Differing descriptions detected: XML: "North component of the along-track unit vector at the target location, expressed in the east-north-up (ENU) coordinate system and projected onto the horizontal plane (i.e., excluding the up component)", HDF5: "North component of unit vector along ground track": Dataset /science/LSAR/ROFF/metadata/geolocationGrid/alongTrackUnitVectorY"
"Differing descriptions detected: XML: "East component of the line-of-sight (LOS) unit vector, defined from the target to the sensor, expressed in the east-north-up (ENU) coordinate system with its origin at the target location", HDF5: "East component of unit vector of LOS from target to sensor": Dataset /science/LSAR/ROFF/metadata/geolocationGrid/losUnitVectorX"
"Differing descriptions detected: XML: "North component of the line-of-sight (LOS) unit vector, defined from the target to the sensor, expressed in the east-north-up (ENU) coordinate system with its origin at the target location", HDF5: "North component of unit vector of LOS from target to sensor": Dataset /science/LSAR/ROFF/metadata/geolocationGrid/losUnitVectorY"
"Differing descriptions detected: XML: "Vector of zero Doppler azimuth times, measured relative to a UTC epoch, corresponding to the geolocation grid", HDF5: "Zero Doppler time since UTC epoch values corresponding to the geolocation grid": Dataset /science/LSAR/ROFF/metadata/geolocationGrid/zeroDopplerTime"
"Differing descriptions detected: XML: "Algorithm used for radio frequency interference (RFI) mitigation in the reference RSLC, either "ST-EVD" or "FDNF" (or "disabled" if no RFI mitigation was applied)", HDF5: "Algorithm used for radio frequency interference (RFI) mitigation in the {rslc_name} RSLC, either "ST-EVD" or "FDNF" (or "disabled" if no RFI mitigation was applied)": Dataset /science/LSAR/ROFF/metadata/processingInformation/parameters/reference/rfiMitigation"
"Differing descriptions detected: XML: "Algorithm used for radio frequency interference (RFI) mitigation in the secondary RSLC, either "ST-EVD" or "FDNF" (or "disabled" if no RFI mitigation was applied)", HDF5: "Algorithm used for radio frequency interference (RFI) mitigation in the {rslc_name} RSLC, either "ST-EVD" or "FDNF" (or "disabled" if no RFI mitigation was applied)": Dataset /science/LSAR/ROFF/metadata/processingInformation/parameters/secondary/rfiMitigation"
"Differing descriptions detected: XML: "Vector of zero Doppler azimuth times measured relative to a UTC epoch", HDF5: "Zero Doppler azimuth time since UTC epoch vector": Dataset /science/LSAR/ROFF/swaths/frequencyA/pixelOffsets/zeroDopplerTime"
"Differing descriptions detected: XML: "Product level. "L0A": Unprocessed instrument data; "L0B": Reformatted, unprocessed instrument data; "L1": Processed instrument data in radar coordinates system; and "L2": Processed instrument data in geocoded coordinates system", HDF5: "Product level. L0A: Unprocessed instrument data; L0B: Reformatted, unprocessed instrument data; L1: Processed instrument data in radar coordinates system; and L2: Processed instrument data in geocoded coordinates system": Dataset /science/LSAR/identification/productLevel"
```

GOFF:
```
Update ISCE3 InSAR so that /science/LSAR/GOFF/metadata/radarGrid/secondarySlantRange" has long_name of "Slant range"
Update ISCE3 InSAR so that /science/LSAR/GOFF/metadata/radarGrid/referenceZeroDopplerAzimuthTime" has long_name of "Zero Doppler azimuth time" (to match GCOV)
Update ISCE3 InSAR so that /science/LSAR/GOFF/metadata/radarGrid/secondaryZeroDopplerAzimuthTime" has long_name of "Zero Doppler azimuth time" (to match GCOV)
"Differing descriptions detected: XML: "Zero Doppler azimuth time in seconds since UTC epoch of the reference RSLC image", HDF5: "Zero doppler azimuth time of the reference RSLC image": Dataset /science/LSAR/GOFF/metadata/radarGrid/referenceZeroDopplerAzimuthTime"
"Differing descriptions detected: XML: "Zero Doppler azimuth time in seconds since UTC epoch of the secondary RSLC image", HDF5: "Zero Doppler azimuth time in seconds since UTC epoch of the reference RSLC image": Dataset /science/LSAR/GOFF/metadata/radarGrid/secondaryZeroDopplerAzimuthTime"
"Differing descriptions detected: XML: "Algorithm used for radio frequency interference (RFI) mitigation in the reference RSLC, either "ST-EVD" or "FDNF" (or "disabled" if no RFI mitigation was applied)", HDF5: "Algorithm used for radio frequency interference (RFI) mitigation in the {rslc_name} RSLC, either "ST-EVD" or "FDNF" (or "disabled" if no RFI mitigation was applied)": Dataset /science/LSAR/GOFF/metadata/processingInformation/parameters/reference/rfiMitigation"
"Differing descriptions detected: XML: "Algorithm used for radio frequency interference (RFI) mitigation in the secondary RSLC, either "ST-EVD" or "FDNF" (or "disabled" if no RFI mitigation was applied)", HDF5: "Algorithm used for radio frequency interference (RFI) mitigation in the {rslc_name} RSLC, either "ST-EVD" or "FDNF" (or "disabled" if no RFI mitigation was applied)": Dataset /science/LSAR/GOFF/metadata/processingInformation/parameters/secondary/rfiMitigation"
"Differing descriptions detected: XML: "Product level. "L0A": Unprocessed instrument data; "L0B": Reformatted, unprocessed instrument data; "L1": Processed instrument data in radar coordinates system; and "L2": Processed instrument data in geocoded coordinates system", HDF5: "Product level. L0A: Unprocessed instrument data; L0B: Reformatted, unprocessed instrument data; L1: Processed instrument data in radar coordinates system; and L2: Processed instrument data in geocoded coordinates system": Dataset /science/LSAR/identification/productLevel"
```