### PR TITLE
Fix macOS Debug CI builds

### DIFF
--- a/python/extensions/pybind_isce3/CMakeLists.txt
+++ b/python/extensions/pybind_isce3/CMakeLists.txt
@@ -21,6 +21,23 @@ if(WITH_CUDA)
     target_link_libraries(${ISCEEXTENSION} PUBLIC ${LISCECUDA})
 endif()
 
+# ---------------------------------------------------------------------------
+# macOS Debug workaround for pybind11 import failures
+#
+# Conda/micromamba Python interpreters are built in Release mode. When the
+# pybind11 extension is compiled with libc++ debug STL enabled (as can happen
+# in Debug builds on macOS), container ABI differences can cause pybind11
+# signature parsing to fail at module import time:
+#
+#   ImportError: Internal error while parsing type signature (2)
+#
+# To avoid this mismatch we explicitly disable libc++ debug mode for the
+# Python extension module when building Debug on macOS.
+# ---------------------------------------------------------------------------
+if(APPLE AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_compile_options(${ISCEEXTENSION} PRIVATE -U_LIBCPP_DEBUG)
+endif()
+
 # install
 install(TARGETS ${ISCEEXTENSION}
         LIBRARY DESTINATION ${ISCE_PACKAGESDIR}/isce3/ext

--- a/python/extensions/pybind_isce3/CMakeLists.txt
+++ b/python/extensions/pybind_isce3/CMakeLists.txt
@@ -24,18 +24,19 @@ endif()
 # ---------------------------------------------------------------------------
 # macOS Debug workaround for pybind11 import failures
 #
-# Conda/micromamba Python interpreters are built in Release mode. When the
-# pybind11 extension is compiled with libc++ debug STL enabled (as can happen
-# in Debug builds on macOS), container ABI differences can cause pybind11
-# signature parsing to fail at module import time:
+# Conda/micromamba Python interpreters are built in Release mode (with NDEBUG
+# defined). Without NDEBUG, libc++ may use different container layouts or
+# hardening modes, causing an ABI mismatch between the extension and the
+# interpreter. This manifests as:
 #
 #   ImportError: Internal error while parsing type signature (2)
 #
-# To avoid this mismatch we explicitly disable libc++ debug mode for the
-# Python extension module when building Debug on macOS.
+# Force NDEBUG for the pybind11 extension so its libc++ ABI matches the
+# Release-built Python interpreter. The rest of isce3 still builds in full
+# Debug mode.
 # ---------------------------------------------------------------------------
 if(APPLE AND CMAKE_BUILD_TYPE STREQUAL "Debug")
-    target_compile_options(${ISCEEXTENSION} PRIVATE -U_LIBCPP_DEBUG)
+    target_compile_definitions(${ISCEEXTENSION} PRIVATE NDEBUG)
 endif()
 
 # install


### PR DESCRIPTION
Our CI has been failing in macOS Debug builds for a while. The received wisdom from the oracle (ChatGPT and gemini) is that conda python is built against a release build of libc++, while CMake Debug builds add `_LIBCPP_DEBUG`, which changes the libc++ ABI/RTTI and causes a mismatch between the extension and interpreter. Let's see if that's the case!