### PR TITLE
Hack in options for enlarging raw data gaps

### DIFF
--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1867,6 +1867,16 @@ def focus(runconfig, runconfig_path=""):
                 channel_in.band.center, fs, raw_grid.shape[1],
                 raw.isDithered(channel_in.freq_id))
 
+            usec2samp = lambda x: round(x * 1e-6 * isce3.core.speed_of_light / (2 * raw_grid.slant_ranges.spacing))
+            pad_left = usec2samp(cfg.processing.gap_pad_usec.left)
+            pad_right = usec2samp(cfg.processing.gap_pad_usec.right)
+            log.info(f"Padding gaps ({-pad_left}, {pad_right})")
+            valid = swaths[..., 1] > swaths[..., 0]
+            swaths[valid, 0] += pad_right
+            ends = swaths[valid, 1]
+            swaths[valid, 1] = np.where(ends >= pad_left, ends - pad_left,
+                np.zeros_like(ends))
+
             for i in range(0, raw_grid.shape[0], na):
                 pulse = i + pulse_begin
                 nblock = min(na, rawdata.shape[0] - pulse, raw_mm.shape[0] - i)

--- a/share/nisar/defaults/focus.yaml
+++ b/share/nisar/defaults/focus.yaml
@@ -423,6 +423,11 @@ runconfig:
             # cal pulses.
             zero_fill_gaps: True
 
+            # Options to enlarge gaps
+            gap_pad_usec:
+                left: 0.0
+                right: 0.0
+
             caltone:
                 # If "azimuth_mean", subtract the azimuth mean from the raw
                 # data, which is useful when the caltone is nearly constant in

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -253,6 +253,10 @@ runconfig:
       # If true, fill transmit gaps with zeros to remove loop-back cal pulses.
       zero_fill_gaps: bool(required=False)
 
+      #gap_pad_usec:
+      #    left: 0.0
+      #    right: 0.0
+
       caltone: include('caltone_options', required=False)
 
       # Processing stage switches, mostly for debug.


### PR DESCRIPTION
This PR enables enlarging the TX gaps reported in the L0B metadata during RSLC processing. We've noticed raw data artifacts adjacent to the gaps, so this feature is useful for quickly evaluating the effects of throwing out nearby data. In dithered modes, those samples will be filled in via azimuth presumming.

This isn't really the the best way to implement this feature, so I'm marking the PR as draft and don't plan to merge it. That's because it uses the validSampleSubSwathN L0B metadata in a straightforward way and doesn't distinguish between TX gaps and zero-padding due to DWP updates. So it also trims the start and end of the swath in the process. Once we determine the desired amount of padding, we should just provide it to the L0B processor which can pad only the gaps.