### PR TITLE
Make isce3 work with numpy 2.x

### DIFF
--- a/python/packages/isce3/io/gdal/gdal_raster.py
+++ b/python/packages/isce3/io/gdal/gdal_raster.py
@@ -20,10 +20,7 @@ GDALRasterT = TypeVar("GDALRasterT", bound="GDALRaster")
 
 def get_gdal_dtype(type: DTypeLike) -> int:
     """Returns the GDAL data type associated with a given NumPy dtype."""
-    try:
-        np_dtype = np.dtype(type)
-    except Exception:
-        np_dtype = np.dtype(type.dtype)
+    np_dtype = np.dtype(type)
 
     if np_dtype == np.complex128:
         return gdal.GDT_CFloat64

--- a/python/packages/isce3/io/gdal/gdal_raster.py
+++ b/python/packages/isce3/io/gdal/gdal_raster.py
@@ -20,7 +20,10 @@ GDALRasterT = TypeVar("GDALRasterT", bound="GDALRaster")
 
 def get_gdal_dtype(type: DTypeLike) -> int:
     """Returns the GDAL data type associated with a given NumPy dtype."""
-    np_dtype = np.dtype(type)
+    try:
+        np_dtype = np.dtype(type)
+    except Exception:
+        np_dtype = np.dtype(type.dtype)
 
     if np_dtype == np.complex128:
         return gdal.GDT_CFloat64

--- a/python/packages/nisar/cal/faraday_rotation_angle_slc.py
+++ b/python/packages/nisar/cal/faraday_rotation_angle_slc.py
@@ -387,14 +387,14 @@ class FaradayRotAngleSlc(ABC):
 
         # get range bins per block and the number of blocks of sr
         n_rgb_blk = round(sr_blk_size / self._rdr_grid.range_pixel_spacing)
-        n_blks_sr = int(np.ceil(np.diff(rgb_limit) / n_rgb_blk))
+        n_blks_sr = int(np.ceil(np.diff(rgb_limit).item() / n_rgb_blk))
 
         self.logger.info(f'Full block size in slant range -> {n_rgb_blk}')
         self.logger.info(f'Total number of range blocks -> {n_blks_sr}')
 
         # get azimuth bins per block and the number of blocks of azt
         n_azb_blk = round(azt_blk_size * self._rdr_grid.prf)
-        n_blks_azt = int(np.ceil(np.diff(azb_limit) / n_azb_blk))
+        n_blks_azt = int(np.ceil(np.diff(azb_limit).item() / n_azb_blk))
 
         self.logger.info(f'Full block size in AZ time -> {n_azb_blk}')
         self.logger.info(f'Total number of AZ blocks -> {n_blks_azt}')

--- a/python/packages/nisar/cal/pol_channel_imbalance_slc.py
+++ b/python/packages/nisar/cal/pol_channel_imbalance_slc.py
@@ -414,14 +414,14 @@ class PolChannelImbalanceSlc:
 
         # get range bins per block and the number of blocks of sr
         n_rgb_blk = round(sr_blk_size / self._rdr_grid.range_pixel_spacing)
-        n_blks_sr = int(np.ceil(np.diff(rgb_limit) / n_rgb_blk))
+        n_blks_sr = int(np.ceil(np.diff(rgb_limit).item() / n_rgb_blk))
 
         self.logger.info(f'Full block size in slant range -> {n_rgb_blk}')
         self.logger.info(f'Total number of range blocks -> {n_blks_sr}')
 
         # get azimuth bins per block and the number of blocks of azt
         n_azb_blk = round(azt_blk_size * self._rdr_grid.prf)
-        n_blks_azt = int(np.ceil(np.diff(azb_limit) / n_azb_blk))
+        n_blks_azt = int(np.ceil(np.diff(azb_limit).item() / n_azb_blk))
 
         self.logger.info(f'Full block size in AZ time -> {n_azb_blk}')
         self.logger.info(f'Total number of AZ blocks -> {n_blks_azt}')

--- a/python/packages/nisar/h5/h5utils.py
+++ b/python/packages/nisar/h5/h5utils.py
@@ -23,7 +23,7 @@ def extractScalar(h5grp, key, destType, logger=None, msg=None):
 
     try:
         val = h5grp[key][()]
-        val = destType(val)
+        val = destType(val.item() if hasattr(val, "item") else val)
     except KeyError as e:
         raise KeyError(handle_message(f'{key} not found at {h5grp.name}')) from e
     except Exception as e:

--- a/tests/python/extensions/pybind/signal/filter2D.py
+++ b/tests/python/extensions/pybind/signal/filter2D.py
@@ -33,7 +33,7 @@ def test_run_filter2D():
     block = 20
 
     # Create filter kernels
-    kernel1d = np.ones([kernel_length, 1], dtype=np.float64) / kernel_length
+    kernel1d = np.ones(kernel_length, dtype=np.float64) / kernel_length
 
     # Create real data to filter
     data_real = np.zeros([length, width], dtype=np.float64)

--- a/tests/python/packages/isce3/io/gdal/gdal_raster.py
+++ b/tests/python/packages/isce3/io/gdal/gdal_raster.py
@@ -142,35 +142,6 @@ def test_create_dataset_file_dtype_character_codes():
         assert raster.dtype == np.float32
 
 
-def test_create_dataset_file_dtype_classes():
-    """
-    Test the GDALRaster.create_dataset_file for acceptance of class instances that have
-    a .dtype attribute as a dtype parameter
-    """
-    @dataclass
-    class a:
-        dtype = np.complex64
-
-    with TemporaryDirectory() as tempdir:
-        raster = GDALRaster.create_dataset_file(
-            filepath=Path(tempdir) / "dtype_test_a.gdal",
-            dtype=a(),
-            shape=(100, 100),
-            num_bands=1,
-        )
-
-        assert raster.dtype == np.complex64
-
-        raster_2 = GDALRaster.create_dataset_file(
-            filepath=Path(tempdir) / "dtype_test_raster.gdal",
-            dtype=raster,
-            shape=(100, 100),
-            num_bands=1,
-        )
-
-        assert raster_2.dtype == np.complex64
-
-
 def test_create_dataset_file_dtype_character_codes():
     """
     Test the GDALRaster.create_dataset_file for acceptance of np.dtype objects as a


### PR DESCRIPTION
- `isce3` currently is still pinned to numpy < 2, making it hard to use with most analytics tools that have moved on to newer versions
- This PR will be in draft state as we fix issues that we run into when working with isce3 in newer environments
- Current env used for this PR
    - OSX 26.3
    - numpy 2.4.2
    - GDAL 3.12.2
    - HDF5 2.0.0
    - h5py 3.15.1
- We are not able to test any of the nisar workflows as the test data is not open
- These changes ensure that unit tests work with newer setup