### PR TITLE
RFI Detection and Mitigation for Dithered PRF mode

### DIFF
--- a/python/packages/isce3/signal/compute_evd_cpi.py
+++ b/python/packages/isce3/signal/compute_evd_cpi.py
@@ -102,9 +102,9 @@ def compute_evd_tb(
     mask_valid : np.ndarray bool, [num_pulses x num_rng_samples], optional
         Valid-sample mask with same shape as raw_data. Required if
         prf_dither_mode=True.
-    off_diag_overlap_ratio : float, optional
+    off_diag_overlap_ratio : float, optional, default = 0.25
         Minimum overlap ratio used by gap exclusion covariance estimation
-    diag_valid_ratio : float, optional
+    diag_valid_ratio : float, optional, default = 0.20
         Minimum fraction of valid samples required to compute a diagonal term
         in the sample covariance matrix entry R_ii.
     min_ev_valid_idx: int, optional
@@ -220,10 +220,10 @@ def compute_evd(
         True indicates valid samples. False indicates invalid samples or gaps.
         This is used only when prf_dither_mode=True.
         If None, an all-True mask is created.
-    off_diag_overlap_ratio : float, default=0.1
+    off_diag_overlap_ratio : float, default=0.25
         Minimum fraction of overlapping valid range samples required to compute
         an off-diagonal covariance term R_ij when prf_dither_mode=True.
-    diag_valid_ratio : float, default=0.05
+    diag_valid_ratio : float, default=0.20
         Minimum fraction of valid range samples required to compute
         a diagonal covariance term R_ii when prf_dither_mode=True.
 
@@ -286,10 +286,10 @@ def compute_gap_exclusion_cov(
     mask_valid_cpi: (num_pulses, num_rng_samples) bool array, optional
         True indicates valid samples. False indicates invalid samples or gaps.
         If None, an all true boolean mask is created. All samples are assumed to be valid.
-    off_diag_overlap_ratio: float
+    off_diag_overlap_ratio: float, default = 0.25
         Minimum fraction of overlapping valid range samples required to compute
         an off-diagonal term in the sample covariance matrix entry R_ij.
-    diag_valid_ratio : float, optional
+    diag_valid_ratio : float, optional, deffault = 0.20
         Minimum fraction of valid samples required to compute a diagonal term in the
         sample covariance matrix entry R_ii.
         

--- a/python/packages/isce3/signal/compute_evd_cpi.py
+++ b/python/packages/isce3/signal/compute_evd_cpi.py
@@ -78,7 +78,6 @@ def compute_evd_tb(
     raw_data: np.ndarray,
     *,
     cpi_len: int=16,
-    apply_gap_exclusion: bool=False,
     mask_valid: np.ndarray=None,
     off_diag_overlap_ratio: float=0.25,
     diag_valid_ratio: float=0.20,
@@ -98,13 +97,10 @@ def compute_evd_tb(
         Raw data to be processed
     cpi_len: int, optional
         Number of slow-time pulses within a CPI, default=16
-    apply_gap_exclusion: bool, optional, default = True
-        If True, CPI sample covariance matrix will be computed differently by excluding the
-        invalid data gaps.
     mask_valid : np.ndarray bool, [num_pulses x num_rng_samples], optional
-        Valid-sample mask with same shape as raw_data.
-        if apply_gap_exclusion is False, then mask_valid will be ignored, and standard
-        sample covariance matrix will be performed.
+        Valid-sample mask with same shape as raw_data.  If provided, CPI sample
+        covariance matrix will be computed differently by excluding the invalid
+        data gaps.
     off_diag_overlap_ratio : float, optional, default = 0.25
         Minimum overlap ratio used by gap exclusion covariance estimation
     diag_valid_ratio : float, optional, default = 0.20
@@ -162,12 +158,8 @@ def compute_evd_tb(
             "Since Python uses 0-based indexing, the maximum valid index is cpi_len - 1."
         )
 
-    # Verify that mask_valid is provided if apply_gap_exclusion is True
-    if apply_gap_exclusion and mask_valid is None:
-        raise ValueError("mask_valid must be provided if apply_gap_exclusion is True")
-
     # Verify TB Mask shape
-    if mask_valid.shape != raw_data.shape:
+    if (mask_valid is not None) and (mask_valid.shape != raw_data.shape):
         raise ValueError(f"Valid TB mask shape {mask_valid.shape} != TB data shape {raw_data.shape}")
     
     # Output Eigenvalues and Eigenvectors
@@ -181,10 +173,9 @@ def compute_evd_tb(
         slice_gen(num_pulses, cpi_len, combine_rem=False)
     ):
         data_cpi = raw_data[cpi_slow_time]
-        mask_valid_cpi = mask_valid[cpi_slow_time]
+        mask_valid_cpi = None if mask_valid is None else mask_valid[cpi_slow_time]
         eig_val_sort, eig_vec_sort = compute_evd(
             data_cpi,
-            apply_gap_exclusion=apply_gap_exclusion,
             mask_valid_cpi=mask_valid_cpi,
             off_diag_overlap_ratio=off_diag_overlap_ratio,
             diag_valid_ratio=diag_valid_ratio,
@@ -206,7 +197,6 @@ def compute_evd_tb(
 def compute_evd(
     raw_data: np.ndarray,
     *,
-    apply_gap_exclusion: bool = False,
     mask_valid_cpi: np.ndarray = None,
     off_diag_overlap_ratio: float = 0.25,
     diag_valid_ratio: float = 0.20,
@@ -217,19 +207,16 @@ def compute_evd(
     ----------
     raw_data : array-like complex [num_pulses x num_rng_samples]
         Raw data to be processed.
-    apply_gap_exclusion : bool, default=False
-        If True, CPI sample covariance matrix will be computed differently by excluding the
-        invalid data gaps.
     mask_valid_cpi : (num_pulses, num_rng_samples) bool array, optional
         True indicates valid samples. False indicates invalid samples or gaps.
-        This is used only when apply_gap_exclusion=True.
-        If None, an all-True mask is created.
+        If provided, CPI sample covariance matrix will be computed differently
+        by excluding the invalid data gaps.
     off_diag_overlap_ratio : float, default=0.25
         Minimum fraction of overlapping valid range samples required to compute
-        an off-diagonal covariance term R_ij if apply_gap_exclusion is True.
+        an off-diagonal covariance term R_ij if mask is provided.
     diag_valid_ratio : float, default=0.20
         Minimum fraction of valid range samples required to compute
-        a diagonal covariance term R_ii when apply_gap_exclusion is True.
+        a diagonal covariance term R_ii when mask is provided.
 
     Returns
     -------
@@ -247,10 +234,7 @@ def compute_evd(
     # Application in Narrow-Band Interference Suppression for SAR”, IEEE Geoscience 
     # and Remote Sensing Letters, vol. 4, no. 1, pp. 76,2007.
 
-    if apply_gap_exclusion:
-        if mask_valid_cpi is None:
-            raise ValueError("mask_valid_cpi must be provided when apply_gap_exclusion is True.")
-
+    if mask_valid_cpi is not None:
         mask_valid_cpi = mask_valid_cpi.astype(bool, copy=False)
 
         if mask_valid_cpi.shape != raw_data.shape:

--- a/python/packages/isce3/signal/compute_evd_cpi.py
+++ b/python/packages/isce3/signal/compute_evd_cpi.py
@@ -47,7 +47,6 @@ def slice_gen(total_size: int, batch_size: int, combine_rem: bool=True) -> Itera
             stop_idx = start_idx + batch_size
             yield slice(start_idx, stop_idx)
 
-
 def eigen_decomp_sort(cov_matrix):
     """Perform Eigenvaule Decomposition of Sample Covariance Matrix which is assumed 
     to be Hermitian, and sort Eigenvalues in descending order.  Re-arrange column 
@@ -76,47 +75,13 @@ def eigen_decomp_sort(cov_matrix):
 
     return eig_val_sort, eig_vec_sort
 
-def compute_evd(
-    raw_data: np.ndarray,
-):
-    """Perform Eigenvalue Decomposition along axis 0.
-
-    Parameters
-    ------------
-    raw_data: array-like complex [num_pulses x num_rng_samples]
-        raw data to be processed
-
-    Returns
-    --------
-    eig_val_sort: 1D array of float, same length as the number of rows of input matrix
-        Eigenvalues sorted in descending order
-    eig_vec_sort: 2D array of complex, same shape as input matrix
-        column vector Eigenvectors sorted based on index of sorted Eigenvalues
-    """
-
-    num_rng_samples = raw_data.shape[1]
-
-    # The raw_data is not necessarily zero-mean when it is corrupted by RFI.
-    # If so, estimated sample covariance matrix cov_cpi should be called 
-    # sample correlation  matrix instead.  The reference below demonstrates
-    # this concept and notation.
-
-    # F. Zhou, R. Wu, M. Xing, and Z. Bao, “Eigensubspace-Based Filtering With 
-    # Application in Narrow-Band Interference Suppression for SAR”, IEEE Geoscience 
-    # and Remote Sensing Letters, vol. 4, no. 1, pp. 76,2007.
-
-    cov_cpi = np.matmul(raw_data, np.conj(raw_data).transpose()) / num_rng_samples
-    eig_val_sort, eig_vec_sort = eigen_decomp_sort(cov_cpi)
-
-    return eig_val_sort, eig_vec_sort
-
 def compute_evd_tb(
     raw_data: np.ndarray,
     cpi_len: int=16,
-    prf_dither_mode: bool=False,
+    prf_dither_mode: bool=True,
     mask_valid: np.ndarray=None,
-    off_diag_overlap_ratio: float=0.1,
-    diag_valid_ratio: float=0.05,
+    off_diag_overlap_ratio: float=0.25,
+    diag_valid_ratio: float=0.20,
     min_ev_valid_idx: int=10,
     rx_dynamic_range_db: float=-50.0,
 ):
@@ -133,7 +98,7 @@ def compute_evd_tb(
         Raw data to be processed
     cpi_len: int, optional
         Number of slow-time pulses within a CPI, default=16
-    prf_dither_mode: bool, optional
+    prf_dither_mode: bool, optional, default = True
         If True, use gap-aware covariance estimation
     mask_valid : np.ndarray bool, [num_pulses x num_rng_samples], optional
         Valid-sample mask with same shape as raw_data. Required if
@@ -179,14 +144,14 @@ def compute_evd_tb(
     if num_rng_samples < rng_samples_min:
         raise ValueError(
             "Minimum number of samples in a range block to estimate Sample Covariance"
-            f" Matrix is {rng_samples_min}! Current number of samples per range block"
-            f" is {num_rng_samples}!"
+            f" Matrix is {rng_samples_min} per Reed-Mallet-Brennan Rule."
+            f"Current number of samples per range block is {num_rng_samples}!"
         )
 
     # Verify Total number of pulses is greater than CPI length
     if num_pulses < cpi_len:
         raise ValueError(
-            f"Coherent Processing Interval length exceeds total number of pulses {num_pulses}!"
+            f"Coherent Processing Interval length of {cpi_len} exceeds total number of pulses {num_pulses}!"
         )
 
     if min_ev_valid_idx >= cpi_len:
@@ -198,6 +163,10 @@ def compute_evd_tb(
     if prf_dither_mode and mask_valid is None:
         raise ValueError("mask_valid must be provided when prf_dither_mode=True")
 
+    # Verify TB Mask shape
+    if mask_valid.shape != raw_data.shape:
+        raise ValueError(f"Valid TB mask shape {mask_valid.shape} != TB data shape {raw_data.shape}")
+    
     # Output Eigenvalues and Eigenvectors
     eig_val_sort_array = np.zeros([num_cpi, cpi_len], dtype="f4")
     eig_vec_sort_array = np.zeros((num_cpi, cpi_len, cpi_len), dtype="complex64")
@@ -209,17 +178,14 @@ def compute_evd_tb(
         slice_gen(num_pulses, cpi_len, combine_rem=False)
     ):
         data_cpi = raw_data[cpi_slow_time]
-
-        if not prf_dither_mode:
-            eig_val_sort, eig_vec_sort = compute_evd(data_cpi)
-        else:
-            mask_valid_cpi = mask_valid[cpi_slow_time]
-            eig_val_sort, eig_vec_sort = compute_evd_gap(
-                data_cpi,
-                mask_valid_cpi=mask_valid_cpi,
-                off_diag_overlap_ratio=off_diag_overlap_ratio,
-                diag_valid_ratio=diag_valid_ratio,
-            )
+        mask_valid_cpi = mask_valid[cpi_slow_time]
+        eig_val_sort, eig_vec_sort = compute_evd(
+            data_cpi,
+            prf_dither_mode=prf_dither_mode,
+            mask_valid_cpi=mask_valid_cpi,
+            off_diag_overlap_ratio=off_diag_overlap_ratio,
+            diag_valid_ratio=diag_valid_ratio,
+        )
 
         # Verify if the eigenvalue of CPI at index defind by  noise_ev_idx is meaningful
         eig_val_sort_abs = np.maximum(np.abs(eig_val_sort), 1e-30)
@@ -234,37 +200,41 @@ def compute_evd_tb(
 
     return eig_val_sort_array, eig_vec_sort_array, tb_is_valid
 
-def compute_evd_gap(
+def compute_evd(
     raw_data: np.ndarray,
     *,
+    prf_dither_mode: bool = True,
     mask_valid_cpi: np.ndarray = None,
-    off_diag_overlap_ratio: float = 0.1,
-    diag_valid_ratio: float = 0.05, 
+    off_diag_overlap_ratio: float = 0.25,
+    diag_valid_ratio: float = 0.20,
 ):
     """Perform Eigenvalue Decomposition along axis 0.
 
     Parameters
-    ------------
-    raw_data: array-like complex [num_pulses x num_rng_samples]
-        raw data to be processed
-    mask_valid_cpi: (num_pulses, num_rng_samples) bool array, optional
+    ----------
+    raw_data : array-like complex [num_pulses x num_rng_samples]
+        Raw data to be processed.
+    prf_dither_mode : bool, default=True
+        If True, use gap-exclusion covariance for dithered-PRF data.
+        If False, use the standard sample covariance matrix.
+    mask_valid_cpi : (num_pulses, num_rng_samples) bool array, optional
         True indicates valid samples. False indicates invalid samples or gaps.
-        If None, an all true boolean mask is created. All samples are assumed to be valid.
-    off_diag_overlap_ratio: float
+        This is used only when prf_dither_mode=True.
+        If None, an all-True mask is created.
+    off_diag_overlap_ratio : float, default=0.1
         Minimum fraction of overlapping valid range samples required to compute
-        an off-diagonal term in the sample covariance matrix entry R_ij.
-    diag_valid_ratio : float, optional
-        Minimum fraction of valid samples required to compute a diagonal term in the
-        sample covariance matrix entry R_ii.
+        an off-diagonal covariance term R_ij when prf_dither_mode=True.
+    diag_valid_ratio : float, default=0.05
+        Minimum fraction of valid range samples required to compute
+        a diagonal covariance term R_ii when prf_dither_mode=True.
 
     Returns
-    --------
-    eig_val_sort: 1D array of float, same length as the number of rows of input matrix
-        Eigenvalues sorted in descending order
-    eig_vec_sort: 2D array of complex, same shape as input matrix
-        column vector Eigenvectors sorted based on index of sorted Eigenvalues
+    -------
+    eig_val_sort : 1D array of float
+        Eigenvalues sorted in descending order.
+    eig_vec_sort : 2D array of complex
+        Column eigenvectors sorted to match eig_val_sort.
     """
-
     # The raw_data is not necessarily zero-mean when it is corrupted by RFI.
     # If so, estimated sample covariance matrix cov_cpi should be called 
     # sample correlation  matrix instead.  The reference below demonstrates
@@ -274,30 +244,37 @@ def compute_evd_gap(
     # Application in Narrow-Band Interference Suppression for SAR”, IEEE Geoscience 
     # and Remote Sensing Letters, vol. 4, no. 1, pp. 76,2007.
 
-    if mask_valid_cpi is None:
-        mask_valid_cpi = np.ones(raw_data.shape, dtype=bool)
+    if prf_dither_mode:
+        if mask_valid_cpi is None:
+            mask_valid_cpi = np.ones(raw_data.shape, dtype=bool)
+        else:
+            mask_valid_cpi = mask_valid_cpi.astype(bool, copy=False)
 
-    if mask_valid_cpi.shape != raw_data.shape:
-        raise ValueError(f"mask shape {mask_valid_cpi.shape} != data shape {raw_data.shape}")
-    
-    cov_cpi = compute_gap_exclusion_cov(
-        raw_data, 
-        mask_valid_cpi=mask_valid_cpi, 
-        off_diag_overlap_ratio=off_diag_overlap_ratio,
-        diag_valid_ratio=diag_valid_ratio,
-    )
+        if mask_valid_cpi.shape != raw_data.shape:
+            raise ValueError(
+                f"CPI mask shape {mask_valid_cpi.shape} != CPI data shape {raw_data.shape}"
+            )
+
+        cov_cpi = compute_gap_exclusion_cov(
+            raw_data,
+            mask_valid_cpi=mask_valid_cpi,
+            off_diag_overlap_ratio=off_diag_overlap_ratio,
+            diag_valid_ratio=diag_valid_ratio,
+        )
+    else:
+        num_rng_samples = raw_data.shape[1]
+        cov_cpi = (raw_data @ raw_data.conj().T) / num_rng_samples
 
     eig_val_sort, eig_vec_sort = eigen_decomp_sort(cov_cpi)
 
     return eig_val_sort, eig_vec_sort
 
-
 def compute_gap_exclusion_cov(
     data: np.ndarray,
     *,
     mask_valid_cpi: np.ndarray = None,
-    off_diag_overlap_ratio: float = 0.2,
-    diag_valid_ratio: float = 0.15,
+    off_diag_overlap_ratio: float = 0.25,
+    diag_valid_ratio: float = 0.20,
 ):
     """
     Compute a gap-excluded slow-time sample covariance matrix.
@@ -341,6 +318,21 @@ def compute_gap_exclusion_cov(
     # Sample Covariance Matrix
     min_valid_off_diag = max(1, int(np.ceil(off_diag_overlap_ratio * num_rng_samples)))
     min_valid_diag = max(1, int(np.ceil(diag_valid_ratio * num_rng_samples))) 
+
+    rng_samples_min = 2 * num_pulses
+
+    if min_valid_off_diag < rng_samples_min:
+        warnings.warn(f"""
+            Minimum number of samples required per pulse to estimate sample covariance matrix
+            is {rng_samples_min}. The number of valid overlapping off-diagonal samples is
+            {min_valid_off_diag}.
+        """)
+
+    if min_valid_diag < rng_samples_min:
+        warnings.warn(f"""
+            Minimum number of samples required per pulse to estimate sample covariance matrix
+            is {rng_samples_min}. The number of valid diagonal samples is {min_valid_off_diag}.
+        """)
 
     # Zero-out invalid samples
     x_valid =  data * mask_valid_cpi

--- a/python/packages/isce3/signal/compute_evd_cpi.py
+++ b/python/packages/isce3/signal/compute_evd_cpi.py
@@ -186,11 +186,11 @@ def compute_evd_tb(
             diag_valid_ratio=diag_valid_ratio,
         )
 
-        # Verify if the eigenvalue of CPI at index defind by  noise_ev_idx is meaningful
+        # Verify if the eigenvalue of CPI at index defind by min_ev_valid_idx is meaningful
         eig_val_sort_abs = np.maximum(np.abs(eig_val_sort), 1e-30)
         noise_ev_norm_db = 10 * np.log10(eig_val_sort_abs[min_ev_valid_idx] / eig_val_sort_abs[0])
 
-        if noise_ev_norm_db < -rx_dynamic_range_db:
+        if -noise_ev_norm_db > rx_dynamic_range_db:
             tb_is_valid = False
             break
 
@@ -251,7 +251,7 @@ def compute_evd(
 
         if mask_valid_cpi.shape != raw_data.shape:
             raise ValueError(
-                f"CPI mask shape {mask_valid_cpi.shape} != CPI data shape {raw_data.shape}"
+                f"Valid CPI mask shape {mask_valid_cpi.shape} != CPI data shape {raw_data.shape}"
             )
 
         cov_cpi = compute_gap_exclusion_cov(
@@ -297,6 +297,11 @@ def compute_gap_exclusion_cov(
     -------
     cov : (num_pulses, num_pulses) complex64
         Gap-excluded sample covariance matrix.
+
+    Notes
+    -------
+    The number of range samples per purlse must be equal or larger than 2 x number of pulses 
+    to be processed in order to have a reliable sample covariance matrix estimate.
     """
 
     num_pulses, num_rng_samples = data.shape
@@ -305,7 +310,7 @@ def compute_gap_exclusion_cov(
         mask_valid_cpi = np.ones(data.shape, dtype=bool)
 
     if mask_valid_cpi.shape != data.shape:
-        raise ValueError(f"mask shape {mask_valid_cpi.shape} != data shape {data.shape}")
+        raise ValueError(f"CPI mask shape {mask_valid_cpi.shape} != CPI data shape {data.shape}")
 
     if not (0.0 <= off_diag_overlap_ratio <= 1.0):
         raise ValueError("off_diag_overlap_ratio must be between 0 and 1.")
@@ -318,6 +323,11 @@ def compute_gap_exclusion_cov(
     min_valid_off_diag = max(1, int(np.ceil(off_diag_overlap_ratio * num_rng_samples)))
     min_valid_diag = max(1, int(np.ceil(diag_valid_ratio * num_rng_samples))) 
 
+    # The number of range samples per purlse must be equal or larger than 2 x number of pulses
+    # to be processed in order to have a reliable sample covariance matrix estimate.
+    # However, sometimes we would like to explore the trade-off betweeen less number of samples
+    # to estimate sample covariance matrix and reduction of RFI artifact. Hence only a warning
+    # is raised.
     rng_samples_min = 2 * num_pulses
 
     if min_valid_off_diag < rng_samples_min:

--- a/python/packages/isce3/signal/compute_evd_cpi.py
+++ b/python/packages/isce3/signal/compute_evd_cpi.py
@@ -77,7 +77,7 @@ def eigen_decomp_sort(cov_matrix):
 def compute_evd_tb(
     raw_data: np.ndarray,
     cpi_len: int=16,
-    prf_dither_mode: bool=True,
+    apply_gap_exclusion: bool=False,
     mask_valid: np.ndarray=None,
     off_diag_overlap_ratio: float=0.25,
     diag_valid_ratio: float=0.20,
@@ -97,11 +97,13 @@ def compute_evd_tb(
         Raw data to be processed
     cpi_len: int, optional
         Number of slow-time pulses within a CPI, default=16
-    prf_dither_mode: bool, optional, default = True
-        If True, use gap-aware covariance estimation
+    apply_gap_exclusion: bool, optional, default = True
+        If True, CPI sample covariance matrix will be computed differently by excluding the
+        invalid data gaps.
     mask_valid : np.ndarray bool, [num_pulses x num_rng_samples], optional
-        Valid-sample mask with same shape as raw_data. Required if
-        prf_dither_mode=True.
+        Valid-sample mask with same shape as raw_data.
+        if apply_gap_exclusion is False, then mask_valid will be ignored, and standard
+        sample covariance matrix will be performed.
     off_diag_overlap_ratio : float, optional, default = 0.25
         Minimum overlap ratio used by gap exclusion covariance estimation
     diag_valid_ratio : float, optional, default = 0.20
@@ -159,8 +161,9 @@ def compute_evd_tb(
             "Since Python uses 0-based indexing, the maximum valid index is cpi_len - 1."
         )
 
-    if prf_dither_mode and mask_valid is None:
-        raise ValueError("mask_valid must be provided when prf_dither_mode=True")
+    # Verify that mask_valid is provided if apply_gap_exclusion is True
+    if apply_gap_exclusion and mask_valid is None:
+        raise ValueError("mask_valid must be provided if apply_gap_exclusion is True")
 
     # Verify TB Mask shape
     if mask_valid.shape != raw_data.shape:
@@ -180,7 +183,7 @@ def compute_evd_tb(
         mask_valid_cpi = mask_valid[cpi_slow_time]
         eig_val_sort, eig_vec_sort = compute_evd(
             data_cpi,
-            prf_dither_mode=prf_dither_mode,
+            apply_gap_exclusion=apply_gap_exclusion,
             mask_valid_cpi=mask_valid_cpi,
             off_diag_overlap_ratio=off_diag_overlap_ratio,
             diag_valid_ratio=diag_valid_ratio,
@@ -202,7 +205,7 @@ def compute_evd_tb(
 def compute_evd(
     raw_data: np.ndarray,
     *,
-    prf_dither_mode: bool = True,
+    apply_gap_exclusion: bool = False,
     mask_valid_cpi: np.ndarray = None,
     off_diag_overlap_ratio: float = 0.25,
     diag_valid_ratio: float = 0.20,
@@ -213,19 +216,19 @@ def compute_evd(
     ----------
     raw_data : array-like complex [num_pulses x num_rng_samples]
         Raw data to be processed.
-    prf_dither_mode : bool, default=True
-        If True, use gap-exclusion covariance for dithered-PRF data.
-        If False, use the standard sample covariance matrix.
+    apply_gap_exclusion : bool, default=False
+        If True, CPI sample covariance matrix will be computed differently by excluding the
+        invalid data gaps.
     mask_valid_cpi : (num_pulses, num_rng_samples) bool array, optional
         True indicates valid samples. False indicates invalid samples or gaps.
-        This is used only when prf_dither_mode=True.
+        This is used only when apply_gap_exclusion=True.
         If None, an all-True mask is created.
     off_diag_overlap_ratio : float, default=0.25
         Minimum fraction of overlapping valid range samples required to compute
-        an off-diagonal covariance term R_ij when prf_dither_mode=True.
+        an off-diagonal covariance term R_ij if apply_gap_exclusion is True.
     diag_valid_ratio : float, default=0.20
         Minimum fraction of valid range samples required to compute
-        a diagonal covariance term R_ii when prf_dither_mode=True.
+        a diagonal covariance term R_ii when apply_gap_exclusion is True.
 
     Returns
     -------
@@ -243,11 +246,11 @@ def compute_evd(
     # Application in Narrow-Band Interference Suppression for SAR”, IEEE Geoscience 
     # and Remote Sensing Letters, vol. 4, no. 1, pp. 76,2007.
 
-    if prf_dither_mode:
+    if apply_gap_exclusion:
         if mask_valid_cpi is None:
-            mask_valid_cpi = np.ones(raw_data.shape, dtype=bool)
-        else:
-            mask_valid_cpi = mask_valid_cpi.astype(bool, copy=False)
+            raise ValueError("mask_valid_cpi must be provided when apply_gap_exclusion is True.")
+
+        mask_valid_cpi = mask_valid_cpi.astype(bool, copy=False)
 
         if mask_valid_cpi.shape != raw_data.shape:
             raise ValueError(
@@ -267,6 +270,7 @@ def compute_evd(
     eig_val_sort, eig_vec_sort = eigen_decomp_sort(cov_cpi)
 
     return eig_val_sort, eig_vec_sort
+
 
 def compute_gap_exclusion_cov(
     data: np.ndarray,

--- a/python/packages/isce3/signal/compute_evd_cpi.py
+++ b/python/packages/isce3/signal/compute_evd_cpi.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import numpy as np
 from numpy import linalg as la
 from collections.abc import Iterator
-import copy
 import warnings
 
 def slice_gen(total_size: int, batch_size: int, combine_rem: bool=True) -> Iterator[slice]:

--- a/python/packages/isce3/signal/compute_evd_cpi.py
+++ b/python/packages/isce3/signal/compute_evd_cpi.py
@@ -118,7 +118,7 @@ def compute_evd_tb(
     off_diag_overlap_ratio: float=0.1,
     diag_valid_ratio: float=0.05,
     min_ev_valid_idx: int=10,
-    rx_dynamic_range_db: int=-50,
+    rx_dynamic_range_db: float=-50.0,
 ):
     """Divide input raw data equivalent to a threshold block into Coherent
     Processing Intervals (CPI) with respect to axis=0 and perform Eigenvalue

--- a/python/packages/isce3/signal/compute_evd_cpi.py
+++ b/python/packages/isce3/signal/compute_evd_cpi.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import numpy as np
 from numpy import linalg as la
 from collections.abc import Iterator
+import copy
+import warnings
 
 def slice_gen(total_size: int, batch_size: int, combine_rem: bool=True) -> Iterator[slice]:
     """Generate slices with size defined by batch_size.
@@ -73,7 +75,6 @@ def eigen_decomp_sort(cov_matrix):
     eig_vec_sort = eig_vec[:, ::-1]
 
     return eig_val_sort, eig_vec_sort
-
 
 def compute_evd(
     raw_data: np.ndarray,
@@ -160,6 +161,7 @@ def compute_evd_tb(
     eig_val_sort_array = np.zeros([num_cpi, cpi_len], dtype="f4")
     eig_vec_sort_array = np.zeros((num_cpi, cpi_len, cpi_len), dtype="complex64")
 
+    # Compute Eigenvalue and Eigenvector pairs for each CPI
     for idx_cpi, cpi_slow_time in enumerate(slice_gen(num_pulses, cpi_len, combine_rem=False)):
         data_cpi = raw_data[cpi_slow_time]
 
@@ -168,3 +170,247 @@ def compute_evd_tb(
         eig_vec_sort_array[idx_cpi] = eig_vec_sort
 
     return eig_val_sort_array, eig_vec_sort_array
+
+
+def compute_evd_tb_gap(
+    raw_data: np.ndarray,
+    mask_valid: np.ndarray,
+    cpi_len=32,
+    off_diag_overlap_ratio: float=0.1,
+    diag_valid_ratio: float=0.05,
+    noise_ev_idx: int=10
+):
+    """Divide input raw data equivalent to a threshold block into data blocks 
+    or Coherent Processing Intervals (CPI) with resepct to axis=0 and perform 
+    Eigenvalue Decomposition for all CPIs for data with gaps of invalid data samples
+
+    Parameters
+    ------------
+    raw_data: array-like complex [num_pulses x num_rng_samples]
+        raw data to be processed
+    mask_valid : np.ndarray bool, [num_pulses x num_rng_samples]
+        Valid-sample mask with same shape as raw_data
+    cpi_len: int, optional
+        Number of slow-time pulses within a CPI, default=32
+    off_diag_overlap_ratio : float, optional
+        Minimum overlap ratio used by gap exclusion covariance estimation
+    diag_valid_ratio : float, optional
+        Minimum fraction of valid samples required to compute a diagonal term in the
+        sample covariance matrix entry R_ii.
+    noise_ev_idx : int, optional
+        Eigenvalue index used by threshold estimation to estimate the slow-time minimum
+        Eigenvalue slope
+
+    Returns
+    --------
+    eig_val_sort_array: 2D array of float with dimension [num_cpi x cpi_len]
+        Eigenvalues of all CPIs sorted in descending order
+    eig_vec_sort_array: 3D array of complex with dimension [num_cpi x cpi_len x cpi_len]
+        Sorted column vector Eigenvectors of all CPIs based on index of sorted Eigenvalues
+    tb_is_valid : bool
+        False if any CPI in the threshold block does not have enough usable
+        eigenvalues for noise_ev_idx
+    """
+
+    # compute number of CPIs
+    num_pulses, num_rng_samples = raw_data.shape
+    num_cpi = num_pulses // cpi_len
+
+    # Minimum number of range samples to estimate Sample Correlation Matrix L:
+    # L ~ 2 * cpi_len
+    # Reference: Space Time Adaptive Processing for Radar, Artech House, pp33
+    rng_samples_min = 2 * cpi_len
+
+    # Verify number of range samples in raw data is greater than minimum needed
+    # to estimate Sample Covariance Matrix
+    if num_rng_samples < rng_samples_min:
+        raise ValueError(
+            "Minimum number of samples in a range block to estimate Sample Covariance"
+            f" Matrix is {rng_samples_min}! Current number of samples per range block"
+            f" is {num_rng_samples}!"
+        )
+
+    # Verify Total number of pulses is greater than CPI length
+    if num_pulses < cpi_len:
+        raise ValueError(
+            f"Coherent Processing Interval length exceeds total number of pulses {num_pulses}!"
+        )
+
+    # Output Eigenvalues and Eigenvectors
+    eig_val_sort_array = np.zeros([num_cpi, cpi_len], dtype="f4")
+    eig_vec_sort_array = np.zeros((num_cpi, cpi_len, cpi_len), dtype="complex64")
+
+    tb_is_valid = True
+
+    for idx_cpi, cpi_slow_time in enumerate(slice_gen(num_pulses, cpi_len, combine_rem=False)):
+        data_cpi = raw_data[cpi_slow_time]
+
+        # Compute CPI-wise gap mask
+        mask_valid_cpi = mask_valid[cpi_slow_time]
+        eig_val_sort, eig_vec_sort = compute_evd_gap(
+            data_cpi, 
+            mask_valid_cpi=mask_valid_cpi, 
+            off_diag_overlap_ratio=off_diag_overlap_ratio,
+            diag_valid_ratio=diag_valid_ratio,
+        )
+
+        # Count number of usable eigenvalues of CPI and compare with chosen noise_ev_idx.
+        # Since Python uses 0-based indexing, a CPI must have at least noise_ev_idx + 1 usable
+        # eigenvalues.
+        # Abnormal small Eigenvalues in general occur only at the tail of the sorted
+        # Eigenvalues.  Zero Eigenvalues are replaced by a small epsilon, 1e-30 to 
+        # ensure log values of such are greater than zero.
+        eig_val_sort_db = 10*np.log10(np.maximum(np.abs(eig_val_sort), 1e-30))
+        usable_rank = int(np.count_nonzero(eig_val_sort_db > 0))
+
+        if usable_rank < noise_ev_idx + 1:
+            tb_is_valid = False
+            warnings.warn(
+                f"Skipping threshold block: This CPI has only "
+                f"{usable_rank} usable Eigenvalues, but noise_ev_idx = {noise_ev_idx} "
+                f"requires at least {noise_ev_idx + 1} valid Eigenvalues."
+            )
+            break
+
+        eig_val_sort_array[idx_cpi] = eig_val_sort
+        eig_vec_sort_array[idx_cpi] = eig_vec_sort
+
+    return eig_val_sort_array, eig_vec_sort_array, tb_is_valid
+
+
+def compute_evd_gap(
+    raw_data: np.ndarray,
+    *,
+    mask_valid_cpi: np.ndarray = None,
+    off_diag_overlap_ratio: float = 0.1,
+    diag_valid_ratio: float = 0.05, 
+):
+    """Perform Eigenvalue Decomposition along axis 0.
+
+    Parameters
+    ------------
+    raw_data: array-like complex [num_pulses x num_rng_samples]
+        raw data to be processed
+    mask_valid_cpi: (num_pulses, num_rng_samples) bool array, optional
+        True indicates valid samples. False indicates invalid samples or gaps.
+        If None, an all true boolean mask is created. All samples are assumed to be valid.
+    off_diag_overlap_ratio: float
+        Minimum fraction of overlapping valid range samples required to compute
+        an off-diagonal term in the sample covariance matrix entry R_ij.
+    diag_valid_ratio : float, optional
+        Minimum fraction of valid samples required to compute a diagonal term in the
+        sample covariance matrix entry R_ii.
+
+    Returns
+    --------
+    eig_val_sort: 1D array of float, same length as the number of rows of input matrix
+        Eigenvalues sorted in descending order
+    eig_vec_sort: 2D array of complex, same shape as input matrix
+        column vector Eigenvectors sorted based on index of sorted Eigenvalues
+    """
+
+    # The raw_data is not necessarily zero-mean when it is corrupted by RFI.
+    # If so, estimated sample covariance matrix cov_cpi should be called 
+    # sample correlation  matrix instead.  The reference below demonstrates
+    # this concept and notation.
+
+    # F. Zhou, R. Wu, M. Xing, and Z. Bao, “Eigensubspace-Based Filtering With 
+    # Application in Narrow-Band Interference Suppression for SAR”, IEEE Geoscience 
+    # and Remote Sensing Letters, vol. 4, no. 1, pp. 76,2007.
+
+    if mask_valid_cpi is None:
+        mask_valid_cpi = np.ones(raw_data.shape, dtype=bool)
+
+    if mask_valid_cpi.shape != raw_data.shape:
+        raise ValueError(f"mask shape {mask_valid_cpi.shape} != data shape {raw_data.shape}")
+    
+    cov_cpi = compute_gap_exclusion_cov(
+        raw_data, 
+        mask_valid_cpi=mask_valid_cpi, 
+        off_diag_overlap_ratio=off_diag_overlap_ratio,
+        diag_valid_ratio=diag_valid_ratio,
+    )
+
+    eig_val_sort, eig_vec_sort = eigen_decomp_sort(cov_cpi)
+
+    return eig_val_sort, eig_vec_sort
+
+
+def compute_gap_exclusion_cov(
+    data: np.ndarray,
+    *,
+    mask_valid_cpi: np.ndarray = None,
+    off_diag_overlap_ratio: float = 0.1,
+    diag_valid_ratio: float = 0.05,
+):
+    """
+    Compute a gap-excluded slow-time sample covariance matrix.
+
+    Parameters
+    ----------
+    data: (num_pulses, num_rng_samples) complex array
+        Slow-time block: K pulses x M range samples.
+        Pulses should be contiguous in slow time for ST-EVD.
+    mask_valid_cpi: (num_pulses, num_rng_samples) bool array, optional
+        True indicates valid samples. False indicates invalid samples or gaps.
+        If None, an all true boolean mask is created. All samples are assumed to be valid.
+    off_diag_overlap_ratio: float
+        Minimum fraction of overlapping valid range samples required to compute
+        an off-diagonal term in the sample covariance matrix entry R_ij.
+    diag_valid_ratio : float, optional
+        Minimum fraction of valid samples required to compute a diagonal term in the
+        sample covariance matrix entry R_ii.
+        
+    Returns
+    -------
+    cov : (num_pulses, num_pulses) complex64
+        Gap-excluded sample covariance matrix.
+    """
+
+    num_pulses, num_rng_samples = data.shape
+
+    if mask_valid_cpi is None:
+        mask_valid_cpi = np.ones(data.shape, dtype=bool)
+
+    if mask_valid_cpi.shape != data.shape:
+        raise ValueError(f"mask shape {mask_valid_cpi.shape} != data shape {data.shape}")
+
+    if not (0.0 <= off_diag_overlap_ratio <= 1.0):
+        raise ValueError("off_diag_overlap_ratio must be between 0 and 1.")
+
+    if not (0.0 <= diag_valid_ratio <= 1.0):
+        raise ValueError("diag_valid_ratio must be between 0 and 1.")
+
+    # Minimum Samples required to compute diagonal and off-diagonal terms of
+    # Sample Covariance Matrix
+    min_valid_off_diag = int(off_diag_overlap_ratio * num_rng_samples)
+    min_valid_diag = int(diag_valid_ratio * num_rng_samples) 
+
+    cov = np.zeros((num_pulses, num_pulses), dtype=np.complex64)
+
+    for i in range(num_pulses):
+        # Compute Diagonal terms
+        valid_pulse = mask_valid_cpi[i]
+        num_valid_samples_pulse = int(valid_pulse.sum())
+
+        if num_valid_samples_pulse >= min_valid_diag:
+            pulse_i = data[i, valid_pulse]
+            cov[i, i] = np.vdot(pulse_i, pulse_i) / num_valid_samples_pulse
+        else:
+            cov[i, i] = 0.0
+
+        # Compute Off-diagonal terms
+        for j in range(i + 1, num_pulses):
+            valid_overlap = mask_valid_cpi[i] & mask_valid_cpi[j]
+            num_overlap_adjacent = int(valid_overlap.sum())
+
+            if num_overlap_adjacent >= min_valid_off_diag:
+                cov_off_diag = np.vdot(data[j, valid_overlap], data[i, valid_overlap]) / num_overlap_adjacent
+                cov[i, j] = cov_off_diag
+                cov[j, i] = np.conj(cov_off_diag)
+
+    # Ensure Hermitian
+    cov = 0.5 * (cov + cov.conj().T)
+    
+    return cov
+

--- a/python/packages/isce3/signal/compute_evd_cpi.py
+++ b/python/packages/isce3/signal/compute_evd_cpi.py
@@ -76,6 +76,7 @@ def eigen_decomp_sort(cov_matrix):
 
 def compute_evd_tb(
     raw_data: np.ndarray,
+    *,
     cpi_len: int=16,
     apply_gap_exclusion: bool=False,
     mask_valid: np.ndarray=None,

--- a/python/packages/isce3/signal/compute_evd_cpi.py
+++ b/python/packages/isce3/signal/compute_evd_cpi.py
@@ -383,34 +383,54 @@ def compute_gap_exclusion_cov(
 
     # Minimum Samples required to compute diagonal and off-diagonal terms of
     # Sample Covariance Matrix
-    min_valid_off_diag = int(off_diag_overlap_ratio * num_rng_samples)
-    min_valid_diag = int(diag_valid_ratio * num_rng_samples) 
+    min_valid_off_diag = max(1, int(np.ceil(off_diag_overlap_ratio * num_rng_samples)))
+    min_valid_diag = max(1, int(np.ceil(diag_valid_ratio * num_rng_samples))) 
 
+    # Zero-out invalid samples
+    x_valid =  data * mask_valid_cpi
+
+    # Count valid sample overalp count for each element of the
+    # sample covariance matrix
+    mask_int = mask_valid_cpi.astype(np.int32)
+    overlap_counts = mask_int @ mask_int.T  # shape (pulse x pulse)
+
+    # Sum of conjugate products over overlapping valid samples
+    # without proper normalization
+    cov_sum = x_valid @ x_valid.conj().T
+
+    # Initialize gap-excluded sample covariance matrix
     cov = np.zeros((num_pulses, num_pulses), dtype=np.complex64)
 
-    for i in range(num_pulses):
-        # Compute Diagonal terms
-        valid_pulse = mask_valid_cpi[i]
-        num_valid_samples_pulse = int(valid_pulse.sum())
+    #Count number of valid in diagonal and off-diagonal for normalization
 
-        if num_valid_samples_pulse >= min_valid_diag:
-            pulse_i = data[i, valid_pulse]
-            cov[i, i] = np.vdot(pulse_i, pulse_i) / num_valid_samples_pulse
-        else:
-            cov[i, i] = 0.0
+    # Diagonal terms: Generate Diagonal indices
+    diag_idx = np.diag_indices(num_pulses)
+ 
+    # Extract the number of valid samples of diagonal terms
+    diag_counts = overlap_counts[diag_idx]
 
-        # Compute Off-diagonal terms
-        for j in range(i + 1, num_pulses):
-            valid_overlap = mask_valid_cpi[i] & mask_valid_cpi[j]
-            num_overlap_adjacent = int(valid_overlap.sum())
+    # Extract the uncorrected diagonal values
+    diag_cov_sum = cov_sum[diag_idx]
 
-            if num_overlap_adjacent >= min_valid_off_diag:
-                cov_off_diag = np.vdot(data[j, valid_overlap], data[i, valid_overlap]) / num_overlap_adjacent
-                cov[i, j] = cov_off_diag
-                cov[j, i] = np.conj(cov_off_diag)
+    # Check if there are enough valid samples
+    diag_valid_idx = diag_counts >= min_valid_diag
 
-    # Ensure Hermitian
-    cov = 0.5 * (cov + cov.conj().T)
+    diag_vals = np.zeros(num_pulses, dtype=np.complex64)
+
+    # Normalize the diagonal terms
+    diag_vals[diag_valid_idx] = diag_cov_sum[diag_valid_idx] / diag_counts[diag_valid_idx]
+    cov[diag_idx] = diag_vals
+
+    # Off-diagonal: Verify if there are enough valid samples for off-diagonal terms
+    off_diag_valid = overlap_counts >= min_valid_off_diag
     
-    return cov
+    # Mask out diagonal terms of the off_diagonal_valid matrix
+    np.fill_diagonal(off_diag_valid, False)
 
+    # Normalize the off-diagonal terms
+    cov[off_diag_valid] = cov_sum[off_diag_valid] / overlap_counts[off_diag_valid]
+
+    # Ensure Hermitian numerically
+    cov = (0.5 * (cov + cov.conj().T)).astype(np.complex64)
+
+    return cov

--- a/python/packages/isce3/signal/compute_evd_cpi.py
+++ b/python/packages/isce3/signal/compute_evd_cpi.py
@@ -117,7 +117,8 @@ def compute_evd_tb(
     mask_valid: np.ndarray=None,
     off_diag_overlap_ratio: float=0.1,
     diag_valid_ratio: float=0.05,
-    noise_ev_idx: int=10,
+    min_ev_valid_idx: int=10,
+    rx_dynamic_range_db: int=-50,
 ):
     """Divide input raw data equivalent to a threshold block into Coherent
     Processing Intervals (CPI) with respect to axis=0 and perform Eigenvalue
@@ -142,9 +143,14 @@ def compute_evd_tb(
     diag_valid_ratio : float, optional
         Minimum fraction of valid samples required to compute a diagonal term
         in the sample covariance matrix entry R_ii.
-    noise_ev_idx : int, optional
-        Eigenvalue index used by threshold estimation to estimate the slow-time
-        minimum Eigenvalue slope.
+    min_ev_valid_idx: int, optional
+        Eigenvalue index used by threshold estimation to estimate the slow-time minimum
+        Eigenvalue slope. This parameter is also used to validate that the threshold block
+        has enough usable eigenvalues for robust sample covaraince estimation of a CPI.
+    rx_dynamic_range_db: int, optional
+        radar platform receiver dynamic range, e.g. -50 dB. This is applied as a threshold
+        to determine if the Eigenvalue under test is meaningfully signficant. If the
+        Eigenvalue under test is less than this threshold, it will be viewed as unusable.
 
     Returns
     --------
@@ -155,8 +161,8 @@ def compute_evd_tb(
         Sorted column vector Eigenvectors of all CPIs based on index of sorted
         Eigenvalues
     tb_is_valid : bool
-        False if any CPI in the threshold block does not have enough usable
-        eigenvalues for noise_ev_idx.
+        False if any CPI in the threshold block lacks sufficient usable Eigenvalues,
+        determined by checking whether the Eigenvalue at min_ev_valid_idx is meaningful.
     """
 
     # compute number of CPIs
@@ -183,9 +189,9 @@ def compute_evd_tb(
             f"Coherent Processing Interval length exceeds total number of pulses {num_pulses}!"
         )
 
-    if noise_ev_idx >= cpi_len:
+    if min_ev_valid_idx >= cpi_len:
         raise ValueError(
-            f"noise_ev_idx ({noise_ev_idx}) must be less than cpi_len ({cpi_len}). "
+            f"min_ev_valid_idx ({min_ev_valid_idx}) must be less than cpi_len ({cpi_len}). "
             "Since Python uses 0-based indexing, the maximum valid index is cpi_len - 1."
         )
 
@@ -216,11 +222,10 @@ def compute_evd_tb(
             )
 
         # Verify if the eigenvalue of CPI at index defind by  noise_ev_idx is meaningful
-        eig_val_abs = np.maximum(np.abs(eig_val_sort), 1e-30)
-        noise_ev_rel_db = 10 * np.log10(eig_val_abs[noise_ev_idx] / eig_val_abs[0])
-        rel_ev_thresh_db = -30
+        eig_val_sort_abs = np.maximum(np.abs(eig_val_sort), 1e-30)
+        noise_ev_norm_db = 10 * np.log10(eig_val_sort_abs[min_ev_valid_idx] / eig_val_sort_abs[0])
 
-        if noise_ev_rel_db < rel_ev_thresh_db:
+        if noise_ev_norm_db < rx_dynamic_range_db:
             tb_is_valid = False
             break
 
@@ -291,8 +296,8 @@ def compute_gap_exclusion_cov(
     data: np.ndarray,
     *,
     mask_valid_cpi: np.ndarray = None,
-    off_diag_overlap_ratio: float = 0.1,
-    diag_valid_ratio: float = 0.05,
+    off_diag_overlap_ratio: float = 0.2,
+    diag_valid_ratio: float = 0.15,
 ):
     """
     Compute a gap-excluded slow-time sample covariance matrix.

--- a/python/packages/isce3/signal/compute_evd_cpi.py
+++ b/python/packages/isce3/signal/compute_evd_cpi.py
@@ -82,7 +82,7 @@ def compute_evd_tb(
     off_diag_overlap_ratio: float=0.25,
     diag_valid_ratio: float=0.20,
     min_ev_valid_idx: int=10,
-    rx_dynamic_range_db: float=-50.0,
+    rx_dynamic_range_db: float=50.0,
 ):
     """Divide input raw data equivalent to a threshold block into Coherent
     Processing Intervals (CPI) with respect to axis=0 and perform Eigenvalue
@@ -111,8 +111,8 @@ def compute_evd_tb(
         Eigenvalue index used by threshold estimation to estimate the slow-time minimum
         Eigenvalue slope. This parameter is also used to validate that the threshold block
         has enough usable eigenvalues for robust sample covaraince estimation of a CPI.
-    rx_dynamic_range_db: int, optional
-        radar platform receiver dynamic range, e.g. -50 dB. This is applied as a threshold
+    rx_dynamic_range_db: int, optional, default = 50 dB
+        Radar platform receiver dynamic range. This is applied as a threshold
         to determine if the Eigenvalue under test is meaningfully signficant. If the
         Eigenvalue under test is less than this threshold, it will be viewed as unusable.
 
@@ -190,7 +190,7 @@ def compute_evd_tb(
         eig_val_sort_abs = np.maximum(np.abs(eig_val_sort), 1e-30)
         noise_ev_norm_db = 10 * np.log10(eig_val_sort_abs[min_ev_valid_idx] / eig_val_sort_abs[0])
 
-        if noise_ev_norm_db < rx_dynamic_range_db:
+        if noise_ev_norm_db < -rx_dynamic_range_db:
             tb_is_valid = False
             break
 

--- a/python/packages/isce3/signal/compute_evd_cpi.py
+++ b/python/packages/isce3/signal/compute_evd_cpi.py
@@ -112,104 +112,51 @@ def compute_evd(
 
 def compute_evd_tb(
     raw_data: np.ndarray,
-    cpi_len=32,
-):
-    """Divide input raw data equivalent to a threshold block into data blocks 
-    or Coherent Processing Intervals (CPI) with resepct to axis=0 and perform 
-    Eigenvalue Decomposition for all CPIs.
-
-    Parameters
-    ------------
-    raw_data: array-like complex [num_pulses x num_rng_samples]
-        raw data to be processed
-    cpi_len: int, optional
-        Number of slow-time pulses within a CPI, default=32
-
-    Returns
-    --------
-    eig_val_sort_array: 2D array of float with dimension [num_cpi x cpi_len]
-        Eigenvalues of all CPIs sorted in descending order
-    eig_vec_sort_array: 3D array of complex with dimension [num_cpi x cpi_len x cpi_len]
-        Sorted column vector Eigenvectors of all CPIs based on index of sorted Eigenvalues
-    """
-
-    # compute number of CPIs
-    num_pulses, num_rng_samples = raw_data.shape
-    num_cpi = num_pulses // cpi_len
-
-    # Minimum number of range samples to estimate Sample Correlation Matrix L:
-    # L ~ 2 * cpi_len
-    # Reference: Space Time Adaptive Processing for Radar, Artech House, pp33
-    rng_samples_min = 2 * cpi_len
-
-    # Verify number of range samples in raw data is greater than minimum needed
-    # to estimate Sample Covariance Matrix
-    if num_rng_samples < rng_samples_min:
-        raise ValueError(
-            "Minimum number of samples in a range block to estimate Sample Covariance"
-            f" Matrix is {rng_samples_min}! Current number of samples per range block"
-            f" is {num_rng_samples}!"
-        )
-
-    # Verify Total number of pulses is greater than CPI length
-    if num_pulses < cpi_len:
-        raise ValueError(
-            f"Coherent Processing Interval length exceeds total number of pulses {num_pulses}!"
-        )
-
-    # Output Eigenvalues and Eigenvectors
-    eig_val_sort_array = np.zeros([num_cpi, cpi_len], dtype="f4")
-    eig_vec_sort_array = np.zeros((num_cpi, cpi_len, cpi_len), dtype="complex64")
-
-    # Compute Eigenvalue and Eigenvector pairs for each CPI
-    for idx_cpi, cpi_slow_time in enumerate(slice_gen(num_pulses, cpi_len, combine_rem=False)):
-        data_cpi = raw_data[cpi_slow_time]
-
-        eig_val_sort, eig_vec_sort = compute_evd(data_cpi)
-        eig_val_sort_array[idx_cpi] = eig_val_sort
-        eig_vec_sort_array[idx_cpi] = eig_vec_sort
-
-    return eig_val_sort_array, eig_vec_sort_array
-
-
-def compute_evd_tb_gap(
-    raw_data: np.ndarray,
-    mask_valid: np.ndarray,
-    cpi_len=32,
+    cpi_len: int=16,
+    prf_dither_mode: bool=False,
+    mask_valid: np.ndarray=None,
     off_diag_overlap_ratio: float=0.1,
     diag_valid_ratio: float=0.05,
-    noise_ev_idx: int=10
+    noise_ev_idx: int=10,
 ):
-    """Divide input raw data equivalent to a threshold block into data blocks 
-    or Coherent Processing Intervals (CPI) with resepct to axis=0 and perform 
-    Eigenvalue Decomposition for all CPIs for data with gaps of invalid data samples
+    """Divide input raw data equivalent to a threshold block into Coherent
+    Processing Intervals (CPI) with respect to axis=0 and perform Eigenvalue
+    Decomposition for all CPIs.
+
+    For constant-PRF data, standard EVD is used. For dithered-PRF data, gap-exclusion 
+    EVD is used. CPI validity is always checked.
 
     Parameters
     ------------
     raw_data: array-like complex [num_pulses x num_rng_samples]
-        raw data to be processed
-    mask_valid : np.ndarray bool, [num_pulses x num_rng_samples]
-        Valid-sample mask with same shape as raw_data
+        Raw data to be processed
     cpi_len: int, optional
-        Number of slow-time pulses within a CPI, default=32
+        Number of slow-time pulses within a CPI, default=16
+    prf_dither_mode: bool, optional
+        If True, use gap-aware covariance estimation
+    mask_valid : np.ndarray bool, [num_pulses x num_rng_samples], optional
+        Valid-sample mask with same shape as raw_data. Required if
+        prf_dither_mode=True.
     off_diag_overlap_ratio : float, optional
         Minimum overlap ratio used by gap exclusion covariance estimation
     diag_valid_ratio : float, optional
-        Minimum fraction of valid samples required to compute a diagonal term in the
-        sample covariance matrix entry R_ii.
+        Minimum fraction of valid samples required to compute a diagonal term
+        in the sample covariance matrix entry R_ii.
     noise_ev_idx : int, optional
-        Eigenvalue index used by threshold estimation to estimate the slow-time minimum
-        Eigenvalue slope
+        Eigenvalue index used by threshold estimation to estimate the slow-time
+        minimum Eigenvalue slope.
 
     Returns
     --------
     eig_val_sort_array: 2D array of float with dimension [num_cpi x cpi_len]
         Eigenvalues of all CPIs sorted in descending order
-    eig_vec_sort_array: 3D array of complex with dimension [num_cpi x cpi_len x cpi_len]
-        Sorted column vector Eigenvectors of all CPIs based on index of sorted Eigenvalues
+    eig_vec_sort_array: 3D array of complex with dimension
+        [num_cpi x cpi_len x cpi_len]
+        Sorted column vector Eigenvectors of all CPIs based on index of sorted
+        Eigenvalues
     tb_is_valid : bool
         False if any CPI in the threshold block does not have enough usable
-        eigenvalues for noise_ev_idx
+        eigenvalues for noise_ev_idx.
     """
 
     # compute number of CPIs
@@ -235,6 +182,15 @@ def compute_evd_tb_gap(
         raise ValueError(
             f"Coherent Processing Interval length exceeds total number of pulses {num_pulses}!"
         )
+
+    if noise_ev_idx >= cpi_len:
+        raise ValueError(
+            f"noise_ev_idx ({noise_ev_idx}) must be less than cpi_len ({cpi_len}). "
+            "Since Python uses 0-based indexing, the maximum valid index is cpi_len - 1."
+        )
+
+    if prf_dither_mode and mask_valid is None:
+        raise ValueError("mask_valid must be provided when prf_dither_mode=True")
 
     # Output Eigenvalues and Eigenvectors
     eig_val_sort_array = np.zeros([num_cpi, cpi_len], dtype="f4")
@@ -242,41 +198,36 @@ def compute_evd_tb_gap(
 
     tb_is_valid = True
 
-    for idx_cpi, cpi_slow_time in enumerate(slice_gen(num_pulses, cpi_len, combine_rem=False)):
+    # Compute Eigenvalue and Eigenvector pairs for each CPI
+    for idx_cpi, cpi_slow_time in enumerate(
+        slice_gen(num_pulses, cpi_len, combine_rem=False)
+    ):
         data_cpi = raw_data[cpi_slow_time]
 
-        # Compute CPI-wise gap mask
-        mask_valid_cpi = mask_valid[cpi_slow_time]
-        eig_val_sort, eig_vec_sort = compute_evd_gap(
-            data_cpi, 
-            mask_valid_cpi=mask_valid_cpi, 
-            off_diag_overlap_ratio=off_diag_overlap_ratio,
-            diag_valid_ratio=diag_valid_ratio,
-        )
-
-        # Count number of usable eigenvalues of CPI and compare with chosen noise_ev_idx.
-        # Since Python uses 0-based indexing, a CPI must have at least noise_ev_idx + 1 usable
-        # eigenvalues.
-        # Abnormal small Eigenvalues in general occur only at the tail of the sorted
-        # Eigenvalues.  Zero Eigenvalues are replaced by a small epsilon, 1e-30 to 
-        # ensure log values of such are greater than zero.
-        eig_val_sort_db = 10*np.log10(np.maximum(np.abs(eig_val_sort), 1e-30))
-        usable_rank = int(np.count_nonzero(eig_val_sort_db > 0))
-
-        if usable_rank < noise_ev_idx + 1:
-            tb_is_valid = False
-            warnings.warn(
-                f"Skipping threshold block: This CPI has only "
-                f"{usable_rank} usable Eigenvalues, but noise_ev_idx = {noise_ev_idx} "
-                f"requires at least {noise_ev_idx + 1} valid Eigenvalues."
+        if not prf_dither_mode:
+            eig_val_sort, eig_vec_sort = compute_evd(data_cpi)
+        else:
+            mask_valid_cpi = mask_valid[cpi_slow_time]
+            eig_val_sort, eig_vec_sort = compute_evd_gap(
+                data_cpi,
+                mask_valid_cpi=mask_valid_cpi,
+                off_diag_overlap_ratio=off_diag_overlap_ratio,
+                diag_valid_ratio=diag_valid_ratio,
             )
+
+        # Verify if the eigenvalue of CPI at index defind by  noise_ev_idx is meaningful
+        eig_val_abs = np.maximum(np.abs(eig_val_sort), 1e-30)
+        noise_ev_rel_db = 10 * np.log10(eig_val_abs[noise_ev_idx] / eig_val_abs[0])
+        rel_ev_thresh_db = -30
+
+        if noise_ev_rel_db < rel_ev_thresh_db:
+            tb_is_valid = False
             break
 
         eig_val_sort_array[idx_cpi] = eig_val_sort
         eig_vec_sort_array[idx_cpi] = eig_vec_sort
 
     return eig_val_sort_array, eig_vec_sort_array, tb_is_valid
-
 
 def compute_evd_gap(
     raw_data: np.ndarray,

--- a/python/packages/isce3/signal/compute_evd_cpi.py
+++ b/python/packages/isce3/signal/compute_evd_cpi.py
@@ -301,10 +301,10 @@ def compute_gap_exclusion_cov(
     if mask_valid_cpi.shape != data.shape:
         raise ValueError(f"CPI mask shape {mask_valid_cpi.shape} != CPI data shape {data.shape}")
 
-    if not (0.0 <= off_diag_overlap_ratio <= 1.0):
+    if not (0.0 < off_diag_overlap_ratio <= 1.0):
         raise ValueError("off_diag_overlap_ratio must be between 0 and 1.")
 
-    if not (0.0 <= diag_valid_ratio <= 1.0):
+    if not (0.0 < diag_valid_ratio <= 1.0):
         raise ValueError("diag_valid_ratio must be between 0 and 1.")
 
     # Minimum Samples required to compute diagonal and off-diagonal terms of

--- a/python/packages/isce3/signal/compute_evd_cpi.py
+++ b/python/packages/isce3/signal/compute_evd_cpi.py
@@ -110,7 +110,7 @@ def compute_evd_tb(
         Eigenvalue index used by threshold estimation to estimate the slow-time minimum
         Eigenvalue slope. This parameter is also used to validate that the threshold block
         has enough usable eigenvalues for robust sample covaraince estimation of a CPI.
-    rx_dynamic_range_db: int, optional, default = 50 dB
+    rx_dynamic_range_db: float, optional, default = 50 dB
         Radar platform receiver dynamic range. This is applied as a threshold
         to determine if the Eigenvalue under test is meaningfully signficant. If the
         Eigenvalue under test is less than this threshold, it will be viewed as unusable.

--- a/python/packages/isce3/signal/rfi_detection_evd.py
+++ b/python/packages/isce3/signal/rfi_detection_evd.py
@@ -90,8 +90,8 @@ def rfi_detect(
         Eigenvalue index used by threshold estimation to estimate the slow-time minimum
         Eigenvalue slope. This parameter is also used to validate that the threshold block
         has enough usable eigenvalues for robust sample covaraince estimation of a CPI.
-    rx_dynamic_range_db: int, optional
-        radar platform receiver dynamic range, e.g. -50 dB. This is applied as a threshold
+    rx_dynamic_range_db: int, optional, defaul = 50 dB
+        Radar platform receiver dynamic range. This is applied as a threshold
         to determine if the Eigenvalue under test is meaningfully signficant. If the
         Eigenvalue under test is less than this threshold, it will be viewed as unusable.
     mask_valid : np.ndarray bool, [num_pulses x num_rng_samples]

--- a/python/packages/isce3/signal/rfi_detection_evd.py
+++ b/python/packages/isce3/signal/rfi_detection_evd.py
@@ -51,7 +51,6 @@ def rfi_detect(
     max_num_rfi_ev=2,
     off_diag_overlap_ratio=0.25,
     diag_valid_ratio=0.20,
-    apply_gap_exclusion=False,
     rx_dynamic_range_db=50.0,
     mask_valid=None,
     threshold_params: ThresholdParams = ThresholdParams(),
@@ -88,15 +87,14 @@ def rfi_detect(
     diag_valid_ratio : float, default=0.20
         Minimum fraction of valid samples required to compute a diagonal term in the
         sample covariance matrix entry R_ii.
-    apply_gap_exclusion: bool, default=False
-        If True, CPI sample covariance matrix will be computed differently by excluding the 
-        invalid data gaps.
     rx_dynamic_range_db: int, default=50.0
         Radar platform receiver dynamic range. This is applied as a threshold
         to determine if the Eigenvalue under test is meaningfully signficant. If the
         Eigenvalue under test is less than this threshold, it will be viewed as unusable.
     mask_valid : np.ndarray bool, [num_pulses x num_rng_samples], default=None
-        Valid-sample mask with same shape as raw_data
+        Valid-sample mask with same shape as raw_data If provided, CPI sample
+        covariance matrix will be computed differently by excluding the invalid
+        data gaps.
     threshold_params: ThresholdParams dataclass object, default=ThresholdParams()
         RFI detection threshold interpolation parameters. The x field defines STD
         ratio between maximum and minimum Eigenvalue slopes (MMES) of the
@@ -127,7 +125,6 @@ def rfi_detect(
     ) = compute_evd_tb(
         raw_data,
         cpi_len=cpi_len,
-        apply_gap_exclusion=apply_gap_exclusion,
         mask_valid=mask_valid,
         off_diag_overlap_ratio=off_diag_overlap_ratio,
         diag_valid_ratio=diag_valid_ratio,

--- a/python/packages/isce3/signal/rfi_detection_evd.py
+++ b/python/packages/isce3/signal/rfi_detection_evd.py
@@ -44,16 +44,17 @@ def rfi_detect(
     raw_data,
     cpi_len,
     max_deg_freedom,
-    num_max_trim,
-    num_min_trim,
-    max_num_rfi_ev,
-    off_diag_overlap_ratio,
-    diag_valid_ratio,
-    apply_gap_exclusion,
     min_ev_valid_idx,
-    rx_dynamic_range_db,
-    mask_valid,
-    threshold_params,
+    *,
+    num_max_trim=0,
+    num_min_trim=0,
+    max_num_rfi_ev=2,
+    off_diag_overlap_ratio=0.25,
+    diag_valid_ratio=0.20,
+    apply_gap_exclusion=False,
+    rx_dynamic_range_db=50.0,
+    mask_valid=None,
+    threshold_params: ThresholdParams = ThresholdParams(),
 ):
 
     """This wrapper performs Eigenvalue Decomposition of input raw data as well as 
@@ -139,16 +140,14 @@ def rfi_detect(
     if not tb_is_valid:
         num_cpi = eig_val_sort_array.shape[0]
         rfi_cpi_flag_array = np.zeros((num_cpi, cpi_len), dtype=np.bool_)
-        fig_merit_detect_tb = 0
 
         return (
             rfi_cpi_flag_array,
             eig_vec_sort_array,
-            fig_merit_detect_tb,
         )
 
     # Estimate a single threshold for all CPIs
-    detect_threshold, fig_merit_detect_tb = threshold_estimate_evd(
+    detect_threshold = threshold_estimate_evd(
         eig_val_sort_array,
         num_max_trim,
         num_min_trim,
@@ -162,7 +161,7 @@ def rfi_detect(
         eig_val_sort_array, detect_threshold, max_deg_freedom
     )
 
-    return rfi_cpi_flag_array, eig_vec_sort_array, fig_merit_detect_tb
+    return rfi_cpi_flag_array, eig_vec_sort_array
 
 def threshold_estimate_evd(
     eig_val_sort_array,
@@ -271,7 +270,7 @@ def threshold_estimate_evd(
 
     detect_threshold = ev_slope_min_mean + num_sigma * ev_slope_min_std
 
-    return detect_threshold, std_ratio_ev_slope
+    return detect_threshold
 
 
 def rfi_detect_evd(

--- a/python/packages/isce3/signal/rfi_detection_evd.py
+++ b/python/packages/isce3/signal/rfi_detection_evd.py
@@ -49,7 +49,7 @@ def rfi_detect(
     max_num_rfi_ev,
     off_diag_overlap_ratio,
     diag_valid_ratio,
-    prf_dither_mode,
+    apply_gap_exclusion,
     min_ev_valid_idx,
     rx_dynamic_range_db,
     mask_valid,
@@ -83,9 +83,9 @@ def rfi_detect(
     diag_valid_ratio : float
         Minimum fraction of valid samples required to compute a diagonal term in the
         sample covariance matrix entry R_ii.
-    prf_dither_mode: bool
-        If True, L0B acquisition is of PRF Dithering mode. Sample Covariance Matrix
-        is computed differently by excluding the invalid data gaps.
+    apply_gap_exclusion: bool
+        If True, CPI sample covariance matrix will be computed differently by excluding the 
+        invalid data gaps.
     min_ev_valid_idx: int
         Eigenvalue index used by threshold estimation to estimate the slow-time minimum
         Eigenvalue slope. This parameter is also used to validate that the threshold block
@@ -126,7 +126,7 @@ def rfi_detect(
     ) = compute_evd_tb(
         raw_data,
         cpi_len=cpi_len,
-        prf_dither_mode=prf_dither_mode,
+        apply_gap_exclusion=apply_gap_exclusion,
         mask_valid=mask_valid,
         off_diag_overlap_ratio=off_diag_overlap_ratio,
         diag_valid_ratio=diag_valid_ratio,

--- a/python/packages/isce3/signal/rfi_detection_evd.py
+++ b/python/packages/isce3/signal/rfi_detection_evd.py
@@ -69,35 +69,35 @@ def rfi_detect(
     max_deg_freedom: int
         Max number of independent RFI emitters designed to be detected and mitigated.
         This number should be less than cpi_len to avoid unintended removal of signal data.
-    num_max_trim: int
+    min_ev_valid_idx: int
+        Eigenvalue index used by threshold estimation to estimate the slow-time minimum
+        Eigenvalue slope. This parameter is also used to validate that the threshold block
+        has enough usable eigenvalues for robust sample covaraince estimation of a CPI.
+    num_max_trim: int, default=0
         Number of large-value outliers to be trimmed in slow-time minimum Eigenvalues.
-    num_min_trim: int
+    num_min_trim: int, default=0
         Number of small-value outliers to be trimmed in slow-time minimum Eigenvalues
-    max_num_rfi_ev: int
+    max_num_rfi_ev: int, , default=2
         A detection error (miss) happens when a maximum power RFI emitter contaminates 
         multiple consecutive CPIs, resulting in a flat maximum Eigenvalue slope in slow 
         time. Hence the standard (STD) deviation of multiple dominant EVs across slow time 
         defined by this parameter are compared. The one with the maximum STD is used for RFI
         Eigenvalue first difference computation.
-    off_diag_overlap_ratio : float
+    off_diag_overlap_ratio : float, default=0.25
         Minimum overlap ratio used by gap exclusion covariance estimation
-    diag_valid_ratio : float
+    diag_valid_ratio : float, default=0.20
         Minimum fraction of valid samples required to compute a diagonal term in the
         sample covariance matrix entry R_ii.
-    apply_gap_exclusion: bool
+    apply_gap_exclusion: bool, default=False
         If True, CPI sample covariance matrix will be computed differently by excluding the 
         invalid data gaps.
-    min_ev_valid_idx: int
-        Eigenvalue index used by threshold estimation to estimate the slow-time minimum
-        Eigenvalue slope. This parameter is also used to validate that the threshold block
-        has enough usable eigenvalues for robust sample covaraince estimation of a CPI.
-    rx_dynamic_range_db: int
+    rx_dynamic_range_db: int, default=50.0
         Radar platform receiver dynamic range. This is applied as a threshold
         to determine if the Eigenvalue under test is meaningfully signficant. If the
         Eigenvalue under test is less than this threshold, it will be viewed as unusable.
-    mask_valid : np.ndarray bool, [num_pulses x num_rng_samples]
+    mask_valid : np.ndarray bool, [num_pulses x num_rng_samples], default=None
         Valid-sample mask with same shape as raw_data
-    threshold_params: ThresholdParams dataclass object
+    threshold_params: ThresholdParams dataclass object, default=ThresholdParams()
         RFI detection threshold interpolation parameters. The x field defines STD
         ratio between maximum and minimum Eigenvalue slopes (MMES) of the
         slow-time threshold interval. The y field defines the number of sigma (STD)

--- a/python/packages/isce3/signal/rfi_detection_evd.py
+++ b/python/packages/isce3/signal/rfi_detection_evd.py
@@ -118,7 +118,6 @@ def rfi_detect(
             "Total number of pulses must be greater or equal to number of pulses per single CPI."
         )
 
-    
     # Need to validate sample covariance rank
     (
         eig_val_sort_array, 
@@ -164,7 +163,6 @@ def rfi_detect(
     )
 
     return rfi_cpi_flag_array, eig_vec_sort_array, fig_merit_detect_tb
-
 
 def threshold_estimate_evd(
     eig_val_sort_array,
@@ -344,8 +342,7 @@ def rfi_detect_evd_tb(
 
     # Ensure detection threshold is a positive value
     if (not np.isfinite(detect_threshold)) or (detect_threshold <= 0):
-        #raise ValueError("Detection threshold must be a positive value!")
-        # Add a CPI-Level rank check
+        # Add a CPI-Level rank check: detection threshold must be a positive value
         warnings.warn("Warning: Non-positive detection threshold. Skipping TB detection.")
         return np.zeros((num_cpi, cpi_len), dtype=np.bool_)
 

--- a/python/packages/isce3/signal/rfi_detection_evd.py
+++ b/python/packages/isce3/signal/rfi_detection_evd.py
@@ -3,10 +3,10 @@ Performs RFI detection of input data using Slow-Time Eigenvalue Slope
 Thresholding algorithm (ST-EST).
 """
 import numpy as np
-from isce3.signal.compute_evd_cpi import compute_evd_tb
+from isce3.signal.compute_evd_cpi import compute_evd_tb, compute_evd_tb_gap
 from dataclasses import dataclass, field
 from typing import List
-
+import warnings
 
 @dataclass
 class ThresholdParams:
@@ -47,6 +47,11 @@ def rfi_detect(
     num_max_trim,
     num_min_trim,
     max_num_rfi_ev,
+    off_diag_overlap_ratio,
+    diag_valid_ratio,
+    prf_dither_mode,
+    noise_ev_idx,
+    mask_valid,
     threshold_params,
 ):
 
@@ -72,6 +77,19 @@ def rfi_detect(
         time. Hence the standard (STD) deviation of multiple dominant EVs across slow time 
         defined by this parameter are compared. The one with the maximum STD is used for RFI
         Eigenvalue first difference computation.
+    off_diag_overlap_ratio : float, optional
+        Minimum overlap ratio used by gap exclusion covariance estimation
+    diag_valid_ratio : float, optional
+        Minimum fraction of valid samples required to compute a diagonal term in the
+        sample covariance matrix entry R_ii.
+    prf_dither_mode: bool
+        If True, L0B acquisition is of PRF Dithering mode. Sample Covariance Matrix
+        is computed differently by excluding the invalid data gaps.
+    noise_ev_idx : int
+        Eigenvalue index used by threshold estimation to estimate the slow-time minimum
+        Eigenvalue slope
+    mask_valid : np.ndarray bool, [num_pulses x num_rng_samples]
+        Valid-sample mask with same shape as raw_data
     threshold_params: ThresholdParams dataclass object
         RFI detection threshold interpolation parameters. The x field defines STD
         ratio between maximum and minimum Eigenvalue slopes (MMES) of the
@@ -86,7 +104,6 @@ def rfi_detect(
     eig_vec_sort: 3D array of complex, [num_cpi x cpi_len x cpi_len]
         Sorted column vector Eigenvectors of all CPIs based on indices of sorted Eigenvalues
     """
-
     num_pulses = raw_data.shape[0]
 
     # Verify total number of pulses is greater than number of pulses per CPI
@@ -95,8 +112,36 @@ def rfi_detect(
             "Total number of pulses must be greater or equal to number of pulses per single CPI."
         )
 
-    # Compute EVD of input data
-    eig_val_sort_array, eig_vec_sort_array = compute_evd_tb(raw_data, cpi_len)
+    
+    # Constant PRF does not need to skip threshold blocks
+    # Need to validate sample covariance rank for Dithered PRF modes
+    if not prf_dither_mode:
+        eig_val_sort_array, eig_vec_sort_array = compute_evd_tb(raw_data, cpi_len)
+        tb_is_valid = True
+    else:
+        (
+            eig_val_sort_array, 
+            eig_vec_sort_array,
+            tb_is_valid,
+        ) = compute_evd_tb_gap(
+            raw_data,
+            mask_valid,
+            cpi_len,
+            off_diag_overlap_ratio,
+            diag_valid_ratio,
+            noise_ev_idx
+        )
+        # If any CPI within a threshold block is determined to be invalid
+        # Then skip threshold computation for this block by setting rfi_cpi_flag_array
+        # to all zeros
+        if not tb_is_valid:
+            num_cpi = eig_val_sort_array.shape[0]
+            rfi_cpi_flag_array = np.zeros((num_cpi, cpi_len), dtype=np.bool_)
+
+            return (
+                rfi_cpi_flag_array,
+                eig_vec_sort_array,
+            )
 
     # Estimate a single threshold for all CPIs
     detect_threshold = threshold_estimate_evd(
@@ -104,6 +149,7 @@ def rfi_detect(
         num_max_trim,
         num_min_trim,
         max_num_rfi_ev,
+        noise_ev_idx,
         threshold_params,
     )
 
@@ -120,6 +166,7 @@ def threshold_estimate_evd(
     num_max_trim=0,
     num_min_trim=0,
     max_num_rfi_ev=2,
+    noise_ev_idx=10,
     threshold_params: ThresholdParams = ThresholdParams(),
 ):
     """Perform data-centric thresholding algorithm: "Slow-Time Eigenvalue Slope
@@ -155,6 +202,9 @@ def threshold_estimate_evd(
         time. Hence the standard (STD) deviation of multiple dominant EVs across slow time 
         defined by this parameter are compared. The one with the maximum STD is used for RFI
         Eigenvalue first difference computation.
+    noise_ev_idx : int, optional
+        Eigenvalue index used by threshold estimation to estimate the slow-time minimum
+        Eigenvalue slope
     threshold_params: ThresholdParams dataclass object, default=ThresholdParams()
         RFI detection threshold interpolation parameters
 
@@ -184,7 +234,9 @@ def threshold_estimate_evd(
     ev_max_std_idx = np.argmax(eval_sort_max_std)
     ev_max_db = eval_sort_max_db[:, ev_max_std_idx]
 
-    ev_min_db = 10 * np.log10(np.abs(eig_val_sort_array[:, -1]))
+    # For Dithered PRF mode, noise_ev_idx is selected to avoid zeros in the tail
+    # of the Eigenvalue spectrum due to invalid data gaps for each pulse.
+    ev_min_db = 10 * np.log10(np.abs(eig_val_sort_array[:, noise_ev_idx]))
 
     # Remove possible outliers in max and min Eigenvalues without reordering.
     if num_min_trim > 0:
@@ -221,7 +273,7 @@ def threshold_estimate_evd(
 def rfi_detect_evd(
     eig_val_db_slope,
     detect_threshold,
-    max_deg_freedom=12,
+    max_deg_freedom=8,
 ):
     """Perform RFI detection of Eigenvalues within a CPI based on input detection 
     threshold in dB/Eigenvalue index. The threshold is set to be a negative value.  
@@ -257,7 +309,7 @@ def rfi_detect_evd(
 def rfi_detect_evd_tb(
     eig_val_sort_array,
     detect_threshold,
-    max_deg_freedom=12,
+    max_deg_freedom=8,
 ):
     """Wrapper function which performs RFI detection of data within a Threshold Block (TB) 
     one CPI at a time base don input detection threshold in dB/Eigenvalue index. 
@@ -285,8 +337,11 @@ def rfi_detect_evd_tb(
     num_cpi, cpi_len = eig_val_sort_array.shape
 
     # Ensure detection threshold is a positive value
-    if detect_threshold <= 0:
-        raise ValueError("Detection threshold must be a positive value!")
+    if (not np.isfinite(detect_threshold)) or (detect_threshold <= 0):
+        #raise ValueError("Detection threshold must be a positive value!")
+        # Add a CPI-Level rank check
+        warnings.warn("Warning: Non-positive detection threshold. Skipping TB detection.")
+        return np.zeros((num_cpi, cpi_len), dtype=np.bool_)
 
     # Maximum number of degrees of freedom must be less than cpi_len
     if max_deg_freedom >= cpi_len:
@@ -302,6 +357,7 @@ def rfi_detect_evd_tb(
     eig_val_db_slope_array = np.diff(eig_val_sort_db_array, axis=1)
 
     for idx_cpi in range(num_cpi):
+        eig_val_db = eig_val_sort_db_array[idx_cpi]
         eig_val_db_slope = eig_val_db_slope_array[idx_cpi]
 
         # Determine starting index of signal EV

--- a/python/packages/isce3/signal/rfi_detection_evd.py
+++ b/python/packages/isce3/signal/rfi_detection_evd.py
@@ -68,9 +68,9 @@ def rfi_detect(
     max_deg_freedom: int
         Max number of independent RFI emitters designed to be detected and mitigated.
         This number should be less than cpi_len to avoid unintended removal of signal data.
-    num_max_trim: int, default = 0
+    num_max_trim: int
         Number of large-value outliers to be trimmed in slow-time minimum Eigenvalues.
-    num_min_trim: int, default = 0
+    num_min_trim: int
         Number of small-value outliers to be trimmed in slow-time minimum Eigenvalues
     max_num_rfi_ev: int
         A detection error (miss) happens when a maximum power RFI emitter contaminates 
@@ -78,9 +78,9 @@ def rfi_detect(
         time. Hence the standard (STD) deviation of multiple dominant EVs across slow time 
         defined by this parameter are compared. The one with the maximum STD is used for RFI
         Eigenvalue first difference computation.
-    off_diag_overlap_ratio : float, optional
+    off_diag_overlap_ratio : float
         Minimum overlap ratio used by gap exclusion covariance estimation
-    diag_valid_ratio : float, optional
+    diag_valid_ratio : float
         Minimum fraction of valid samples required to compute a diagonal term in the
         sample covariance matrix entry R_ii.
     prf_dither_mode: bool
@@ -90,7 +90,7 @@ def rfi_detect(
         Eigenvalue index used by threshold estimation to estimate the slow-time minimum
         Eigenvalue slope. This parameter is also used to validate that the threshold block
         has enough usable eigenvalues for robust sample covaraince estimation of a CPI.
-    rx_dynamic_range_db: int, optional, defaul = 50 dB
+    rx_dynamic_range_db: int
         Radar platform receiver dynamic range. This is applied as a threshold
         to determine if the Eigenvalue under test is meaningfully signficant. If the
         Eigenvalue under test is less than this threshold, it will be viewed as unusable.

--- a/python/packages/isce3/signal/rfi_detection_evd.py
+++ b/python/packages/isce3/signal/rfi_detection_evd.py
@@ -39,7 +39,6 @@ class ThresholdParams:
         if len(self.x) < 2:
             raise ValueError("At least two points are required")
 
-
 def rfi_detect(
     raw_data,
     cpi_len,
@@ -87,7 +86,8 @@ def rfi_detect(
         is computed differently by excluding the invalid data gaps.
     noise_ev_idx : int
         Eigenvalue index used by threshold estimation to estimate the slow-time minimum
-        Eigenvalue slope
+        Eigenvalue slope. This parameter is also used to validate that the threshold block 
+        has enough usable eigenvalues for minimum Eigenvalue estimation
     mask_valid : np.ndarray bool, [num_pulses x num_rng_samples]
         Valid-sample mask with same shape as raw_data
     threshold_params: ThresholdParams dataclass object
@@ -112,36 +112,28 @@ def rfi_detect(
             "Total number of pulses must be greater or equal to number of pulses per single CPI."
         )
 
-    
-    # Constant PRF does not need to skip threshold blocks
-    # Need to validate sample covariance rank for Dithered PRF modes
-    if not prf_dither_mode:
-        eig_val_sort_array, eig_vec_sort_array = compute_evd_tb(raw_data, cpi_len)
-        tb_is_valid = True
-    else:
-        (
-            eig_val_sort_array, 
-            eig_vec_sort_array,
-            tb_is_valid,
-        ) = compute_evd_tb_gap(
-            raw_data,
-            mask_valid,
-            cpi_len,
-            off_diag_overlap_ratio,
-            diag_valid_ratio,
-            noise_ev_idx
-        )
-        # If any CPI within a threshold block is determined to be invalid
-        # Then skip threshold computation for this block by setting rfi_cpi_flag_array
-        # to all zeros
-        if not tb_is_valid:
-            num_cpi = eig_val_sort_array.shape[0]
-            rfi_cpi_flag_array = np.zeros((num_cpi, cpi_len), dtype=np.bool_)
+    # Validate sample covariance rank
+    eig_val_sort_array, eig_vec_sort_array, tb_is_valid = compute_evd_tb(
+        raw_data,
+        cpi_len=cpi_len,
+        prf_dither_mode=prf_dither_mode,
+        mask_valid=mask_valid,
+        off_diag_overlap_ratio=off_diag_overlap_ratio,
+        diag_valid_ratio=diag_valid_ratio,
+        noise_ev_idx=noise_ev_idx,
+    )
 
-            return (
-                rfi_cpi_flag_array,
-                eig_vec_sort_array,
-            )
+    # If any CPI within a threshold block is determined to be invalid
+    # Then skip threshold computation for this block by setting rfi_cpi_flag_array
+    # to all zeros
+    if not tb_is_valid:
+        num_cpi = eig_val_sort_array.shape[0]
+        rfi_cpi_flag_array = np.zeros((num_cpi, cpi_len), dtype=np.bool_)
+
+        return (
+            rfi_cpi_flag_array,
+            eig_vec_sort_array,
+        )
 
     # Estimate a single threshold for all CPIs
     detect_threshold = threshold_estimate_evd(

--- a/python/packages/isce3/signal/rfi_detection_evd.py
+++ b/python/packages/isce3/signal/rfi_detection_evd.py
@@ -3,7 +3,7 @@ Performs RFI detection of input data using Slow-Time Eigenvalue Slope
 Thresholding algorithm (ST-EST).
 """
 import numpy as np
-from isce3.signal.compute_evd_cpi import compute_evd_tb, compute_evd_tb_gap
+from isce3.signal.compute_evd_cpi import compute_evd_tb
 from dataclasses import dataclass, field
 from typing import List
 import warnings
@@ -39,6 +39,7 @@ class ThresholdParams:
         if len(self.x) < 2:
             raise ValueError("At least two points are required")
 
+
 def rfi_detect(
     raw_data,
     cpi_len,
@@ -49,7 +50,8 @@ def rfi_detect(
     off_diag_overlap_ratio,
     diag_valid_ratio,
     prf_dither_mode,
-    noise_ev_idx,
+    min_ev_valid_idx,
+    rx_dynamic_range_db,
     mask_valid,
     threshold_params,
 ):
@@ -84,10 +86,14 @@ def rfi_detect(
     prf_dither_mode: bool
         If True, L0B acquisition is of PRF Dithering mode. Sample Covariance Matrix
         is computed differently by excluding the invalid data gaps.
-    noise_ev_idx : int
+    min_ev_valid_idx: int
         Eigenvalue index used by threshold estimation to estimate the slow-time minimum
-        Eigenvalue slope. This parameter is also used to validate that the threshold block 
-        has enough usable eigenvalues for minimum Eigenvalue estimation
+        Eigenvalue slope. This parameter is also used to validate that the threshold block
+        has enough usable eigenvalues for robust sample covaraince estimation of a CPI.
+    rx_dynamic_range_db: int, optional
+        radar platform receiver dynamic range, e.g. -50 dB. This is applied as a threshold
+        to determine if the Eigenvalue under test is meaningfully signficant. If the
+        Eigenvalue under test is less than this threshold, it will be viewed as unusable.
     mask_valid : np.ndarray bool, [num_pulses x num_rng_samples]
         Valid-sample mask with same shape as raw_data
     threshold_params: ThresholdParams dataclass object
@@ -112,36 +118,43 @@ def rfi_detect(
             "Total number of pulses must be greater or equal to number of pulses per single CPI."
         )
 
-    # Validate sample covariance rank
-    eig_val_sort_array, eig_vec_sort_array, tb_is_valid = compute_evd_tb(
+    
+    # Need to validate sample covariance rank
+    (
+        eig_val_sort_array, 
+        eig_vec_sort_array,
+        tb_is_valid,
+    ) = compute_evd_tb(
         raw_data,
         cpi_len=cpi_len,
         prf_dither_mode=prf_dither_mode,
         mask_valid=mask_valid,
         off_diag_overlap_ratio=off_diag_overlap_ratio,
         diag_valid_ratio=diag_valid_ratio,
-        noise_ev_idx=noise_ev_idx,
+        min_ev_valid_idx=min_ev_valid_idx,
+        rx_dynamic_range_db=rx_dynamic_range_db,
     )
-
     # If any CPI within a threshold block is determined to be invalid
     # Then skip threshold computation for this block by setting rfi_cpi_flag_array
     # to all zeros
     if not tb_is_valid:
         num_cpi = eig_val_sort_array.shape[0]
         rfi_cpi_flag_array = np.zeros((num_cpi, cpi_len), dtype=np.bool_)
+        fig_merit_detect_tb = 0
 
         return (
             rfi_cpi_flag_array,
             eig_vec_sort_array,
+            fig_merit_detect_tb,
         )
 
     # Estimate a single threshold for all CPIs
-    detect_threshold = threshold_estimate_evd(
+    detect_threshold, fig_merit_detect_tb = threshold_estimate_evd(
         eig_val_sort_array,
         num_max_trim,
         num_min_trim,
         max_num_rfi_ev,
-        noise_ev_idx,
+        min_ev_valid_idx,
         threshold_params,
     )
 
@@ -150,7 +163,7 @@ def rfi_detect(
         eig_val_sort_array, detect_threshold, max_deg_freedom
     )
 
-    return rfi_cpi_flag_array, eig_vec_sort_array
+    return rfi_cpi_flag_array, eig_vec_sort_array, fig_merit_detect_tb
 
 
 def threshold_estimate_evd(
@@ -158,7 +171,7 @@ def threshold_estimate_evd(
     num_max_trim=0,
     num_min_trim=0,
     max_num_rfi_ev=2,
-    noise_ev_idx=10,
+    min_ev_valid_idx=10,
     threshold_params: ThresholdParams = ThresholdParams(),
 ):
     """Perform data-centric thresholding algorithm: "Slow-Time Eigenvalue Slope
@@ -194,9 +207,10 @@ def threshold_estimate_evd(
         time. Hence the standard (STD) deviation of multiple dominant EVs across slow time 
         defined by this parameter are compared. The one with the maximum STD is used for RFI
         Eigenvalue first difference computation.
-    noise_ev_idx : int, optional
+    min_ev_valid_idx: int
         Eigenvalue index used by threshold estimation to estimate the slow-time minimum
-        Eigenvalue slope
+        Eigenvalue slope. This parameter is also used to validate that the threshold block
+        has enough usable eigenvalues for robust sample covaraince estimation of a CPI.
     threshold_params: ThresholdParams dataclass object, default=ThresholdParams()
         RFI detection threshold interpolation parameters
 
@@ -226,9 +240,9 @@ def threshold_estimate_evd(
     ev_max_std_idx = np.argmax(eval_sort_max_std)
     ev_max_db = eval_sort_max_db[:, ev_max_std_idx]
 
-    # For Dithered PRF mode, noise_ev_idx is selected to avoid zeros in the tail
+    # For Dithered PRF mode, min_ev_valid_idx is selected to avoid zeros in the tail
     # of the Eigenvalue spectrum due to invalid data gaps for each pulse.
-    ev_min_db = 10 * np.log10(np.abs(eig_val_sort_array[:, noise_ev_idx]))
+    ev_min_db = 10 * np.log10(np.abs(eig_val_sort_array[:, min_ev_valid_idx]))
 
     # Remove possible outliers in max and min Eigenvalues without reordering.
     if num_min_trim > 0:
@@ -259,7 +273,7 @@ def threshold_estimate_evd(
 
     detect_threshold = ev_slope_min_mean + num_sigma * ev_slope_min_std
 
-    return detect_threshold
+    return detect_threshold, std_ratio_ev_slope
 
 
 def rfi_detect_evd(

--- a/python/packages/isce3/signal/rfi_detection_evd.py
+++ b/python/packages/isce3/signal/rfi_detection_evd.py
@@ -76,7 +76,7 @@ def rfi_detect(
         Number of large-value outliers to be trimmed in slow-time minimum Eigenvalues.
     num_min_trim: int, default=0
         Number of small-value outliers to be trimmed in slow-time minimum Eigenvalues
-    max_num_rfi_ev: int, , default=2
+    max_num_rfi_ev: int, default=2
         A detection error (miss) happens when a maximum power RFI emitter contaminates 
         multiple consecutive CPIs, resulting in a flat maximum Eigenvalue slope in slow 
         time. Hence the standard (STD) deviation of multiple dominant EVs across slow time 
@@ -91,10 +91,10 @@ def rfi_detect(
         Radar platform receiver dynamic range. This is applied as a threshold
         to determine if the Eigenvalue under test is meaningfully signficant. If the
         Eigenvalue under test is less than this threshold, it will be viewed as unusable.
-    mask_valid : np.ndarray bool, [num_pulses x num_rng_samples], default=None
-        Valid-sample mask with same shape as raw_data If provided, CPI sample
-        covariance matrix will be computed differently by excluding the invalid
-        data gaps.
+    mask_valid : np.ndarray bool or None, default=None
+        Valid-sample mask with same shape as raw_data If provided, it has the shape of
+        [num_pulses x num_rng_samples]. CPI sample covariance matrix will be normalized
+        differently by excluding the invalid data gaps.
     threshold_params: ThresholdParams dataclass object, default=ThresholdParams()
         RFI detection threshold interpolation parameters. The x field defines STD
         ratio between maximum and minimum Eigenvalue slopes (MMES) of the

--- a/python/packages/isce3/signal/rfi_detection_evd.py
+++ b/python/packages/isce3/signal/rfi_detection_evd.py
@@ -87,7 +87,7 @@ def rfi_detect(
     diag_valid_ratio : float, default=0.20
         Minimum fraction of valid samples required to compute a diagonal term in the
         sample covariance matrix entry R_ii.
-    rx_dynamic_range_db: int, default=50.0
+    rx_dynamic_range_db: float, default=50.0
         Radar platform receiver dynamic range. This is applied as a threshold
         to determine if the Eigenvalue under test is meaningfully signficant. If the
         Eigenvalue under test is less than this threshold, it will be viewed as unusable.

--- a/python/packages/isce3/signal/rfi_process_evd.py
+++ b/python/packages/isce3/signal/rfi_process_evd.py
@@ -22,7 +22,6 @@ def run_slow_time_evd(
     off_diag_overlap_ratio=0.25,
     diag_valid_ratio=0.20,
     mitigate_enable=False,
-    prf_dither_mode=False,
     min_rank_frac=0.70,
     rx_dynamic_range_db=50.0,
     mask_valid=None,
@@ -80,9 +79,6 @@ def run_slow_time_evd(
         sample covariance matrix entry R_ii.
     mitigate_enable: bool, default=False
         Enable mitigation
-    prf_dither_mode: bool
-        If True, L0B acquisition is of PRF Dithering mode. Sample Covariance Matrix
-        is computed differently by excluding the invalid data gaps.
     min_rank_frac: float, default = 0.7
         This fraction will be used to determine the minimum number of valid Eigenvalues
         required for a CPI. min_ev_valid_idx = int(np.floor(min_rank_frac * cpi_len))
@@ -93,6 +89,9 @@ def run_slow_time_evd(
         Eigenvalue under test is less than this threshold, it will be viewed as unusable.
     mask_valid : np.ndarray bool, [num_pulses x num_rng_samples], optional
         Valid-sample mask with same shape as raw_data
+        if mask_valid is None, sample covariance matrix will be estimated by standard
+        matrix multiplication. Otherwise, sample covariance matrix estimation with invalid data
+        gap exclusion will be performed (NISAR dithered PRF mode).
     raw_data_mitigated: array-like complex [num_pulses x num_rng_samples] or None, optional
         output array in which the mitigated data values is placed. It
         must be an array-like object supporting `multidimensional array access
@@ -156,10 +155,6 @@ def run_slow_time_evd(
             f"min_rank_frac must be in (0, 1], got {min_rank_frac}."
         )
 
-    # Create a mask if no mask if provided
-    if mask_valid is None:
-        mask_valid = np.ones(raw_data.shape, dtype=bool)
-
     # Collect total number of CPI range blocks contaminated by RFI
     rfi_cpi_count_sum = 0
 
@@ -175,10 +170,18 @@ def run_slow_time_evd(
             "Max number of deg. of freedom must be less than number of pulses in a CPI."
         )
 
-    # Verify Mask shape
-    if mask_valid.shape != raw_data.shape:
-        raise ValueError(f"Valid raw data mask shape {mask_valid.shape} != raw data shape {raw_data.shape}")
-    
+    # Verify mask_valid: check to see if it is None or populated.
+    # Ifi mask_valid is None, apply_gap_exclusion = False. Otherwise apply_gap_exclusion = True
+    if mask_valid is not None:
+        if mask_valid.shape != raw_data.shape:
+            raise ValueError(f"Valid raw data mask shape {mask_valid.shape} != raw data shape {raw_data.shape}")
+
+        mask_valid = mask_valid.astype(bool, copy=False)
+        apply_gap_exclusion = True
+    else:
+        mask_valid = np.ones(raw_data.shape, dtype=bool)
+        apply_gap_exclusion = False
+     
     # Determine a valid Eigenvalue index to estimate minimum-Eigenvalue statistics,
     # ensuring robustness against zero Eigenvalues caused by insufficient valid samples in a CPI.
     min_ev_valid_idx = max(1, int(np.round(min_rank_frac * cpi_len)) - 1)
@@ -204,7 +207,7 @@ def run_slow_time_evd(
                 max_num_rfi_ev,
                 off_diag_overlap_ratio,
                 diag_valid_ratio,
-                prf_dither_mode,
+                apply_gap_exclusion,
                 min_ev_valid_idx,
                 rx_dynamic_range_db,
                 mask_valid_tb,

--- a/python/packages/isce3/signal/rfi_process_evd.py
+++ b/python/packages/isce3/signal/rfi_process_evd.py
@@ -24,7 +24,7 @@ def run_slow_time_evd(
     mitigate_enable=False,
     min_rank_frac=0.70,
     rx_dynamic_range_db=50.0,
-    mask_valid=None,
+    swaths=None,
     raw_data_mitigated=None,
 ):
 
@@ -87,11 +87,12 @@ def run_slow_time_evd(
         radar platform receiver dynamic range. This is applied as a threshold
         to determine if the Eigenvalue under test is meaningfully signficant. If the
         Eigenvalue under test is less than this threshold, it will be viewed as unusable.
-    mask_valid : np.ndarray bool, [num_pulses x num_rng_samples], optional
-        Valid-sample mask with same shape as raw_data
-        if mask_valid is None, sample covariance matrix will be estimated by standard
-        matrix multiplication. Otherwise, sample covariance matrix estimation with invalid data
-        gap exclusion will be performed (NISAR dithered PRF mode).
+    swaths : np.ndarray [int], optional
+        Valid subswath samples, dims = (ns, nt, 2) where ns is the number of
+        sub-swaths, nt is the number of pulses, and the trailing dimension is
+        the [start, stop) indices of the sub-swath.  It's recommended to supply
+        this for modes with dithered PRI, where it will be used to normalize
+        the sample covariance matrix.
     raw_data_mitigated: array-like complex [num_pulses x num_rng_samples] or None, optional
         output array in which the mitigated data values is placed. It
         must be an array-like object supporting `multidimensional array access
@@ -171,28 +172,28 @@ def run_slow_time_evd(
         )
 
     # Verify mask_valid: check to see if it is None or populated.
-    # Ifi mask_valid is None, apply_gap_exclusion = False. Otherwise apply_gap_exclusion = True
-    if mask_valid is not None:
-        if mask_valid.shape != raw_data.shape:
-            raise ValueError(f"Valid raw data mask shape {mask_valid.shape} != raw data shape {raw_data.shape}")
+    if (swaths is not None) and (swaths.shape[1] != raw_data.shape[0]):
+        raise ValueError("Require same number of rows in swaths and raw_data")
 
-        mask_valid = mask_valid.astype(bool, copy=False)
-        apply_gap_exclusion = True
-    else:
-        mask_valid = np.ones(raw_data.shape, dtype=bool)
-        apply_gap_exclusion = False
-     
     # Determine a valid Eigenvalue index to estimate minimum-Eigenvalue statistics,
     # ensuring robustness against zero Eigenvalues caused by insufficient valid samples in a CPI.
     min_ev_valid_idx = max(1, int(np.round(min_rank_frac * cpi_len)) - 1)
 
     # Run RFI Detection and Mitigation
     for idx_tb, tb_slow_time in enumerate(slice_gen(num_pulses_proc, num_pulses_tb)):
+        # Get valid data mask for all rows in current block.
+        if swaths is not None:
+            swaths_tb = swaths[:, tb_slow_time, :]
+            mask_valid = np.zeros((swaths_tb.shape[1], raw_data.shape[1]), bool)
+            for i in range(mask_valid.shape[0]):
+                for start, end in swaths_tb[:, i, :]:
+                    mask_valid[i, start:end] = True
+
         for idx_rng, tb_fast_time in enumerate(
             slice_gen(num_rng_samples, num_samples_rng_blk, combine_rem=True)
         ):
             raw_tb_blk = raw_data[tb_slow_time, tb_fast_time]
-            mask_valid_tb = mask_valid[tb_slow_time, tb_fast_time]
+            mask_valid_tb = None if swaths is None else swaths_tb[:, tb_fast_time]
 
             (
                 rfi_cpi_flag_tb, 
@@ -207,7 +208,6 @@ def run_slow_time_evd(
                 max_num_rfi_ev=max_num_rfi_ev,
                 off_diag_overlap_ratio=off_diag_overlap_ratio,
                 diag_valid_ratio=diag_valid_ratio,
-                apply_gap_exclusion=apply_gap_exclusion,
                 rx_dynamic_range_db=rx_dynamic_range_db,
                 mask_valid=mask_valid_tb,
                 threshold_params=threshold_params,

--- a/python/packages/isce3/signal/rfi_process_evd.py
+++ b/python/packages/isce3/signal/rfi_process_evd.py
@@ -177,7 +177,7 @@ def run_slow_time_evd(
 
     # Verify Mask shape
     if mask_valid.shape != raw_data.shape:
-        raise ValueError(f"mask shape {mask_valid.shape} != data shape {raw_data.shape}")
+        raise ValueError(f"Valid raw data mask shape {mask_valid.shape} != raw data shape {raw_data.shape}")
     
     # Determine a valid Eigenvalue index to estimate minimum-Eigenvalue statistics,
     # ensuring robustness against zero Eigenvalues caused by insufficient valid samples in a CPI.

--- a/python/packages/isce3/signal/rfi_process_evd.py
+++ b/python/packages/isce3/signal/rfi_process_evd.py
@@ -19,11 +19,11 @@ def run_slow_time_evd(
     use_entire_pulse=False,
     threshold_params: ThresholdParams = ThresholdParams(),
     num_cpi_tb=20,
-    off_diag_overlap_ratio=0.2,
-    diag_valid_ratio=0.15,
+    off_diag_overlap_ratio=0.25,
+    diag_valid_ratio=0.20,
     mitigate_enable=False,
     prf_dither_mode=False,
-    normalized_min_rank_ratio=0.65,
+    min_rank_frac=0.70,
     rx_dynamic_range_db=50.0,
     mask_valid=None,
     raw_data_mitigated=None,
@@ -73,9 +73,9 @@ def run_slow_time_evd(
         from the mean of MMES.
     num_cpi_tb: int, default=20
         Number of slow-time CPIs in a TB
-    off_diag_overlap_ratio : float, optional
+    off_diag_overlap_ratio : float, optional, default = 0.25
         Minimum overlap ratio used by gap exclusion covariance estimation
-    diag_valid_ratio : float, optional
+    diag_valid_ratio : float, optional, default = 0.20
         Minimum fraction of valid samples required to compute a diagonal term in the
         sample covariance matrix entry R_ii.
     mitigate_enable: bool, default=False
@@ -83,9 +83,9 @@ def run_slow_time_evd(
     prf_dither_mode: bool
         If True, L0B acquisition is of PRF Dithering mode. Sample Covariance Matrix
         is computed differently by excluding the invalid data gaps.
-    normalized_min_rank_ratio: float
-        This ratio will be used to determine the minimum number of valid Eigenvalues
-        required for a CPI. min_ev_valid_idx = int(np.floor(normalized_min_rank_ratio * cpi_len))
+    min_rank_frac: float, default = 0.7
+        This fraction will be used to determine the minimum number of valid Eigenvalues
+        required for a CPI. min_ev_valid_idx = int(np.floor(min_rank_frac * cpi_len))
         Must be a value within (0,1]
     rx_dynamic_range_db: int, optional, default = 50 dB
         radar platform receiver dynamic range. This is applied as a threshold
@@ -150,10 +150,10 @@ def run_slow_time_evd(
                 " as the input data"
             )
 
-    # Verify normalized_min_rank_ratio
-    if not (0.0 < normalized_min_rank_ratio <= 1.0):
+    # Verify min_rank_frac
+    if not (0.0 < min_rank_frac <= 1.0):
         raise ValueError(
-            f"normalized_min_rank_ratio must be in (0, 1], got {normalized_min_rank_ratio}."
+            f"min_rank_frac must be in (0, 1], got {min_rank_frac}."
         )
 
     # Create a mask if no mask if provided
@@ -181,7 +181,7 @@ def run_slow_time_evd(
     
     # Determine a valid Eigenvalue index to estimate minimum-Eigenvalue statistics,
     # ensuring robustness against zero Eigenvalues caused by insufficient valid samples in a CPI.
-    min_ev_valid_idx = int(np.floor(normalized_min_rank_ratio * cpi_len))
+    min_ev_valid_idx = max(1, int(np.round(min_rank_frac * cpi_len)) - 1)
 
     # Run RFI Detection and Mitigation
     for idx_tb, tb_slow_time in enumerate(slice_gen(num_pulses_proc, num_pulses_tb)):

--- a/python/packages/isce3/signal/rfi_process_evd.py
+++ b/python/packages/isce3/signal/rfi_process_evd.py
@@ -86,6 +86,7 @@ def run_slow_time_evd(
     normalized_min_rank_ratio: float
         This ratio will be used to determine the minimum number of valid Eigenvalues
         required for a CPI. min_ev_valid_idx = int(np.floor(normalized_min_rank_ratio * cpi_len))
+        Must be a value within (0,1]
     rx_dynamic_range_db: int, optional, default = 50 dB
         radar platform receiver dynamic range. This is applied as a threshold
         to determine if the Eigenvalue under test is meaningfully signficant. If the
@@ -150,9 +151,9 @@ def run_slow_time_evd(
             )
 
     # Verify normalized_min_rank_ratio
-    if normalized_min_rank_ratio >= 1:
+    if not (0.0 < normalized_min_rank_ratio <= 1.0):
         raise ValueError(
-            f"normalized_min_rank_ratio must be less than 1, got {normalized_min_rank_ratio}."
+            f"normalized_min_rank_ratio must be in (0, 1], got {normalized_min_rank_ratio}."
         )
 
     # Create a mask if no mask if provided

--- a/python/packages/isce3/signal/rfi_process_evd.py
+++ b/python/packages/isce3/signal/rfi_process_evd.py
@@ -3,7 +3,8 @@ Perform RFI detection and mitigation of input raw data using Slow-Time Eigenvalu
 (ST-EVD).
 """
 import numpy as np
-from isce3.signal.compute_evd_cpi import slice_gen
+from numpy.fft import fft, ifft, fftshift
+from isce3.signal.compute_evd_cpi import slice_gen, compute_evd_tb_gap
 from isce3.signal.rfi_detection_evd import rfi_detect, ThresholdParams
 from isce3.signal.rfi_mitigation_evd import rfi_mitigate_tb
 
@@ -15,11 +16,16 @@ def run_slow_time_evd(
     num_max_trim=0,
     num_min_trim=0,
     max_num_rfi_ev=2,
-    num_samples_rng_blk=256,
+    num_samples_rng_blk=1000,
     use_entire_pulse=False,
     threshold_params: ThresholdParams = ThresholdParams(),
     num_cpi_tb=20,
+    off_diag_overlap_ratio=0.1,
+    diag_valid_ratio=0.05,
     mitigate_enable=False,
+    prf_dither_mode=False,
+    noise_ev_idx=10,
+    mask_valid=None,
     raw_data_mitigated=None,
 ):
 
@@ -67,8 +73,21 @@ def run_slow_time_evd(
         from the mean of MMES.
     num_cpi_tb: int, default=20
         Number of slow-time CPIs in a TB
+    off_diag_overlap_ratio : float, optional
+        Minimum overlap ratio used by gap exclusion covariance estimation
+    diag_valid_ratio : float, optional
+        Minimum fraction of valid samples required to compute a diagonal term in the
+        sample covariance matrix entry R_ii.
     mitigate_enable: bool, default=False
         Enable mitigation
+    prf_dither_mode: bool
+        If True, L0B acquisition is of PRF Dithering mode. Sample Covariance Matrix
+        is computed differently by excluding the invalid data gaps.
+    noise_ev_idx : int
+        Eigenvalue index used by threshold estimation to estimate the slow-time minimum
+        Eigenvalue slope
+    mask_valid : np.ndarray bool, [num_pulses x num_rng_samples], optional
+        Valid-sample mask with same shape as raw_data
     raw_data_mitigated: array-like complex [num_pulses x num_rng_samples] or None, optional
         output array in which the mitigated data values is placed. It
         must be an array-like object supporting `multidimensional array access
@@ -114,6 +133,11 @@ def run_slow_time_evd(
     num_pulses_proc = cpi_len * num_cpi
     num_pulses_tb = cpi_len * num_cpi_tb
 
+    num_tb = num_pulses_proc // num_pulses_tb
+
+    figure_merit_array = np.zeros((num_tb, num_rng_blks), dtype=np.float32)
+    num_rfi_ev_tb_array = np.zeros((num_tb, num_rng_blks), dtype=np.int16)
+
     # Modify raw_data in-place
     if raw_data_mitigated is None:
         raw_data_mitigated = raw_data
@@ -123,6 +147,10 @@ def run_slow_time_evd(
                 "Shape mismatch: output mitigated data array must have the same shape"
                 " as the input data"
             )
+
+    # Create a mask if no mask if provided
+    if mask_valid is None:
+        mask_valid = np.ones(raw_data.shape, dtype=bool)
 
     # Collect total number of CPI range blocks contaminated by RFI
     rfi_cpi_count_sum = 0
@@ -139,23 +167,43 @@ def run_slow_time_evd(
             "Max number of deg. of freedom must be less than number of pulses in a CPI."
         )
 
+    # Verify noise_ev_idx
+    if noise_ev_idx >= cpi_len:
+        raise ValueError(
+            f"noise_ev_idx must be less than {cpi_len - 1}, got {noise_ev_idx}."
+    )
+
+    # Verify Mask shape
+    if mask_valid.shape != raw_data.shape:
+        raise ValueError(f"mask shape {mask_valid.shape} != data shape {raw_data.shape}")
+    
     # Run RFI Detection and Mitigation
     for idx_tb, tb_slow_time in enumerate(slice_gen(num_pulses_proc, num_pulses_tb)):
         for idx_rng, tb_fast_time in enumerate(
-            slice_gen(num_rng_samples, num_samples_rng_blk)
+            slice_gen(num_rng_samples, num_samples_rng_blk, combine_rem=True)
         ):
             raw_tb_blk = raw_data[tb_slow_time, tb_fast_time]
+            mask_valid_tb = mask_valid[tb_slow_time, tb_fast_time]
 
-            (rfi_cpi_flag_tb, evec_sort_tb) = rfi_detect(
+            (
+                rfi_cpi_flag_tb, 
+                evec_sort_tb, 
+            ) = rfi_detect(
                 raw_tb_blk,
                 cpi_len,
                 max_deg_freedom,
                 num_max_trim,
                 num_min_trim,
                 max_num_rfi_ev,
+                off_diag_overlap_ratio,
+                diag_valid_ratio,
+                prf_dither_mode,
+                noise_ev_idx,
+                mask_valid_tb,
                 threshold_params,
             )
 
+            # Compute number of CPIs detected with RFI presence
             num_rfi_ev_cpi = np.sum(rfi_cpi_flag_tb, axis=1)
             rfi_cpi_count = np.sum(num_rfi_ev_cpi != 0)
             rfi_cpi_count_sum += rfi_cpi_count

--- a/python/packages/isce3/signal/rfi_process_evd.py
+++ b/python/packages/isce3/signal/rfi_process_evd.py
@@ -3,7 +3,6 @@ Perform RFI detection and mitigation of input raw data using Slow-Time Eigenvalu
 (ST-EVD).
 """
 import numpy as np
-from numpy.fft import fft, ifft, fftshift
 from isce3.signal.compute_evd_cpi import slice_gen
 from isce3.signal.rfi_detection_evd import rfi_detect, ThresholdParams
 from isce3.signal.rfi_mitigation_evd import rfi_mitigate_tb

--- a/python/packages/isce3/signal/rfi_process_evd.py
+++ b/python/packages/isce3/signal/rfi_process_evd.py
@@ -193,7 +193,7 @@ def run_slow_time_evd(
             slice_gen(num_rng_samples, num_samples_rng_blk, combine_rem=True)
         ):
             raw_tb_blk = raw_data[tb_slow_time, tb_fast_time]
-            mask_valid_tb = None if swaths is None else swaths_tb[:, tb_fast_time]
+            mask_valid_tb = None if swaths is None else mask_valid[:, tb_fast_time]
 
             (
                 rfi_cpi_flag_tb, 

--- a/python/packages/isce3/signal/rfi_process_evd.py
+++ b/python/packages/isce3/signal/rfi_process_evd.py
@@ -197,21 +197,20 @@ def run_slow_time_evd(
             (
                 rfi_cpi_flag_tb, 
                 evec_sort_tb, 
-                fig_merit_detect_tb,
             ) = rfi_detect(
                 raw_tb_blk,
                 cpi_len,
                 max_deg_freedom,
-                num_max_trim,
-                num_min_trim,
-                max_num_rfi_ev,
-                off_diag_overlap_ratio,
-                diag_valid_ratio,
-                apply_gap_exclusion,
                 min_ev_valid_idx,
-                rx_dynamic_range_db,
-                mask_valid_tb,
-                threshold_params,
+                num_max_trim=num_max_trim,
+                num_min_trim=num_min_trim,
+                max_num_rfi_ev=max_num_rfi_ev,
+                off_diag_overlap_ratio=off_diag_overlap_ratio,
+                diag_valid_ratio=diag_valid_ratio,
+                apply_gap_exclusion=apply_gap_exclusion,
+                rx_dynamic_range_db=rx_dynamic_range_db,
+                mask_valid=mask_valid_tb,
+                threshold_params=threshold_params,
             )
 
             # Compute number of CPIs detected with RFI presence

--- a/python/packages/isce3/signal/rfi_process_evd.py
+++ b/python/packages/isce3/signal/rfi_process_evd.py
@@ -4,7 +4,7 @@ Perform RFI detection and mitigation of input raw data using Slow-Time Eigenvalu
 """
 import numpy as np
 from numpy.fft import fft, ifft, fftshift
-from isce3.signal.compute_evd_cpi import slice_gen, compute_evd_tb_gap
+from isce3.signal.compute_evd_cpi import slice_gen
 from isce3.signal.rfi_detection_evd import rfi_detect, ThresholdParams
 from isce3.signal.rfi_mitigation_evd import rfi_mitigate_tb
 
@@ -16,15 +16,16 @@ def run_slow_time_evd(
     num_max_trim=0,
     num_min_trim=0,
     max_num_rfi_ev=2,
-    num_samples_rng_blk=1000,
+    num_samples_rng_blk=250,
     use_entire_pulse=False,
     threshold_params: ThresholdParams = ThresholdParams(),
     num_cpi_tb=20,
-    off_diag_overlap_ratio=0.1,
-    diag_valid_ratio=0.05,
+    off_diag_overlap_ratio=0.2,
+    diag_valid_ratio=0.15,
     mitigate_enable=False,
     prf_dither_mode=False,
-    noise_ev_idx=10,
+    min_valid_ev_ratio=0.65,
+    rx_dynamic_range_db=-50,
     mask_valid=None,
     raw_data_mitigated=None,
 ):
@@ -83,9 +84,13 @@ def run_slow_time_evd(
     prf_dither_mode: bool
         If True, L0B acquisition is of PRF Dithering mode. Sample Covariance Matrix
         is computed differently by excluding the invalid data gaps.
-    noise_ev_idx : int
-        Eigenvalue index used by threshold estimation to estimate the slow-time minimum
-        Eigenvalue slope
+    min_valid_ev_ratio: float
+        This ratio will be used to determine the minimum number of valid Eigenvalues
+        required for a CPI. min_ev_valid_idx = min_valid_ev_ratio * cpi_len
+    rx_dynamic_range_db: int, optional
+        radar platform receiver dynamic range, e.g. -50 dB. This is applied as a threshold
+        to determine if the Eigenvalue under test is meaningfully signficant. If the
+        Eigenvalue under test is less than this threshold, it will be viewed as unusable.
     mask_valid : np.ndarray bool, [num_pulses x num_rng_samples], optional
         Valid-sample mask with same shape as raw_data
     raw_data_mitigated: array-like complex [num_pulses x num_rng_samples] or None, optional
@@ -135,9 +140,6 @@ def run_slow_time_evd(
 
     num_tb = num_pulses_proc // num_pulses_tb
 
-    figure_merit_array = np.zeros((num_tb, num_rng_blks), dtype=np.float32)
-    num_rfi_ev_tb_array = np.zeros((num_tb, num_rng_blks), dtype=np.int16)
-
     # Modify raw_data in-place
     if raw_data_mitigated is None:
         raw_data_mitigated = raw_data
@@ -147,6 +149,12 @@ def run_slow_time_evd(
                 "Shape mismatch: output mitigated data array must have the same shape"
                 " as the input data"
             )
+
+    # Verify min_valid_ev_ratio
+    if min_valid_ev_ratio >= 1:
+        raise ValueError(
+            f"min_valid_ev_ratio must be less than 1, got {min_valid_ev_ratio}."
+        )
 
     # Create a mask if no mask if provided
     if mask_valid is None:
@@ -167,16 +175,14 @@ def run_slow_time_evd(
             "Max number of deg. of freedom must be less than number of pulses in a CPI."
         )
 
-    # Verify noise_ev_idx
-    if noise_ev_idx >= cpi_len:
-        raise ValueError(
-            f"noise_ev_idx must be less than {cpi_len - 1}, got {noise_ev_idx}."
-    )
-
     # Verify Mask shape
     if mask_valid.shape != raw_data.shape:
         raise ValueError(f"mask shape {mask_valid.shape} != data shape {raw_data.shape}")
     
+    # Determine a valid Eigenvalue index to estimate minimum-Eigenvalue statistics,
+    # ensuring robustness against zero Eigenvalues caused by insufficient valid samples in a CPI.
+    min_ev_valid_idx = int(np.floor(min_valid_ev_ratio * cpi_len))
+
     # Run RFI Detection and Mitigation
     for idx_tb, tb_slow_time in enumerate(slice_gen(num_pulses_proc, num_pulses_tb)):
         for idx_rng, tb_fast_time in enumerate(
@@ -188,6 +194,7 @@ def run_slow_time_evd(
             (
                 rfi_cpi_flag_tb, 
                 evec_sort_tb, 
+                fig_merit_detect_tb,
             ) = rfi_detect(
                 raw_tb_blk,
                 cpi_len,
@@ -198,7 +205,8 @@ def run_slow_time_evd(
                 off_diag_overlap_ratio,
                 diag_valid_ratio,
                 prf_dither_mode,
-                noise_ev_idx,
+                min_ev_valid_idx,
+                rx_dynamic_range_db,
                 mask_valid_tb,
                 threshold_params,
             )

--- a/python/packages/isce3/signal/rfi_process_evd.py
+++ b/python/packages/isce3/signal/rfi_process_evd.py
@@ -25,7 +25,7 @@ def run_slow_time_evd(
     mitigate_enable=False,
     prf_dither_mode=False,
     min_valid_ev_ratio=0.65,
-    rx_dynamic_range_db=-50,
+    rx_dynamic_range_db=-50.0,
     mask_valid=None,
     raw_data_mitigated=None,
 ):

--- a/python/packages/isce3/signal/rfi_process_evd.py
+++ b/python/packages/isce3/signal/rfi_process_evd.py
@@ -24,7 +24,7 @@ def run_slow_time_evd(
     mitigate_enable=False,
     prf_dither_mode=False,
     min_valid_ev_ratio=0.65,
-    rx_dynamic_range_db=-50.0,
+    rx_dynamic_range_db=50.0,
     mask_valid=None,
     raw_data_mitigated=None,
 ):
@@ -86,8 +86,8 @@ def run_slow_time_evd(
     min_valid_ev_ratio: float
         This ratio will be used to determine the minimum number of valid Eigenvalues
         required for a CPI. min_ev_valid_idx = min_valid_ev_ratio * cpi_len
-    rx_dynamic_range_db: int, optional
-        radar platform receiver dynamic range, e.g. -50 dB. This is applied as a threshold
+    rx_dynamic_range_db: int, optional, default = 50 dB
+        radar platform receiver dynamic range. This is applied as a threshold
         to determine if the Eigenvalue under test is meaningfully signficant. If the
         Eigenvalue under test is less than this threshold, it will be viewed as unusable.
     mask_valid : np.ndarray bool, [num_pulses x num_rng_samples], optional

--- a/python/packages/isce3/signal/rfi_process_evd.py
+++ b/python/packages/isce3/signal/rfi_process_evd.py
@@ -23,7 +23,7 @@ def run_slow_time_evd(
     diag_valid_ratio=0.15,
     mitigate_enable=False,
     prf_dither_mode=False,
-    min_valid_ev_ratio=0.65,
+    normalized_min_rank_ratio=0.65,
     rx_dynamic_range_db=50.0,
     mask_valid=None,
     raw_data_mitigated=None,
@@ -83,9 +83,9 @@ def run_slow_time_evd(
     prf_dither_mode: bool
         If True, L0B acquisition is of PRF Dithering mode. Sample Covariance Matrix
         is computed differently by excluding the invalid data gaps.
-    min_valid_ev_ratio: float
+    normalized_min_rank_ratio: float
         This ratio will be used to determine the minimum number of valid Eigenvalues
-        required for a CPI. min_ev_valid_idx = min_valid_ev_ratio * cpi_len
+        required for a CPI. min_ev_valid_idx = int(np.floor(normalized_min_rank_ratio * cpi_len))
     rx_dynamic_range_db: int, optional, default = 50 dB
         radar platform receiver dynamic range. This is applied as a threshold
         to determine if the Eigenvalue under test is meaningfully signficant. If the
@@ -149,10 +149,10 @@ def run_slow_time_evd(
                 " as the input data"
             )
 
-    # Verify min_valid_ev_ratio
-    if min_valid_ev_ratio >= 1:
+    # Verify normalized_min_rank_ratio
+    if normalized_min_rank_ratio >= 1:
         raise ValueError(
-            f"min_valid_ev_ratio must be less than 1, got {min_valid_ev_ratio}."
+            f"normalized_min_rank_ratio must be less than 1, got {normalized_min_rank_ratio}."
         )
 
     # Create a mask if no mask if provided
@@ -180,7 +180,7 @@ def run_slow_time_evd(
     
     # Determine a valid Eigenvalue index to estimate minimum-Eigenvalue statistics,
     # ensuring robustness against zero Eigenvalues caused by insufficient valid samples in a CPI.
-    min_ev_valid_idx = int(np.floor(min_valid_ev_ratio * cpi_len))
+    min_ev_valid_idx = int(np.floor(normalized_min_rank_ratio * cpi_len))
 
     # Run RFI Detection and Mitigation
     for idx_tb, tb_slow_time in enumerate(slice_gen(num_pulses_proc, num_pulses_tb)):

--- a/python/packages/isce3/signal/rfi_process_evd.py
+++ b/python/packages/isce3/signal/rfi_process_evd.py
@@ -83,7 +83,7 @@ def run_slow_time_evd(
         This fraction will be used to determine the minimum number of valid Eigenvalues
         required for a CPI. min_ev_valid_idx = int(np.floor(min_rank_frac * cpi_len))
         Must be a value within (0,1]
-    rx_dynamic_range_db: int, optional, default = 50 dB
+    rx_dynamic_range_db: float, optional, default = 50 dB
         radar platform receiver dynamic range. This is applied as a threshold
         to determine if the Eigenvalue under test is meaningfully signficant. If the
         Eigenvalue under test is less than this threshold, it will be viewed as unusable.

--- a/python/packages/isce3/signal/rfi_process_evd.py
+++ b/python/packages/isce3/signal/rfi_process_evd.py
@@ -6,6 +6,7 @@ import numpy as np
 from isce3.signal.compute_evd_cpi import slice_gen
 from isce3.signal.rfi_detection_evd import rfi_detect, ThresholdParams
 from isce3.signal.rfi_mitigation_evd import rfi_mitigate_tb
+import warnings
 
 def run_slow_time_evd(
     raw_data: np.ndarray,
@@ -84,7 +85,7 @@ def run_slow_time_evd(
         required for a CPI. min_ev_valid_idx = int(np.floor(min_rank_frac * cpi_len))
         Must be a value within (0,1]
     rx_dynamic_range_db: float, optional, default = 50 dB
-        radar platform receiver dynamic range. This is applied as a threshold
+        radar platform receiver dynamic range in dB. This is applied as a threshold
         to determine if the Eigenvalue under test is meaningfully signficant. If the
         Eigenvalue under test is less than this threshold, it will be viewed as unusable.
     swaths : np.ndarray [int], optional
@@ -138,8 +139,6 @@ def run_slow_time_evd(
     num_pulses_proc = cpi_len * num_cpi
     num_pulses_tb = cpi_len * num_cpi_tb
 
-    num_tb = num_pulses_proc // num_pulses_tb
-
     # Modify raw_data in-place
     if raw_data_mitigated is None:
         raw_data_mitigated = raw_data
@@ -179,17 +178,25 @@ def run_slow_time_evd(
     # ensuring robustness against zero Eigenvalues caused by insufficient valid samples in a CPI.
     min_ev_valid_idx = max(1, int(np.round(min_rank_frac * cpi_len)) - 1)
 
+    # Maximum number of degrees of freedom must be less than max_deg_freedom
+    if max_deg_freedom >= min_ev_valid_idx:
+        warnings.warn(
+            f"max_deg_freedom ({max_deg_freedom}) >= min_ev_valid_idx ({min_ev_valid_idx})."
+            "This is not recommended since it may lead to insufficient noise subspace.",
+            RuntimeWarning
+        )
+
     # Run RFI Detection and Mitigation
-    for idx_tb, tb_slow_time in enumerate(slice_gen(num_pulses_proc, num_pulses_tb)):
+    for _, tb_slow_time in enumerate(slice_gen(num_pulses_proc, num_pulses_tb)):
         # Get valid data mask for all rows in current block.
         if swaths is not None:
             swaths_tb = swaths[:, tb_slow_time, :]
-            mask_valid = np.zeros((swaths_tb.shape[1], raw_data.shape[1]), bool)
+            mask_valid = np.zeros((swaths_tb.shape[1], raw_data.shape[1]), dtype=bool)
             for i in range(mask_valid.shape[0]):
                 for start, end in swaths_tb[:, i, :]:
                     mask_valid[i, start:end] = True
 
-        for idx_rng, tb_fast_time in enumerate(
+        for _, tb_fast_time in enumerate(
             slice_gen(num_rng_samples, num_samples_rng_blk, combine_rem=True)
         ):
             raw_tb_blk = raw_data[tb_slow_time, tb_fast_time]

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1078,7 +1078,7 @@ def resample(raw: np.ndarray, t: np.ndarray,
 
 
 def process_rfi(cfg: Struct, raw_data: np.ndarray, swaths: np.ndarray,
-                prf_dither_mode: bool, tmpfile: Callable = lambda name: open(name, "wb")):
+                tmpfile: Callable = lambda name: open(name, "wb")):
     """
     Run radio frequency interference (RFI) detection and mitigation as
     configured by user input.
@@ -1093,9 +1093,6 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray, swaths: np.ndarray,
         Valid subswath samples, dims = (ns, nt, 2) where ns is the number of
         sub-swaths, nt is the number of pulses, and the trailing dimension is
         the [start, stop) indices of the sub-swath.
-    prf_dither_mode: bool
-        If True, L0B acquisition is of PRF Dithering mode. Sample Covariance Matrix
-        is computed differently by excluding the invalid data gaps.
     tmpfile : Callable
         Function of a single string argument that returns an open file handle.
 
@@ -1163,8 +1160,7 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray, swaths: np.ndarray,
             off_diag_overlap_ratio=opt_evd.off_diag_overlap_ratio,
             diag_valid_ratio=opt_evd.diag_valid_ratio,
             mitigate_enable=opt.mitigation_enabled,
-            prf_dither_mode=prf_dither_mode,
-            normalized_min_rank_ratio=opt_evd.normalized_min_rank_ratio,
+            min_rank_frac=opt_evd.min_rank_frac,
             rx_dynamic_range_db=opt_evd.rx_dynamic_range_db,
             mask_valid=mask_valid,
             raw_data_mitigated=raw_data_mitigated)
@@ -1962,7 +1958,6 @@ def focus(runconfig, runconfig_path=""):
                 cfg, 
                 raw_mm, 
                 swaths,
-                raw.isDithered(channel_in.freq_id),
                 temp
             )
             rfi_results[(frequency, pol)].append(

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1164,7 +1164,7 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray, swaths: np.ndarray,
             diag_valid_ratio=opt_evd.diag_valid_ratio,
             mitigate_enable=opt.mitigation_enabled,
             prf_dither_mode=prf_dither_mode,
-            min_valid_ev_ratio=opt_evd.min_valid_ev_ratio,
+            normalized_min_rank_ratio=opt_evd.normalized_min_rank_ratio,
             rx_dynamic_range_db=opt_evd.rx_dynamic_range_db,
             mask_valid=mask_valid,
             raw_data_mitigated=raw_data_mitigated)

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1165,7 +1165,8 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray, swaths: np.ndarray,
             diag_valid_ratio=opt_evd.diag_valid_ratio,
             mitigate_enable=opt.mitigation_enabled,
             prf_dither_mode=prf_dither_mode,
-            noise_ev_idx=opt_evd.noise_ev_idx,
+            min_valid_ev_ratio=opt_evd.min_valid_ev_ratio,
+            rx_dynamic_range_db=rx_dynamic_range_db,
             mask_valid=mask_valid,
             raw_data_mitigated=raw_data_mitigated)
     else:

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1166,7 +1166,7 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray, swaths: np.ndarray,
             mitigate_enable=opt.mitigation_enabled,
             prf_dither_mode=prf_dither_mode,
             min_valid_ev_ratio=opt_evd.min_valid_ev_ratio,
-            rx_dynamic_range_db=rx_dynamic_range_db,
+            rx_dynamic_range_db=opt_evd.rx_dynamic_range_db,
             mask_valid=mask_valid,
             raw_data_mitigated=raw_data_mitigated)
     else:

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -16,7 +16,14 @@ from nisar.mixed_mode import (PolChannel, PolChannelSet, Band,
     find_overlapping_channel)
 from nisar.products.readers.antenna import AntennaParser
 from nisar.products.readers.instrument import InstrumentParser
-from nisar.products.readers.Raw import Raw, open_rrsd
+from nisar.products.readers.Raw import (
+    Raw,
+    open_rrsd,
+    chirpcorrelator_caltype_from_raw,
+    is_raw_quad_pol,
+    first_tx_pol_for_quad,
+    opposite_linear_pol
+)
 from nisar.products.readers.rslc_cal import (RslcCalibration,
     parse_rslc_calibration, get_scale_and_delay, check_cal_validity_dates)
 from nisar.products.writers import SLC
@@ -41,6 +48,7 @@ import tempfile
 from typing import Union, Optional, Callable, Iterable, overload
 from isce3.io import Raster as RasterIO
 from io import StringIO
+import pathlib
 
 
 # TODO some CSV logger
@@ -291,12 +299,13 @@ def get_total_grid_bounds(rawfiles: list[str]):
     return epoch, tmin, tmax, rmin, rmax
 
 
-def get_total_grid(rawfiles: list[str], dt, dr):
+def get_total_grid(rawfiles: list[str], dt, dr,
+                   az_margin_in_pixels, rg_margin_in_pixels):
     epoch, tmin, tmax, rmin, rmax = get_total_grid_bounds(rawfiles)
-    nt = int(np.ceil((tmax - tmin) / dt)) + 1
-    nr = int(np.ceil((rmax - rmin) / dr)) + 1
-    t = isce3.core.Linspace(tmin, dt, nt)
-    r = isce3.core.Linspace(rmin, dr, nr)
+    nt = int(np.ceil((tmax - tmin) / dt)) + 1 + 2 * az_margin_in_pixels
+    nr = int(np.ceil((rmax - rmin) / dr)) + 1 + 2 * rg_margin_in_pixels
+    t = isce3.core.Linspace(tmin - az_margin_in_pixels * dt, dt, nt)
+    r = isce3.core.Linspace(rmin - rg_margin_in_pixels * dr, dr, nr)
     return epoch, t, r
 
 
@@ -327,6 +336,8 @@ def make_doppler_lut(rawfiles: list[str],
         dem: Optional[isce3.geometry.DEMInterpolator] = None,
         azimuth_spacing: float = 1.0,
         range_spacing: float = 1e3,
+        az_margin_in_pixels: int = 11,
+        rg_margin_in_pixels: int = 11,
         interp_method: str = "bilinear",
         epoch: Optional[DateTime] = None):
     """Generate Doppler look up table (LUT).
@@ -351,6 +362,10 @@ def make_doppler_lut(rawfiles: list[str],
         LUT grid spacing in azimuth, in seconds.  Default=1 s.
     range_spacing : optional
         LUT grid spacing in range, in meters.  Default=1000 m.
+    az_margin_in_pixels : int, optional
+        Extra margin added to LUT grid in azimuth, in pixels. Default=11 pixels.
+    rg_margin_in_pixels : int, optional
+        Extra margin added to LUT grid in range, in pixels. Default=11 pixels.
     interp_method : optional
         LUT interpolation method. Default="bilinear".
     epoch : isce3.core.DateTime, optional
@@ -397,7 +412,11 @@ def make_doppler_lut(rawfiles: list[str],
 
     # Now do the actual calculations.
     wvl = isce3.core.speed_of_light / fc
-    epoch_in, t, r = get_total_grid(rawfiles, azimuth_spacing, range_spacing)
+
+    epoch_in, t, r = get_total_grid(
+        rawfiles, azimuth_spacing, range_spacing,
+        az_margin_in_pixels=az_margin_in_pixels,
+        rg_margin_in_pixels=rg_margin_in_pixels)
 
     # If timespan is too small, only one time may be provided, causing the LUT
     # construction to fail. Fall back to t ± Δt/2 to preserve az spacing.
@@ -408,6 +427,22 @@ def make_doppler_lut(rawfiles: list[str],
         t = [tmin, tmax]
 
     t = convert_epoch(t, epoch_in, epoch)
+
+    # crop the azimuth time using orbit and attitude extents
+    min_time = max([orbit.start_time, attitude.start_time])
+    max_time = min([orbit.end_time, attitude.end_time])
+
+    t = np.asarray(t)
+    if np.any(t <= min_time):
+        log.warning(f"Desired Doppler LUT start time is {min_time - t[0]} "
+            "seconds before ephemeris start. Consider adjusting "
+            "ephemeris_crop_pad or providing more orbit/attitude data.")
+    if np.any(t >= max_time):
+        log.warning(f"Desired Doppler LUT end time is {t[-1] - max_time} "
+            "seconds after ephemeris end. Consider adjusting "
+            "ephemeris_crop_pad or providing more orbit/attitude data.")
+    t = t[(t > min_time) & (t < max_time)]
+
     lut = isce3.geometry.make_doppler_lut_from_attitude(
         az_time=t,
         slant_range=r,
@@ -440,11 +475,15 @@ def make_doppler(cfg: Struct, *, epoch: Optional[DateTime] = None,
     az = np.radians(opt.azimuth_boresight_deg)
     rawfiles = cfg.input_file_group.input_file_path
 
-    fc, lut = make_doppler_lut(rawfiles,
-                               az=az, orbit=orbit, attitude=attitude,
-                               dem=dem, azimuth_spacing=opt.spacing.azimuth,
-                               range_spacing=opt.spacing.range,
-                               interp_method=opt.interp_method,  epoch=epoch)
+    fc, lut = make_doppler_lut(
+        rawfiles,
+        az=az, orbit=orbit, attitude=attitude,
+        dem=dem, azimuth_spacing=opt.spacing.azimuth,
+        range_spacing=opt.spacing.range,
+        az_margin_in_pixels=opt.margin_in_pixels.azimuth,
+        rg_margin_in_pixels=opt.margin_in_pixels.range,
+        interp_method=opt.interp_method,
+        epoch=epoch)
 
     log.info(f"Made Doppler LUT for fc={fc} Hz, "
         f"az={opt.azimuth_boresight_deg} deg with mean={lut.data.mean()} Hz")
@@ -909,7 +948,7 @@ def get_dataset_creation_options(cfg: Struct, shape: tuple[int, int]) -> dict:
     """
     Get h5py keyword arguments needed for image dataset creation.
 
-    #Parameters
+    Parameters
     ----------
     cfg : Struct
         RSLC runconfig data. Only reads `cfg.output` group.
@@ -1039,7 +1078,7 @@ def resample(raw: np.ndarray, t: np.ndarray,
 
 
 def process_rfi(cfg: Struct, raw_data: np.ndarray, swaths: np.ndarray,
-                prf_dither_mode, tmpfile: Callable = lambda name: open(name, "wb")):
+                prf_dither_mode: bool, tmpfile: Callable = lambda name: open(name, "wb")):
     """
     Run radio frequency interference (RFI) detection and mitigation as
     configured by user input.
@@ -1055,8 +1094,8 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray, swaths: np.ndarray,
         sub-swaths, nt is the number of pulses, and the trailing dimension is
         the [start, stop) indices of the sub-swath.
     prf_dither_mode: bool
-        If True, L0B acquisition with respect to the specified frequency is of 
-        Dithered PRF mode
+        If True, L0B acquisition is of PRF Dithering mode. Sample Covariance Matrix
+        is computed differently by excluding the invalid data gaps.
     tmpfile : Callable
         Function of a single string argument that returns an open file handle.
 
@@ -1088,21 +1127,16 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray, swaths: np.ndarray,
     # Mitigate in place unless user wants a debug file to compare raw and
     # mitigated data.  This means you'd need to run the workflow twice to find
     # a bug specific to in-place vs out-of-place processing.
-    
-    num_pulses, num_rng_samples = raw_data.shape
 
-    mask_valid = np.zeros((num_pulses, num_rng_samples), dtype=bool)
+    num_pulses = raw_data.shape[0]
+    mask_valid = np.zeros(raw_data.shape, dtype=bool)
     pulse_idx = np.arange(num_pulses)
 
-    print('\nfocus.py running')
-    print(f'{raw_data.shape = }')
-    print()
-
+    # Read Sub-Swath Mask for all pulses of the raw data block
     for imask, ipulse in enumerate(pulse_idx):
         for swath in swaths:
             start, end = swath[ipulse]
             mask_valid[imask, start:end] = True
-
 
     raw_data_mitigated = raw_data
     if opt.mitigation_enabled and not cfg.processing.delete_tempfiles:
@@ -1136,20 +1170,16 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray, swaths: np.ndarray,
             raw_data_mitigated=raw_data_mitigated)
     else:
         opt_fnf = opt.freq_notch_filter
-        threshold_params_notch = isce3.signal.rfi_freq_null.ThresholdParamsNotch(
-            opt_fnf.threshold_hyperparameters.x, opt_fnf.threshold_hyperparameters.y)
-
         rfi_likelihood = isce3.signal.rfi_freq_null.run_freq_notch(
             raw_data,
             opt_fnf.num_pulses_az,
-            num_samples_rng_blk=opt.num_samples_rng_blk,
+            num_rng_blks=opt.num_range_blocks,
             az_winsize=opt_fnf.az_winsize,
             rng_winsize=opt_fnf.rng_winsize,
             trim_frac=opt_fnf.trim_frac,
+            pvalue_threshold=opt_fnf.pvalue_threshold,
             cdf_threshold=opt_fnf.cdf_threshold,
             use_entire_pulse=opt.use_entire_pulse,
-            false_alarm_rate=opt_fnf.false_alarm_rate,
-            threshold_params_notch=threshold_params_notch,
             nb_detect=opt_fnf.nb_detect,
             wb_detect=opt_fnf.wb_detect,
             mitigate_enable=opt.mitigation_enabled,
@@ -1428,7 +1458,7 @@ def set_input_file_metadata(cfg: Struct, slc: SLC, runconfig_path: str = ""):
     anc = cfg.dynamic_ancillary_file_group
     value_or_blank = lambda x: x if x is not None else ""
     slc.set_inputs(
-        l0bGranules=cfg.input_file_group.input_file_path,
+        l0bGranules=[pathlib.PosixPath(f).name for f in cfg.input_file_group.input_file_path],
         orbitFiles=[value_or_blank(anc.orbit)],
         attitudeFiles=[value_or_blank(anc.pointing)],
         auxcalFiles=[value_or_blank(x) for x in (anc.external_calibration,
@@ -1796,12 +1826,24 @@ def focus(runconfig, runconfig_path=""):
         cal = get_calibration(cfg, band.width)
         slc.set_calibration(cal, frequency)
 
-        # add calibration section for each polarization
-        for pol in pols:
-            slc.add_calibration_section(frequency, pol, og.sensing_times,
-                                        orbit.reference_epoch, og.slant_ranges,
-                                        beta0_lut, sigma0_lut, gamma0_lut)
+        # add calibration section based on a downsampled radar grid,
+        # including an extra margin to ensure that, after geocoding
+        # with an interpolation algoritm (e.g., bicubic spline),
+        # the LUTs fully cover the geocoded imagery extents.
 
+        multilooked_radar_grid = og.multilook(
+            cfg.processing.lookup_tables.downsampling_factor.azimuth,
+            cfg.processing.lookup_tables.downsampling_factor.range)
+        extended_radar_grid = multilooked_radar_grid.add_margin(
+            cfg.processing.lookup_tables.margin_in_pixels.azimuth,
+            cfg.processing.lookup_tables.margin_in_pixels.range)
+
+        for pol in pols:
+            slc.add_calibration_section(frequency, pol,
+                                        extended_radar_grid.sensing_times,
+                                        orbit.reference_epoch,
+                                        extended_radar_grid.slant_ranges,
+                                        beta0_lut, sigma0_lut, gamma0_lut)
 
     freq = next(iter(get_bands(common_mode)))
     slc.set_geolocation_grid(orbit, ogrid[freq], dop[freq],
@@ -1916,13 +1958,12 @@ def focus(runconfig, runconfig_path=""):
                         z[k] = wavelets.remove_tone(z[k])
                 raw_mm[block_out] = z
 
-            # Perform RFI Detection and Mitigation
             raw_clean, rfi_likelihood = process_rfi(
                 cfg, 
                 raw_mm, 
-                swaths, 
+                swaths,
                 raw.isDithered(channel_in.freq_id),
-                temp, 
+                temp
             )
             rfi_results[(frequency, pol)].append(
                 (rfi_likelihood, raw_clean.shape[0]))
@@ -1947,9 +1988,22 @@ def focus(runconfig, runconfig_path=""):
 
             # Precompute antenna patterns at downsampled spacing
             if cfg.processing.is_enabled.eap:
+                # XXX Due to a bug in respective DRT of some L0B products
+                # (CRID=05007), caltone.frequency is extrated from runconfig
+                # otherwise, it shall be set to None to be determined from DRT!
+                # The latter requires RSLC runconfig update to allow caltone
+                # frequency to be parsed directly from L0B product for more
+                # flexible configuration over wide range of L0B products.
+                # XXX the intrument-related delay offset used in DBF process
+                # shall be eventually obtained from instrument INT CAL HDF5
+                # once the respective product spec is updated (delay_ofs_dbf)!
+                # The default value is suitable for NISAR L-band instrument.
                 antpat = AntennaPattern(raw, dem, antparser,
                                         instparser, orbit, attitude,
-                                        el_lut=el_lut)
+                                        el_lut=el_lut,
+                                        freq_band=frequency,
+                                        caltone_freq=cfg.processing.caltone.frequency,
+                                        delay_ofs_dbf=-2.1474e-6)
 
                 log.info("Precomputing antenna patterns")
                 i = np.arange(rc_grid.shape[0])
@@ -1969,9 +2023,10 @@ def focus(runconfig, runconfig_path=""):
 
             # Compute NESZ if there exist noise-only range lines
             # get noise only range line indexes within processing interval
-            cal_path_mask = raw.getCalType(
-                channel_in.freq_id, pol[0])[pulse_begin:pulse_end]
-            _, _, _, idx_noise = get_calib_range_line_idx(cal_path_mask)
+            _, cal_path_mask = chirpcorrelator_caltype_from_raw(
+                raw, txrx_pol=pol)
+            _, _, _, idx_noise = get_calib_range_line_idx(
+                cal_path_mask[pulse_begin:pulse_end])
 
             # form output slant range vector for all noise products
             if cfg.processing.noise_equivalent_backscatter.fill_nan_ends:
@@ -2000,7 +2055,29 @@ def focus(runconfig, runconfig_path=""):
                 data_noise = np.memmap(
                     fid_noise, mode='w+', shape=(nrgl_noise, rc.output_size),
                     dtype=np.complex64)
-                rc.rangecompress(data_noise, raw_clean[idx_noise])
+                # Check if raw is quad pol and the TX pol is not the
+                # first TX pol. Then extract noise only range line
+                # from the opposite TX pol w/ the same RX pol.
+                # XXX No RFI/caltone clean up of noise-only range lines
+                # for second TX pol products of quad pol!
+                raw_ns = np.copy(raw_clean[idx_noise])
+                if is_raw_quad_pol(raw):
+                    first_tx_pol = first_tx_pol_for_quad(raw)
+                    log.info(f'Quad pol w/ first {first_tx_pol} pol!')
+                    if pol[0] != first_tx_pol:
+                        pol_ns = opposite_linear_pol(pol[0]) + pol[1]
+                        log.warning('Get noise-only range lines from '
+                                    f'{pol_ns} for {pol} of quad pol!')
+                        ds_ns = raw.getRawDataset(channel_in.freq_id, pol_ns)
+                        idx_ns = np.arange(pulse_begin, pulse_end)[idx_noise]
+                        # decode simply noise-only range lines and
+                        # thus no need for memmap
+                        raw_ns = ds_ns[idx_ns]
+                        raw_ns *= bb_phasor[idx_noise, np.newaxis]
+                        raw_ns[np.isnan(raw_ns)] = 0.0
+                        if cfg.processing.zero_fill_gaps:
+                            fill_gaps(raw_ns, swaths[:, idx_noise, :], 0.0)
+                rc.rangecompress(data_noise, raw_ns)
                 # build and apply antenna pattern correction for noise
                 # pulses if EAP is True
                 if cfg.processing.is_enabled.eap:

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1130,13 +1130,12 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray, swaths: np.ndarray,
 
     num_pulses = raw_data.shape[0]
     mask_valid = np.zeros(raw_data.shape, dtype=bool)
-    pulse_idx = np.arange(num_pulses)
 
     # Read Sub-Swath Mask for all pulses of the raw data block
-    for imask, ipulse in enumerate(pulse_idx):
+    for pulse_idx in range(num_pulses):
         for swath in swaths:
-            start, end = swath[ipulse]
-            mask_valid[imask, start:end] = True
+            start, end = swath[pulse_idx]
+            mask_valid[pulse_idx, start:end] = True
 
     raw_data_mitigated = raw_data
     if opt.mitigation_enabled and not cfg.processing.delete_tempfiles:

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -16,14 +16,7 @@ from nisar.mixed_mode import (PolChannel, PolChannelSet, Band,
     find_overlapping_channel)
 from nisar.products.readers.antenna import AntennaParser
 from nisar.products.readers.instrument import InstrumentParser
-from nisar.products.readers.Raw import (
-    Raw,
-    open_rrsd,
-    chirpcorrelator_caltype_from_raw,
-    is_raw_quad_pol,
-    first_tx_pol_for_quad,
-    opposite_linear_pol
-)
+from nisar.products.readers.Raw import Raw, open_rrsd
 from nisar.products.readers.rslc_cal import (RslcCalibration,
     parse_rslc_calibration, get_scale_and_delay, check_cal_validity_dates)
 from nisar.products.writers import SLC
@@ -48,7 +41,6 @@ import tempfile
 from typing import Union, Optional, Callable, Iterable, overload
 from isce3.io import Raster as RasterIO
 from io import StringIO
-import pathlib
 
 
 # TODO some CSV logger
@@ -299,13 +291,12 @@ def get_total_grid_bounds(rawfiles: list[str]):
     return epoch, tmin, tmax, rmin, rmax
 
 
-def get_total_grid(rawfiles: list[str], dt, dr,
-                   az_margin_in_pixels, rg_margin_in_pixels):
+def get_total_grid(rawfiles: list[str], dt, dr):
     epoch, tmin, tmax, rmin, rmax = get_total_grid_bounds(rawfiles)
-    nt = int(np.ceil((tmax - tmin) / dt)) + 1 + 2 * az_margin_in_pixels
-    nr = int(np.ceil((rmax - rmin) / dr)) + 1 + 2 * rg_margin_in_pixels
-    t = isce3.core.Linspace(tmin - az_margin_in_pixels * dt, dt, nt)
-    r = isce3.core.Linspace(rmin - rg_margin_in_pixels * dr, dr, nr)
+    nt = int(np.ceil((tmax - tmin) / dt)) + 1
+    nr = int(np.ceil((rmax - rmin) / dr)) + 1
+    t = isce3.core.Linspace(tmin, dt, nt)
+    r = isce3.core.Linspace(rmin, dr, nr)
     return epoch, t, r
 
 
@@ -336,8 +327,6 @@ def make_doppler_lut(rawfiles: list[str],
         dem: Optional[isce3.geometry.DEMInterpolator] = None,
         azimuth_spacing: float = 1.0,
         range_spacing: float = 1e3,
-        az_margin_in_pixels: int = 11,
-        rg_margin_in_pixels: int = 11,
         interp_method: str = "bilinear",
         epoch: Optional[DateTime] = None):
     """Generate Doppler look up table (LUT).
@@ -362,10 +351,6 @@ def make_doppler_lut(rawfiles: list[str],
         LUT grid spacing in azimuth, in seconds.  Default=1 s.
     range_spacing : optional
         LUT grid spacing in range, in meters.  Default=1000 m.
-    az_margin_in_pixels : int, optional
-        Extra margin added to LUT grid in azimuth, in pixels. Default=11 pixels.
-    rg_margin_in_pixels : int, optional
-        Extra margin added to LUT grid in range, in pixels. Default=11 pixels.
     interp_method : optional
         LUT interpolation method. Default="bilinear".
     epoch : isce3.core.DateTime, optional
@@ -412,11 +397,7 @@ def make_doppler_lut(rawfiles: list[str],
 
     # Now do the actual calculations.
     wvl = isce3.core.speed_of_light / fc
-
-    epoch_in, t, r = get_total_grid(
-        rawfiles, azimuth_spacing, range_spacing,
-        az_margin_in_pixels=az_margin_in_pixels,
-        rg_margin_in_pixels=rg_margin_in_pixels)
+    epoch_in, t, r = get_total_grid(rawfiles, azimuth_spacing, range_spacing)
 
     # If timespan is too small, only one time may be provided, causing the LUT
     # construction to fail. Fall back to t ± Δt/2 to preserve az spacing.
@@ -427,22 +408,6 @@ def make_doppler_lut(rawfiles: list[str],
         t = [tmin, tmax]
 
     t = convert_epoch(t, epoch_in, epoch)
-
-    # crop the azimuth time using orbit and attitude extents
-    min_time = max([orbit.start_time, attitude.start_time])
-    max_time = min([orbit.end_time, attitude.end_time])
-
-    t = np.asarray(t)
-    if np.any(t <= min_time):
-        log.warning(f"Desired Doppler LUT start time is {min_time - t[0]} "
-            "seconds before ephemeris start. Consider adjusting "
-            "ephemeris_crop_pad or providing more orbit/attitude data.")
-    if np.any(t >= max_time):
-        log.warning(f"Desired Doppler LUT end time is {t[-1] - max_time} "
-            "seconds after ephemeris end. Consider adjusting "
-            "ephemeris_crop_pad or providing more orbit/attitude data.")
-    t = t[(t > min_time) & (t < max_time)]
-
     lut = isce3.geometry.make_doppler_lut_from_attitude(
         az_time=t,
         slant_range=r,
@@ -475,15 +440,11 @@ def make_doppler(cfg: Struct, *, epoch: Optional[DateTime] = None,
     az = np.radians(opt.azimuth_boresight_deg)
     rawfiles = cfg.input_file_group.input_file_path
 
-    fc, lut = make_doppler_lut(
-        rawfiles,
-        az=az, orbit=orbit, attitude=attitude,
-        dem=dem, azimuth_spacing=opt.spacing.azimuth,
-        range_spacing=opt.spacing.range,
-        az_margin_in_pixels=opt.margin_in_pixels.azimuth,
-        rg_margin_in_pixels=opt.margin_in_pixels.range,
-        interp_method=opt.interp_method,
-        epoch=epoch)
+    fc, lut = make_doppler_lut(rawfiles,
+                               az=az, orbit=orbit, attitude=attitude,
+                               dem=dem, azimuth_spacing=opt.spacing.azimuth,
+                               range_spacing=opt.spacing.range,
+                               interp_method=opt.interp_method,  epoch=epoch)
 
     log.info(f"Made Doppler LUT for fc={fc} Hz, "
         f"az={opt.azimuth_boresight_deg} deg with mean={lut.data.mean()} Hz")
@@ -948,7 +909,7 @@ def get_dataset_creation_options(cfg: Struct, shape: tuple[int, int]) -> dict:
     """
     Get h5py keyword arguments needed for image dataset creation.
 
-    Parameters
+    #Parameters
     ----------
     cfg : Struct
         RSLC runconfig data. Only reads `cfg.output` group.
@@ -1077,8 +1038,8 @@ def resample(raw: np.ndarray, t: np.ndarray,
     return regridded
 
 
-def process_rfi(cfg: Struct, raw_data: np.ndarray,
-                tmpfile: Callable = lambda name: open(name, "wb")):
+def process_rfi(cfg: Struct, raw_data: np.ndarray, swaths: np.ndarray,
+                prf_dither_mode, tmpfile: Callable = lambda name: open(name, "wb")):
     """
     Run radio frequency interference (RFI) detection and mitigation as
     configured by user input.
@@ -1089,6 +1050,13 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray,
         RSLC runconfig data
     raw_data : np.ndarray[np.complex64]
         Raw data layer.  May be modified in-place if mitigation is enabled.
+    swaths : np.ndarray [int]
+        Valid subswath samples, dims = (ns, nt, 2) where ns is the number of
+        sub-swaths, nt is the number of pulses, and the trailing dimension is
+        the [start, stop) indices of the sub-swath.
+    prf_dither_mode: bool
+        If True, L0B acquisition with respect to the specified frequency is of 
+        Dithered PRF mode
     tmpfile : Callable
         Function of a single string argument that returns an open file handle.
 
@@ -1120,6 +1088,22 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray,
     # Mitigate in place unless user wants a debug file to compare raw and
     # mitigated data.  This means you'd need to run the workflow twice to find
     # a bug specific to in-place vs out-of-place processing.
+    
+    num_pulses, num_rng_samples = raw_data.shape
+
+    mask_valid = np.zeros((num_pulses, num_rng_samples), dtype=bool)
+    pulse_idx = np.arange(num_pulses)
+
+    print('\nfocus.py running')
+    print(f'{raw_data.shape = }')
+    print()
+
+    for imask, ipulse in enumerate(pulse_idx):
+        for swath in swaths:
+            start, end = swath[ipulse]
+            mask_valid[imask, start:end] = True
+
+
     raw_data_mitigated = raw_data
     if opt.mitigation_enabled and not cfg.processing.delete_tempfiles:
         fd = tmpfile("_raw_clean.c8")
@@ -1143,20 +1127,29 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray,
             use_entire_pulse=opt.use_entire_pulse,
             threshold_params=threshold_params,
             num_cpi_tb=opt_evd.num_cpi_per_threshold_block,
+            off_diag_overlap_ratio=opt_evd.off_diag_overlap_ratio,
+            diag_valid_ratio=opt_evd.diag_valid_ratio,
             mitigate_enable=opt.mitigation_enabled,
+            prf_dither_mode=prf_dither_mode,
+            noise_ev_idx=opt_evd.noise_ev_idx,
+            mask_valid=mask_valid,
             raw_data_mitigated=raw_data_mitigated)
     else:
         opt_fnf = opt.freq_notch_filter
+        threshold_params_notch = isce3.signal.rfi_freq_null.ThresholdParamsNotch(
+            opt_fnf.threshold_hyperparameters.x, opt_fnf.threshold_hyperparameters.y)
+
         rfi_likelihood = isce3.signal.rfi_freq_null.run_freq_notch(
             raw_data,
             opt_fnf.num_pulses_az,
-            num_rng_blks=opt.num_range_blocks,
+            num_samples_rng_blk=opt.num_samples_rng_blk,
             az_winsize=opt_fnf.az_winsize,
             rng_winsize=opt_fnf.rng_winsize,
             trim_frac=opt_fnf.trim_frac,
-            pvalue_threshold=opt_fnf.pvalue_threshold,
             cdf_threshold=opt_fnf.cdf_threshold,
             use_entire_pulse=opt.use_entire_pulse,
+            false_alarm_rate=opt_fnf.false_alarm_rate,
+            threshold_params_notch=threshold_params_notch,
             nb_detect=opt_fnf.nb_detect,
             wb_detect=opt_fnf.wb_detect,
             mitigate_enable=opt.mitigation_enabled,
@@ -1435,7 +1428,7 @@ def set_input_file_metadata(cfg: Struct, slc: SLC, runconfig_path: str = ""):
     anc = cfg.dynamic_ancillary_file_group
     value_or_blank = lambda x: x if x is not None else ""
     slc.set_inputs(
-        l0bGranules=[pathlib.PosixPath(f).name for f in cfg.input_file_group.input_file_path],
+        l0bGranules=cfg.input_file_group.input_file_path,
         orbitFiles=[value_or_blank(anc.orbit)],
         attitudeFiles=[value_or_blank(anc.pointing)],
         auxcalFiles=[value_or_blank(x) for x in (anc.external_calibration,
@@ -1803,24 +1796,12 @@ def focus(runconfig, runconfig_path=""):
         cal = get_calibration(cfg, band.width)
         slc.set_calibration(cal, frequency)
 
-        # add calibration section based on a downsampled radar grid,
-        # including an extra margin to ensure that, after geocoding
-        # with an interpolation algoritm (e.g., bicubic spline),
-        # the LUTs fully cover the geocoded imagery extents.
-
-        multilooked_radar_grid = og.multilook(
-            cfg.processing.lookup_tables.downsampling_factor.azimuth,
-            cfg.processing.lookup_tables.downsampling_factor.range)
-        extended_radar_grid = multilooked_radar_grid.add_margin(
-            cfg.processing.lookup_tables.margin_in_pixels.azimuth,
-            cfg.processing.lookup_tables.margin_in_pixels.range)
-
+        # add calibration section for each polarization
         for pol in pols:
-            slc.add_calibration_section(frequency, pol,
-                                        extended_radar_grid.sensing_times,
-                                        orbit.reference_epoch,
-                                        extended_radar_grid.slant_ranges,
+            slc.add_calibration_section(frequency, pol, og.sensing_times,
+                                        orbit.reference_epoch, og.slant_ranges,
                                         beta0_lut, sigma0_lut, gamma0_lut)
+
 
     freq = next(iter(get_bands(common_mode)))
     slc.set_geolocation_grid(orbit, ogrid[freq], dop[freq],
@@ -1935,7 +1916,14 @@ def focus(runconfig, runconfig_path=""):
                         z[k] = wavelets.remove_tone(z[k])
                 raw_mm[block_out] = z
 
-            raw_clean, rfi_likelihood = process_rfi(cfg, raw_mm, temp)
+            # Perform RFI Detection and Mitigation
+            raw_clean, rfi_likelihood = process_rfi(
+                cfg, 
+                raw_mm, 
+                swaths, 
+                raw.isDithered(channel_in.freq_id),
+                temp, 
+            )
             rfi_results[(frequency, pol)].append(
                 (rfi_likelihood, raw_clean.shape[0]))
             del raw_mm, rawfd
@@ -1959,22 +1947,9 @@ def focus(runconfig, runconfig_path=""):
 
             # Precompute antenna patterns at downsampled spacing
             if cfg.processing.is_enabled.eap:
-                # XXX Due to a bug in respective DRT of some L0B products
-                # (CRID=05007), caltone.frequency is extrated from runconfig
-                # otherwise, it shall be set to None to be determined from DRT!
-                # The latter requires RSLC runconfig update to allow caltone
-                # frequency to be parsed directly from L0B product for more
-                # flexible configuration over wide range of L0B products.
-                # XXX the intrument-related delay offset used in DBF process
-                # shall be eventually obtained from instrument INT CAL HDF5
-                # once the respective product spec is updated (delay_ofs_dbf)!
-                # The default value is suitable for NISAR L-band instrument.
                 antpat = AntennaPattern(raw, dem, antparser,
                                         instparser, orbit, attitude,
-                                        el_lut=el_lut,
-                                        freq_band=frequency,
-                                        caltone_freq=cfg.processing.caltone.frequency,
-                                        delay_ofs_dbf=-2.1474e-6)
+                                        el_lut=el_lut)
 
                 log.info("Precomputing antenna patterns")
                 i = np.arange(rc_grid.shape[0])
@@ -1994,10 +1969,9 @@ def focus(runconfig, runconfig_path=""):
 
             # Compute NESZ if there exist noise-only range lines
             # get noise only range line indexes within processing interval
-            _, cal_path_mask = chirpcorrelator_caltype_from_raw(
-                raw, txrx_pol=pol)
-            _, _, _, idx_noise = get_calib_range_line_idx(
-                cal_path_mask[pulse_begin:pulse_end])
+            cal_path_mask = raw.getCalType(
+                channel_in.freq_id, pol[0])[pulse_begin:pulse_end]
+            _, _, _, idx_noise = get_calib_range_line_idx(cal_path_mask)
 
             # form output slant range vector for all noise products
             if cfg.processing.noise_equivalent_backscatter.fill_nan_ends:
@@ -2026,29 +2000,7 @@ def focus(runconfig, runconfig_path=""):
                 data_noise = np.memmap(
                     fid_noise, mode='w+', shape=(nrgl_noise, rc.output_size),
                     dtype=np.complex64)
-                # Check if raw is quad pol and the TX pol is not the
-                # first TX pol. Then extract noise only range line
-                # from the opposite TX pol w/ the same RX pol.
-                # XXX No RFI/caltone clean up of noise-only range lines
-                # for second TX pol products of quad pol!
-                raw_ns = np.copy(raw_clean[idx_noise])
-                if is_raw_quad_pol(raw):
-                    first_tx_pol = first_tx_pol_for_quad(raw)
-                    log.info(f'Quad pol w/ first {first_tx_pol} pol!')
-                    if pol[0] != first_tx_pol:
-                        pol_ns = opposite_linear_pol(pol[0]) + pol[1]
-                        log.warning('Get noise-only range lines from '
-                                    f'{pol_ns} for {pol} of quad pol!')
-                        ds_ns = raw.getRawDataset(channel_in.freq_id, pol_ns)
-                        idx_ns = np.arange(pulse_begin, pulse_end)[idx_noise]
-                        # decode simply noise-only range lines and
-                        # thus no need for memmap
-                        raw_ns = ds_ns[idx_ns]
-                        raw_ns *= bb_phasor[idx_noise, np.newaxis]
-                        raw_ns[np.isnan(raw_ns)] = 0.0
-                        if cfg.processing.zero_fill_gaps:
-                            fill_gaps(raw_ns, swaths[:, idx_noise, :], 0.0)
-                rc.rangecompress(data_noise, raw_ns)
+                rc.rangecompress(data_noise, raw_clean[idx_noise])
                 # build and apply antenna pattern correction for noise
                 # pulses if EAP is True
                 if cfg.processing.is_enabled.eap:

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -16,14 +16,7 @@ from nisar.mixed_mode import (PolChannel, PolChannelSet, Band,
     find_overlapping_channel)
 from nisar.products.readers.antenna import AntennaParser
 from nisar.products.readers.instrument import InstrumentParser
-from nisar.products.readers.Raw import (
-    Raw,
-    open_rrsd,
-    chirpcorrelator_caltype_from_raw,
-    is_raw_quad_pol,
-    first_tx_pol_for_quad,
-    opposite_linear_pol
-)
+from nisar.products.readers.Raw import Raw, open_rrsd
 from nisar.products.readers.rslc_cal import (RslcCalibration,
     parse_rslc_calibration, get_scale_and_delay, check_cal_validity_dates)
 from nisar.products.writers import SLC
@@ -48,7 +41,6 @@ import tempfile
 from typing import Union, Optional, Callable, Iterable, overload
 from isce3.io import Raster as RasterIO
 from io import StringIO
-import pathlib
 
 
 # TODO some CSV logger
@@ -299,13 +291,12 @@ def get_total_grid_bounds(rawfiles: list[str]):
     return epoch, tmin, tmax, rmin, rmax
 
 
-def get_total_grid(rawfiles: list[str], dt, dr,
-                   az_margin_in_pixels, rg_margin_in_pixels):
+def get_total_grid(rawfiles: list[str], dt, dr):
     epoch, tmin, tmax, rmin, rmax = get_total_grid_bounds(rawfiles)
-    nt = int(np.ceil((tmax - tmin) / dt)) + 1 + 2 * az_margin_in_pixels
-    nr = int(np.ceil((rmax - rmin) / dr)) + 1 + 2 * rg_margin_in_pixels
-    t = isce3.core.Linspace(tmin - az_margin_in_pixels * dt, dt, nt)
-    r = isce3.core.Linspace(rmin - rg_margin_in_pixels * dr, dr, nr)
+    nt = int(np.ceil((tmax - tmin) / dt)) + 1
+    nr = int(np.ceil((rmax - rmin) / dr)) + 1
+    t = isce3.core.Linspace(tmin, dt, nt)
+    r = isce3.core.Linspace(rmin, dr, nr)
     return epoch, t, r
 
 
@@ -336,8 +327,6 @@ def make_doppler_lut(rawfiles: list[str],
         dem: Optional[isce3.geometry.DEMInterpolator] = None,
         azimuth_spacing: float = 1.0,
         range_spacing: float = 1e3,
-        az_margin_in_pixels: int = 11,
-        rg_margin_in_pixels: int = 11,
         interp_method: str = "bilinear",
         epoch: Optional[DateTime] = None):
     """Generate Doppler look up table (LUT).
@@ -362,10 +351,6 @@ def make_doppler_lut(rawfiles: list[str],
         LUT grid spacing in azimuth, in seconds.  Default=1 s.
     range_spacing : optional
         LUT grid spacing in range, in meters.  Default=1000 m.
-    az_margin_in_pixels : int, optional
-        Extra margin added to LUT grid in azimuth, in pixels. Default=11 pixels.
-    rg_margin_in_pixels : int, optional
-        Extra margin added to LUT grid in range, in pixels. Default=11 pixels.
     interp_method : optional
         LUT interpolation method. Default="bilinear".
     epoch : isce3.core.DateTime, optional
@@ -412,11 +397,7 @@ def make_doppler_lut(rawfiles: list[str],
 
     # Now do the actual calculations.
     wvl = isce3.core.speed_of_light / fc
-
-    epoch_in, t, r = get_total_grid(
-        rawfiles, azimuth_spacing, range_spacing,
-        az_margin_in_pixels=az_margin_in_pixels,
-        rg_margin_in_pixels=rg_margin_in_pixels)
+    epoch_in, t, r = get_total_grid(rawfiles, azimuth_spacing, range_spacing)
 
     # If timespan is too small, only one time may be provided, causing the LUT
     # construction to fail. Fall back to t ± Δt/2 to preserve az spacing.
@@ -427,22 +408,6 @@ def make_doppler_lut(rawfiles: list[str],
         t = [tmin, tmax]
 
     t = convert_epoch(t, epoch_in, epoch)
-
-    # crop the azimuth time using orbit and attitude extents
-    min_time = max([orbit.start_time, attitude.start_time])
-    max_time = min([orbit.end_time, attitude.end_time])
-
-    t = np.asarray(t)
-    if np.any(t <= min_time):
-        log.warning(f"Desired Doppler LUT start time is {min_time - t[0]} "
-            "seconds before ephemeris start. Consider adjusting "
-            "ephemeris_crop_pad or providing more orbit/attitude data.")
-    if np.any(t >= max_time):
-        log.warning(f"Desired Doppler LUT end time is {t[-1] - max_time} "
-            "seconds after ephemeris end. Consider adjusting "
-            "ephemeris_crop_pad or providing more orbit/attitude data.")
-    t = t[(t > min_time) & (t < max_time)]
-
     lut = isce3.geometry.make_doppler_lut_from_attitude(
         az_time=t,
         slant_range=r,
@@ -475,15 +440,11 @@ def make_doppler(cfg: Struct, *, epoch: Optional[DateTime] = None,
     az = np.radians(opt.azimuth_boresight_deg)
     rawfiles = cfg.input_file_group.input_file_path
 
-    fc, lut = make_doppler_lut(
-        rawfiles,
-        az=az, orbit=orbit, attitude=attitude,
-        dem=dem, azimuth_spacing=opt.spacing.azimuth,
-        range_spacing=opt.spacing.range,
-        az_margin_in_pixels=opt.margin_in_pixels.azimuth,
-        rg_margin_in_pixels=opt.margin_in_pixels.range,
-        interp_method=opt.interp_method,
-        epoch=epoch)
+    fc, lut = make_doppler_lut(rawfiles,
+                               az=az, orbit=orbit, attitude=attitude,
+                               dem=dem, azimuth_spacing=opt.spacing.azimuth,
+                               range_spacing=opt.spacing.range,
+                               interp_method=opt.interp_method,  epoch=epoch)
 
     log.info(f"Made Doppler LUT for fc={fc} Hz, "
         f"az={opt.azimuth_boresight_deg} deg with mean={lut.data.mean()} Hz")
@@ -948,7 +909,7 @@ def get_dataset_creation_options(cfg: Struct, shape: tuple[int, int]) -> dict:
     """
     Get h5py keyword arguments needed for image dataset creation.
 
-    Parameters
+    #Parameters
     ----------
     cfg : Struct
         RSLC runconfig data. Only reads `cfg.output` group.
@@ -1077,8 +1038,8 @@ def resample(raw: np.ndarray, t: np.ndarray,
     return regridded
 
 
-def process_rfi(cfg: Struct, raw_data: np.ndarray,
-                tmpfile: Callable = lambda name: open(name, "wb")):
+def process_rfi(cfg: Struct, raw_data: np.ndarray, swaths: np.ndarray,
+                prf_dither_mode, tmpfile: Callable = lambda name: open(name, "wb")):
     """
     Run radio frequency interference (RFI) detection and mitigation as
     configured by user input.
@@ -1089,6 +1050,13 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray,
         RSLC runconfig data
     raw_data : np.ndarray[np.complex64]
         Raw data layer.  May be modified in-place if mitigation is enabled.
+    swaths : np.ndarray [int]
+        Valid subswath samples, dims = (ns, nt, 2) where ns is the number of
+        sub-swaths, nt is the number of pulses, and the trailing dimension is
+        the [start, stop) indices of the sub-swath.
+    prf_dither_mode: bool
+        If True, L0B acquisition with respect to the specified frequency is of 
+        Dithered PRF mode
     tmpfile : Callable
         Function of a single string argument that returns an open file handle.
 
@@ -1120,6 +1088,22 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray,
     # Mitigate in place unless user wants a debug file to compare raw and
     # mitigated data.  This means you'd need to run the workflow twice to find
     # a bug specific to in-place vs out-of-place processing.
+    
+    num_pulses, num_rng_samples = raw_data.shape
+
+    mask_valid = np.zeros((num_pulses, num_rng_samples), dtype=bool)
+    pulse_idx = np.arange(num_pulses)
+
+    print('\nfocus.py running')
+    print(f'{raw_data.shape = }')
+    print()
+
+    for imask, ipulse in enumerate(pulse_idx):
+        for swath in swaths:
+            start, end = swath[ipulse]
+            mask_valid[imask, start:end] = True
+
+
     raw_data_mitigated = raw_data
     if opt.mitigation_enabled and not cfg.processing.delete_tempfiles:
         fd = tmpfile("_raw_clean.c8")
@@ -1143,20 +1127,29 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray,
             use_entire_pulse=opt.use_entire_pulse,
             threshold_params=threshold_params,
             num_cpi_tb=opt_evd.num_cpi_per_threshold_block,
+            off_diag_overlap_ratio=opt_evd.off_diag_overlap_ratio,
+            diag_valid_ratio=opt_evd.diag_valid_ratio,
             mitigate_enable=opt.mitigation_enabled,
+            prf_dither_mode=prf_dither_mode,
+            noise_ev_idx=opt_evd.noise_ev_idx,
+            mask_valid=mask_valid,
             raw_data_mitigated=raw_data_mitigated)
     else:
         opt_fnf = opt.freq_notch_filter
+        threshold_params_notch = isce3.signal.rfi_freq_null.ThresholdParamsNotch(
+            opt_fnf.threshold_hyperparameters.x, opt_fnf.threshold_hyperparameters.y)
+
         rfi_likelihood = isce3.signal.rfi_freq_null.run_freq_notch(
             raw_data,
             opt_fnf.num_pulses_az,
-            num_rng_blks=opt.num_range_blocks,
+            num_samples_rng_blk=opt.num_samples_rng_blk,
             az_winsize=opt_fnf.az_winsize,
             rng_winsize=opt_fnf.rng_winsize,
             trim_frac=opt_fnf.trim_frac,
-            pvalue_threshold=opt_fnf.pvalue_threshold,
             cdf_threshold=opt_fnf.cdf_threshold,
             use_entire_pulse=opt.use_entire_pulse,
+            false_alarm_rate=opt_fnf.false_alarm_rate,
+            threshold_params_notch=threshold_params_notch,
             nb_detect=opt_fnf.nb_detect,
             wb_detect=opt_fnf.wb_detect,
             mitigate_enable=opt.mitigation_enabled,
@@ -1438,7 +1431,7 @@ def set_input_file_metadata(cfg: Struct, slc: SLC, runconfig_path: str = ""):
     anc = cfg.dynamic_ancillary_file_group
     value_or_blank = lambda x: x if x is not None else ""
     slc.set_inputs(
-        l0bGranules=[pathlib.PosixPath(f).name for f in cfg.input_file_group.input_file_path],
+        l0bGranules=cfg.input_file_group.input_file_path,
         orbitFiles=[value_or_blank(anc.orbit)],
         attitudeFiles=[value_or_blank(anc.pointing)],
         auxcalFiles=[value_or_blank(x) for x in (anc.external_calibration,
@@ -1839,23 +1832,10 @@ def focus(runconfig, runconfig_path=""):
         cal = get_calibration(cfg, band.width)
         slc.set_calibration(cal, frequency)
 
-        # add calibration section based on a downsampled radar grid,
-        # including an extra margin to ensure that, after geocoding
-        # with an interpolation algoritm (e.g., bicubic spline),
-        # the LUTs fully cover the geocoded imagery extents.
-
-        multilooked_radar_grid = og.multilook(
-            cfg.processing.lookup_tables.downsampling_factor.azimuth,
-            cfg.processing.lookup_tables.downsampling_factor.range)
-        extended_radar_grid = multilooked_radar_grid.add_margin(
-            cfg.processing.lookup_tables.margin_in_pixels.azimuth,
-            cfg.processing.lookup_tables.margin_in_pixels.range)
-
+        # add calibration section for each polarization
         for pol in pols:
-            slc.add_calibration_section(frequency, pol,
-                                        extended_radar_grid.sensing_times,
-                                        orbit.reference_epoch,
-                                        extended_radar_grid.slant_ranges,
+            slc.add_calibration_section(frequency, pol, og.sensing_times,
+                                        orbit.reference_epoch, og.slant_ranges,
                                         beta0_lut, sigma0_lut, gamma0_lut)
 
         # Set anomaly mask. Need to do some geometry.
@@ -1984,7 +1964,14 @@ def focus(runconfig, runconfig_path=""):
                         z[k] = wavelets.remove_tone(z[k])
                 raw_mm[block_out] = z
 
-            raw_clean, rfi_likelihood = process_rfi(cfg, raw_mm, temp)
+            # Perform RFI Detection and Mitigation
+            raw_clean, rfi_likelihood = process_rfi(
+                cfg, 
+                raw_mm, 
+                swaths, 
+                raw.isDithered(channel_in.freq_id),
+                temp, 
+            )
             rfi_results[(frequency, pol)].append(
                 (rfi_likelihood, raw_clean.shape[0]))
             del raw_mm, rawfd
@@ -2008,22 +1995,13 @@ def focus(runconfig, runconfig_path=""):
 
             # Precompute antenna patterns at downsampled spacing
             if cfg.processing.is_enabled.eap:
-                # XXX Due to a bug in respective DRT of some L0B products
-                # (CRID=05007), caltone.frequency is extrated from runconfig
-                # otherwise, it shall be set to None to be determined from DRT!
-                # The latter requires RSLC runconfig update to allow caltone
-                # frequency to be parsed directly from L0B product for more
-                # flexible configuration over wide range of L0B products.
-                # XXX the intrument-related delay offset used in DBF process
-                # shall be eventually obtained from instrument INT CAL HDF5
-                # once the respective product spec is updated (delay_ofs_dbf)!
-                # The default value is suitable for NISAR L-band instrument.
                 antpat = AntennaPattern(raw, dem, antparser,
                                         instparser, orbit, attitude,
                                         el_lut=el_lut,
                                         freq_band=channel_in.freq_id,
                                         caltone_freq=cfg.processing.caltone.frequency,
                                         delay_ofs_dbf=-2.1474e-6)
+                                        el_lut=el_lut)
 
                 log.info("Precomputing antenna patterns")
                 i = np.arange(rc_grid.shape[0])
@@ -2043,10 +2021,9 @@ def focus(runconfig, runconfig_path=""):
 
             # Compute NESZ if there exist noise-only range lines
             # get noise only range line indexes within processing interval
-            _, cal_path_mask = chirpcorrelator_caltype_from_raw(
-                raw, txrx_pol=pol)
-            _, _, _, idx_noise = get_calib_range_line_idx(
-                cal_path_mask[pulse_begin:pulse_end])
+            cal_path_mask = raw.getCalType(
+                channel_in.freq_id, pol[0])[pulse_begin:pulse_end]
+            _, _, _, idx_noise = get_calib_range_line_idx(cal_path_mask)
 
             # form output slant range vector for all noise products
             if cfg.processing.noise_equivalent_backscatter.fill_nan_ends:
@@ -2075,29 +2052,7 @@ def focus(runconfig, runconfig_path=""):
                 data_noise = np.memmap(
                     fid_noise, mode='w+', shape=(nrgl_noise, rc.output_size),
                     dtype=np.complex64)
-                # Check if raw is quad pol and the TX pol is not the
-                # first TX pol. Then extract noise only range line
-                # from the opposite TX pol w/ the same RX pol.
-                # XXX No RFI/caltone clean up of noise-only range lines
-                # for second TX pol products of quad pol!
-                raw_ns = np.copy(raw_clean[idx_noise])
-                if is_raw_quad_pol(raw):
-                    first_tx_pol = first_tx_pol_for_quad(raw)
-                    log.info(f'Quad pol w/ first {first_tx_pol} pol!')
-                    if pol[0] != first_tx_pol:
-                        pol_ns = opposite_linear_pol(pol[0]) + pol[1]
-                        log.warning('Get noise-only range lines from '
-                                    f'{pol_ns} for {pol} of quad pol!')
-                        ds_ns = raw.getRawDataset(channel_in.freq_id, pol_ns)
-                        idx_ns = np.arange(pulse_begin, pulse_end)[idx_noise]
-                        # decode simply noise-only range lines and
-                        # thus no need for memmap
-                        raw_ns = ds_ns[idx_ns]
-                        raw_ns *= bb_phasor[idx_noise, np.newaxis]
-                        raw_ns[np.isnan(raw_ns)] = 0.0
-                        if cfg.processing.zero_fill_gaps:
-                            fill_gaps(raw_ns, swaths[:, idx_noise, :], 0.0)
-                rc.rangecompress(data_noise, raw_ns)
+                rc.rangecompress(data_noise, raw_clean[idx_noise])
                 # build and apply antenna pattern correction for noise
                 # pulses if EAP is True
                 if cfg.processing.is_enabled.eap:

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1078,7 +1078,7 @@ def resample(raw: np.ndarray, t: np.ndarray,
 
 
 def process_rfi(cfg: Struct, raw_data: np.ndarray, swaths: np.ndarray,
-                prf_dither_mode: bool, tmpfile: Callable = lambda name: open(name, "wb")):
+                tmpfile: Callable = lambda name: open(name, "wb")):
     """
     Run radio frequency interference (RFI) detection and mitigation as
     configured by user input.
@@ -1093,9 +1093,6 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray, swaths: np.ndarray,
         Valid subswath samples, dims = (ns, nt, 2) where ns is the number of
         sub-swaths, nt is the number of pulses, and the trailing dimension is
         the [start, stop) indices of the sub-swath.
-    prf_dither_mode: bool
-        If True, L0B acquisition is of PRF Dithering mode. Sample Covariance Matrix
-        is computed differently by excluding the invalid data gaps.
     tmpfile : Callable
         Function of a single string argument that returns an open file handle.
 
@@ -1163,8 +1160,7 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray, swaths: np.ndarray,
             off_diag_overlap_ratio=opt_evd.off_diag_overlap_ratio,
             diag_valid_ratio=opt_evd.diag_valid_ratio,
             mitigate_enable=opt.mitigation_enabled,
-            prf_dither_mode=prf_dither_mode,
-            normalized_min_rank_ratio=opt_evd.normalized_min_rank_ratio,
+            min_rank_frac=opt_evd.min_rank_frac,
             rx_dynamic_range_db=opt_evd.rx_dynamic_range_db,
             mask_valid=mask_valid,
             raw_data_mitigated=raw_data_mitigated)
@@ -2011,7 +2007,6 @@ def focus(runconfig, runconfig_path=""):
                 cfg, 
                 raw_mm, 
                 swaths,
-                raw.isDithered(channel_in.freq_id),
                 temp
             )
             rfi_results[(frequency, pol)].append(

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1077,7 +1077,8 @@ def resample(raw: np.ndarray, t: np.ndarray,
     return regridded
 
 
-def process_rfi(cfg: Struct, raw_data: np.ndarray, swaths: np.ndarray,
+def process_rfi(cfg: Struct, raw_data: np.ndarray,
+                swaths: Optional[np.ndarray] = None,
                 tmpfile: Callable = lambda name: open(name, "wb")):
     """
     Run radio frequency interference (RFI) detection and mitigation as
@@ -1089,10 +1090,12 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray, swaths: np.ndarray,
         RSLC runconfig data
     raw_data : np.ndarray[np.complex64]
         Raw data layer.  May be modified in-place if mitigation is enabled.
-    swaths : np.ndarray [int]
+    swaths : np.ndarray [int], optional
         Valid subswath samples, dims = (ns, nt, 2) where ns is the number of
         sub-swaths, nt is the number of pulses, and the trailing dimension is
-        the [start, stop) indices of the sub-swath.
+        the [start, stop) indices of the sub-swath.  It's recommended to supply
+        this for modes with dithered PRI, where it will be used to normalize
+        the sample covariance matrix.
     tmpfile : Callable
         Function of a single string argument that returns an open file handle.
 
@@ -1125,14 +1128,6 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray, swaths: np.ndarray,
     # mitigated data.  This means you'd need to run the workflow twice to find
     # a bug specific to in-place vs out-of-place processing.
 
-    num_pulses = raw_data.shape[0]
-    mask_valid = np.zeros(raw_data.shape, dtype=bool)
-
-    # Read Sub-Swath Mask for all pulses of the raw data block
-    for pulse_idx in range(num_pulses):
-        for swath in swaths:
-            start, end = swath[pulse_idx]
-            mask_valid[pulse_idx, start:end] = True
 
     raw_data_mitigated = raw_data
     if opt.mitigation_enabled and not cfg.processing.delete_tempfiles:
@@ -1162,7 +1157,7 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray, swaths: np.ndarray,
             mitigate_enable=opt.mitigation_enabled,
             min_rank_frac=opt_evd.min_rank_frac,
             rx_dynamic_range_db=opt_evd.rx_dynamic_range_db,
-            mask_valid=mask_valid,
+            swaths=swaths,
             raw_data_mitigated=raw_data_mitigated)
     else:
         opt_fnf = opt.freq_notch_filter
@@ -2003,17 +1998,18 @@ def focus(runconfig, runconfig_path=""):
                         z[k] = wavelets.remove_tone(z[k])
                 raw_mm[block_out] = z
 
+            uniform_pri = not raw.isDithered(channel_in.freq_id)
+
             raw_clean, rfi_likelihood = process_rfi(
                 cfg, 
                 raw_mm, 
-                swaths,
+                None if uniform_pri else swaths,
                 temp
             )
             rfi_results[(frequency, pol)].append(
                 (rfi_likelihood, raw_clean.shape[0]))
             del raw_mm, rawfd
 
-            uniform_pri = not raw.isDithered(channel_in.freq_id)
             if uniform_pri:
                 log.info("Uniform PRF, using raw data directly.")
                 regridded, regridfd = raw_clean, None

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -2044,10 +2044,6 @@ def focus(runconfig, runconfig_path=""):
                                         freq_band=channel_in.freq_id,
                                         caltone_freq=cfg.processing.caltone.frequency,
                                         delay_ofs_dbf=-2.1474e-6)
-                                        el_lut=el_lut)
-                                        freq_band=frequency,
-                                        caltone_freq=cfg.processing.caltone.frequency,
-                                        delay_ofs_dbf=-2.1474e-6)
 
                 log.info("Precomputing antenna patterns")
                 i = np.arange(rc_grid.shape[0])

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -16,7 +16,14 @@ from nisar.mixed_mode import (PolChannel, PolChannelSet, Band,
     find_overlapping_channel)
 from nisar.products.readers.antenna import AntennaParser
 from nisar.products.readers.instrument import InstrumentParser
-from nisar.products.readers.Raw import Raw, open_rrsd
+from nisar.products.readers.Raw import (
+    Raw,
+    open_rrsd,
+    chirpcorrelator_caltype_from_raw,
+    is_raw_quad_pol,
+    first_tx_pol_for_quad,
+    opposite_linear_pol
+)
 from nisar.products.readers.rslc_cal import (RslcCalibration,
     parse_rslc_calibration, get_scale_and_delay, check_cal_validity_dates)
 from nisar.products.writers import SLC
@@ -41,6 +48,7 @@ import tempfile
 from typing import Union, Optional, Callable, Iterable, overload
 from isce3.io import Raster as RasterIO
 from io import StringIO
+import pathlib
 
 
 # TODO some CSV logger
@@ -291,12 +299,13 @@ def get_total_grid_bounds(rawfiles: list[str]):
     return epoch, tmin, tmax, rmin, rmax
 
 
-def get_total_grid(rawfiles: list[str], dt, dr):
+def get_total_grid(rawfiles: list[str], dt, dr,
+                   az_margin_in_pixels, rg_margin_in_pixels):
     epoch, tmin, tmax, rmin, rmax = get_total_grid_bounds(rawfiles)
-    nt = int(np.ceil((tmax - tmin) / dt)) + 1
-    nr = int(np.ceil((rmax - rmin) / dr)) + 1
-    t = isce3.core.Linspace(tmin, dt, nt)
-    r = isce3.core.Linspace(rmin, dr, nr)
+    nt = int(np.ceil((tmax - tmin) / dt)) + 1 + 2 * az_margin_in_pixels
+    nr = int(np.ceil((rmax - rmin) / dr)) + 1 + 2 * rg_margin_in_pixels
+    t = isce3.core.Linspace(tmin - az_margin_in_pixels * dt, dt, nt)
+    r = isce3.core.Linspace(rmin - rg_margin_in_pixels * dr, dr, nr)
     return epoch, t, r
 
 
@@ -327,6 +336,8 @@ def make_doppler_lut(rawfiles: list[str],
         dem: Optional[isce3.geometry.DEMInterpolator] = None,
         azimuth_spacing: float = 1.0,
         range_spacing: float = 1e3,
+        az_margin_in_pixels: int = 11,
+        rg_margin_in_pixels: int = 11,
         interp_method: str = "bilinear",
         epoch: Optional[DateTime] = None):
     """Generate Doppler look up table (LUT).
@@ -351,6 +362,10 @@ def make_doppler_lut(rawfiles: list[str],
         LUT grid spacing in azimuth, in seconds.  Default=1 s.
     range_spacing : optional
         LUT grid spacing in range, in meters.  Default=1000 m.
+    az_margin_in_pixels : int, optional
+        Extra margin added to LUT grid in azimuth, in pixels. Default=11 pixels.
+    rg_margin_in_pixels : int, optional
+        Extra margin added to LUT grid in range, in pixels. Default=11 pixels.
     interp_method : optional
         LUT interpolation method. Default="bilinear".
     epoch : isce3.core.DateTime, optional
@@ -397,7 +412,11 @@ def make_doppler_lut(rawfiles: list[str],
 
     # Now do the actual calculations.
     wvl = isce3.core.speed_of_light / fc
-    epoch_in, t, r = get_total_grid(rawfiles, azimuth_spacing, range_spacing)
+
+    epoch_in, t, r = get_total_grid(
+        rawfiles, azimuth_spacing, range_spacing,
+        az_margin_in_pixels=az_margin_in_pixels,
+        rg_margin_in_pixels=rg_margin_in_pixels)
 
     # If timespan is too small, only one time may be provided, causing the LUT
     # construction to fail. Fall back to t ± Δt/2 to preserve az spacing.
@@ -408,6 +427,22 @@ def make_doppler_lut(rawfiles: list[str],
         t = [tmin, tmax]
 
     t = convert_epoch(t, epoch_in, epoch)
+
+    # crop the azimuth time using orbit and attitude extents
+    min_time = max([orbit.start_time, attitude.start_time])
+    max_time = min([orbit.end_time, attitude.end_time])
+
+    t = np.asarray(t)
+    if np.any(t <= min_time):
+        log.warning(f"Desired Doppler LUT start time is {min_time - t[0]} "
+            "seconds before ephemeris start. Consider adjusting "
+            "ephemeris_crop_pad or providing more orbit/attitude data.")
+    if np.any(t >= max_time):
+        log.warning(f"Desired Doppler LUT end time is {t[-1] - max_time} "
+            "seconds after ephemeris end. Consider adjusting "
+            "ephemeris_crop_pad or providing more orbit/attitude data.")
+    t = t[(t > min_time) & (t < max_time)]
+
     lut = isce3.geometry.make_doppler_lut_from_attitude(
         az_time=t,
         slant_range=r,
@@ -440,11 +475,15 @@ def make_doppler(cfg: Struct, *, epoch: Optional[DateTime] = None,
     az = np.radians(opt.azimuth_boresight_deg)
     rawfiles = cfg.input_file_group.input_file_path
 
-    fc, lut = make_doppler_lut(rawfiles,
-                               az=az, orbit=orbit, attitude=attitude,
-                               dem=dem, azimuth_spacing=opt.spacing.azimuth,
-                               range_spacing=opt.spacing.range,
-                               interp_method=opt.interp_method,  epoch=epoch)
+    fc, lut = make_doppler_lut(
+        rawfiles,
+        az=az, orbit=orbit, attitude=attitude,
+        dem=dem, azimuth_spacing=opt.spacing.azimuth,
+        range_spacing=opt.spacing.range,
+        az_margin_in_pixels=opt.margin_in_pixels.azimuth,
+        rg_margin_in_pixels=opt.margin_in_pixels.range,
+        interp_method=opt.interp_method,
+        epoch=epoch)
 
     log.info(f"Made Doppler LUT for fc={fc} Hz, "
         f"az={opt.azimuth_boresight_deg} deg with mean={lut.data.mean()} Hz")
@@ -909,7 +948,7 @@ def get_dataset_creation_options(cfg: Struct, shape: tuple[int, int]) -> dict:
     """
     Get h5py keyword arguments needed for image dataset creation.
 
-    #Parameters
+    Parameters
     ----------
     cfg : Struct
         RSLC runconfig data. Only reads `cfg.output` group.
@@ -1039,7 +1078,7 @@ def resample(raw: np.ndarray, t: np.ndarray,
 
 
 def process_rfi(cfg: Struct, raw_data: np.ndarray, swaths: np.ndarray,
-                prf_dither_mode, tmpfile: Callable = lambda name: open(name, "wb")):
+                prf_dither_mode: bool, tmpfile: Callable = lambda name: open(name, "wb")):
     """
     Run radio frequency interference (RFI) detection and mitigation as
     configured by user input.
@@ -1055,8 +1094,8 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray, swaths: np.ndarray,
         sub-swaths, nt is the number of pulses, and the trailing dimension is
         the [start, stop) indices of the sub-swath.
     prf_dither_mode: bool
-        If True, L0B acquisition with respect to the specified frequency is of 
-        Dithered PRF mode
+        If True, L0B acquisition is of PRF Dithering mode. Sample Covariance Matrix
+        is computed differently by excluding the invalid data gaps.
     tmpfile : Callable
         Function of a single string argument that returns an open file handle.
 
@@ -1088,21 +1127,16 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray, swaths: np.ndarray,
     # Mitigate in place unless user wants a debug file to compare raw and
     # mitigated data.  This means you'd need to run the workflow twice to find
     # a bug specific to in-place vs out-of-place processing.
-    
-    num_pulses, num_rng_samples = raw_data.shape
 
-    mask_valid = np.zeros((num_pulses, num_rng_samples), dtype=bool)
+    num_pulses = raw_data.shape[0]
+    mask_valid = np.zeros(raw_data.shape, dtype=bool)
     pulse_idx = np.arange(num_pulses)
 
-    print('\nfocus.py running')
-    print(f'{raw_data.shape = }')
-    print()
-
+    # Read Sub-Swath Mask for all pulses of the raw data block
     for imask, ipulse in enumerate(pulse_idx):
         for swath in swaths:
             start, end = swath[ipulse]
             mask_valid[imask, start:end] = True
-
 
     raw_data_mitigated = raw_data
     if opt.mitigation_enabled and not cfg.processing.delete_tempfiles:
@@ -1136,20 +1170,16 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray, swaths: np.ndarray,
             raw_data_mitigated=raw_data_mitigated)
     else:
         opt_fnf = opt.freq_notch_filter
-        threshold_params_notch = isce3.signal.rfi_freq_null.ThresholdParamsNotch(
-            opt_fnf.threshold_hyperparameters.x, opt_fnf.threshold_hyperparameters.y)
-
         rfi_likelihood = isce3.signal.rfi_freq_null.run_freq_notch(
             raw_data,
             opt_fnf.num_pulses_az,
-            num_samples_rng_blk=opt.num_samples_rng_blk,
+            num_rng_blks=opt.num_range_blocks,
             az_winsize=opt_fnf.az_winsize,
             rng_winsize=opt_fnf.rng_winsize,
             trim_frac=opt_fnf.trim_frac,
+            pvalue_threshold=opt_fnf.pvalue_threshold,
             cdf_threshold=opt_fnf.cdf_threshold,
             use_entire_pulse=opt.use_entire_pulse,
-            false_alarm_rate=opt_fnf.false_alarm_rate,
-            threshold_params_notch=threshold_params_notch,
             nb_detect=opt_fnf.nb_detect,
             wb_detect=opt_fnf.wb_detect,
             mitigate_enable=opt.mitigation_enabled,
@@ -1431,7 +1461,7 @@ def set_input_file_metadata(cfg: Struct, slc: SLC, runconfig_path: str = ""):
     anc = cfg.dynamic_ancillary_file_group
     value_or_blank = lambda x: x if x is not None else ""
     slc.set_inputs(
-        l0bGranules=cfg.input_file_group.input_file_path,
+        l0bGranules=[pathlib.PosixPath(f).name for f in cfg.input_file_group.input_file_path],
         orbitFiles=[value_or_blank(anc.orbit)],
         attitudeFiles=[value_or_blank(anc.pointing)],
         auxcalFiles=[value_or_blank(x) for x in (anc.external_calibration,
@@ -1832,10 +1862,23 @@ def focus(runconfig, runconfig_path=""):
         cal = get_calibration(cfg, band.width)
         slc.set_calibration(cal, frequency)
 
-        # add calibration section for each polarization
+        # add calibration section based on a downsampled radar grid,
+        # including an extra margin to ensure that, after geocoding
+        # with an interpolation algoritm (e.g., bicubic spline),
+        # the LUTs fully cover the geocoded imagery extents.
+
+        multilooked_radar_grid = og.multilook(
+            cfg.processing.lookup_tables.downsampling_factor.azimuth,
+            cfg.processing.lookup_tables.downsampling_factor.range)
+        extended_radar_grid = multilooked_radar_grid.add_margin(
+            cfg.processing.lookup_tables.margin_in_pixels.azimuth,
+            cfg.processing.lookup_tables.margin_in_pixels.range)
+
         for pol in pols:
-            slc.add_calibration_section(frequency, pol, og.sensing_times,
-                                        orbit.reference_epoch, og.slant_ranges,
+            slc.add_calibration_section(frequency, pol,
+                                        extended_radar_grid.sensing_times,
+                                        orbit.reference_epoch,
+                                        extended_radar_grid.slant_ranges,
                                         beta0_lut, sigma0_lut, gamma0_lut)
 
         # Set anomaly mask. Need to do some geometry.
@@ -1964,13 +2007,12 @@ def focus(runconfig, runconfig_path=""):
                         z[k] = wavelets.remove_tone(z[k])
                 raw_mm[block_out] = z
 
-            # Perform RFI Detection and Mitigation
             raw_clean, rfi_likelihood = process_rfi(
                 cfg, 
                 raw_mm, 
-                swaths, 
+                swaths,
                 raw.isDithered(channel_in.freq_id),
-                temp, 
+                temp
             )
             rfi_results[(frequency, pol)].append(
                 (rfi_likelihood, raw_clean.shape[0]))
@@ -1995,6 +2037,16 @@ def focus(runconfig, runconfig_path=""):
 
             # Precompute antenna patterns at downsampled spacing
             if cfg.processing.is_enabled.eap:
+                # XXX Due to a bug in respective DRT of some L0B products
+                # (CRID=05007), caltone.frequency is extrated from runconfig
+                # otherwise, it shall be set to None to be determined from DRT!
+                # The latter requires RSLC runconfig update to allow caltone
+                # frequency to be parsed directly from L0B product for more
+                # flexible configuration over wide range of L0B products.
+                # XXX the intrument-related delay offset used in DBF process
+                # shall be eventually obtained from instrument INT CAL HDF5
+                # once the respective product spec is updated (delay_ofs_dbf)!
+                # The default value is suitable for NISAR L-band instrument.
                 antpat = AntennaPattern(raw, dem, antparser,
                                         instparser, orbit, attitude,
                                         el_lut=el_lut,
@@ -2002,6 +2054,9 @@ def focus(runconfig, runconfig_path=""):
                                         caltone_freq=cfg.processing.caltone.frequency,
                                         delay_ofs_dbf=-2.1474e-6)
                                         el_lut=el_lut)
+                                        freq_band=frequency,
+                                        caltone_freq=cfg.processing.caltone.frequency,
+                                        delay_ofs_dbf=-2.1474e-6)
 
                 log.info("Precomputing antenna patterns")
                 i = np.arange(rc_grid.shape[0])
@@ -2021,9 +2076,10 @@ def focus(runconfig, runconfig_path=""):
 
             # Compute NESZ if there exist noise-only range lines
             # get noise only range line indexes within processing interval
-            cal_path_mask = raw.getCalType(
-                channel_in.freq_id, pol[0])[pulse_begin:pulse_end]
-            _, _, _, idx_noise = get_calib_range_line_idx(cal_path_mask)
+            _, cal_path_mask = chirpcorrelator_caltype_from_raw(
+                raw, txrx_pol=pol)
+            _, _, _, idx_noise = get_calib_range_line_idx(
+                cal_path_mask[pulse_begin:pulse_end])
 
             # form output slant range vector for all noise products
             if cfg.processing.noise_equivalent_backscatter.fill_nan_ends:
@@ -2052,7 +2108,29 @@ def focus(runconfig, runconfig_path=""):
                 data_noise = np.memmap(
                     fid_noise, mode='w+', shape=(nrgl_noise, rc.output_size),
                     dtype=np.complex64)
-                rc.rangecompress(data_noise, raw_clean[idx_noise])
+                # Check if raw is quad pol and the TX pol is not the
+                # first TX pol. Then extract noise only range line
+                # from the opposite TX pol w/ the same RX pol.
+                # XXX No RFI/caltone clean up of noise-only range lines
+                # for second TX pol products of quad pol!
+                raw_ns = np.copy(raw_clean[idx_noise])
+                if is_raw_quad_pol(raw):
+                    first_tx_pol = first_tx_pol_for_quad(raw)
+                    log.info(f'Quad pol w/ first {first_tx_pol} pol!')
+                    if pol[0] != first_tx_pol:
+                        pol_ns = opposite_linear_pol(pol[0]) + pol[1]
+                        log.warning('Get noise-only range lines from '
+                                    f'{pol_ns} for {pol} of quad pol!')
+                        ds_ns = raw.getRawDataset(channel_in.freq_id, pol_ns)
+                        idx_ns = np.arange(pulse_begin, pulse_end)[idx_noise]
+                        # decode simply noise-only range lines and
+                        # thus no need for memmap
+                        raw_ns = ds_ns[idx_ns]
+                        raw_ns *= bb_phasor[idx_noise, np.newaxis]
+                        raw_ns[np.isnan(raw_ns)] = 0.0
+                        if cfg.processing.zero_fill_gaps:
+                            fill_gaps(raw_ns, swaths[:, idx_noise, :], 0.0)
+                rc.rangecompress(data_noise, raw_ns)
                 # build and apply antenna pattern correction for noise
                 # pulses if EAP is True
                 if cfg.processing.is_enabled.eap:

--- a/share/nisar/defaults/focus.yaml
+++ b/share/nisar/defaults/focus.yaml
@@ -220,19 +220,19 @@ runconfig:
                 # 5 x cpi_len to avoid discrepancy from true covariance matrix.
                 # In addition, in order to avoid a run-time error for ST-EVD,
                 # this parameter needs to be at least 2 x cpi
-                num_samples_rng_blk: 1000
+                num_samples_rng_blk: 256
                 # Ignore any values passed in for parameter num_samples_rng_blk.
                 # Instead use all samples in the pulses for detection if this is true.
                 use_entire_pulse: False
 
                 slow_time_evd:
                     # Coherent processing interval length (pulses).  Defaults to 32.
-                    cpi_length: 16
+                    cpi_length: 32
                     # Maximum allowable number of emitters can be detected and
                     # suppressed per CPI. ST-EVD would ignore emitters exceeding
                     # this limit. This number should be less than cpi_length.
                     # Defaults to 16.
-                    max_emitters: 4
+                    max_emitters: 16
                     # Number of large value outliers to be trimmed in slow-time
                     # minimum Eigenvalues.
                     num_max_trim: 0
@@ -249,7 +249,7 @@ runconfig:
                     max_num_rfi_ev: 2
                     # Number of slow-time CPIs grouped together for determining and
                     # applying a common EV slope threshold.
-                    num_cpi_per_threshold_block: 15
+                    num_cpi_per_threshold_block: 20
                     # minimum fraction of samples required for cross-variance terms
                     # of sample covariance matrix
                     off_diag_overlap_ratio: 0.1
@@ -291,15 +291,13 @@ runconfig:
                     # computed, 'trim_frac/2' proportion of outliers will be removed from 
                     # both tails of the distribution.
                     trim_frac: 0.01
-                    # RFI False alarm rate for spectra analysis frequency bins
-                    false_alarm_rate: 1e-3
                     # If FDNF is applied, a threshold for pvalue needs to be selected. 
                     # pvalue is a measure of confidence against a null hypothesis. 
                     # In FDNF: Null Hypothesis: NO RFI, Alternative Hypothesis: RFI present
                     # If p-value of the range-frequency power spectra is less than p-value 
                     # threshold, alternative hypothesis is accepted. Otherwise, null hypothesis 
                     # is accepted.
-                    # pvalue_threshold: 0.005
+                    pvalue_threshold: 0.005
                     # If FDNF is applied, the cumulative probability density function (CDF)
                     # of the input Time Stationary Narrowband (TSNB) and Time Varying Wideband
                     # (TVWB) masks will be compared with this threshold. It represents 
@@ -314,21 +312,6 @@ runconfig:
                     # This should be enabled unless for the purpose of debugging.
                     # Defaults to True
                     wb_detect: True
-                    # Parameters used to adaptively determine RFI eigenvalue
-                    # # difference thresholds
-                    threshold_hyperparameters:
-                        # The computed sigma ratio of maximum and minimum Eigenvalue
-                        # first differences. It is a dimensionless figure of merit.
-                        # Larger value of x indicates higher likelihood of RFI
-                        # presence.
-                        x: [0.25, 5.0]
-                        # Estimated range of number of sigmas of the first
-                        # difference of minimum Eigenvalues across threshold block
-                        # as a function of input x, e.g., smaller x results in
-                        # larger value of y, therefore relaxing the final threshold.
-                        # The values of x outside of the defined range of y are
-                        # extrapolated.
-                        y: [6.0, 1]
 
             # Range filter parameters for mixed-mode cases.
             range_common_band_filter:
@@ -357,6 +340,24 @@ runconfig:
                 # epoch.  null for automatic selection
                 time_end: null
 
+            # Calibration and processing information look-up tables (LUTs)
+            # excluding Doppler
+            lookup_tables:
+
+                # Downsampling factors with respect to the RSLC grid
+                downsampling_factor:
+                    # Downsampling factor in azimuth direction
+                    azimuth: 50
+                    # Downsampling factor in range direction
+                    range: 50
+
+                # Extra margin added to LUTs
+                margin_in_pixels:
+                    # Extra margin added to lookup table in azimuth, in pixels.
+                    azimuth: 11
+                    # Extra margin added to lookup table in range, in pixels.
+                    range: 11
+
             doppler:
                 # Offset between quaternion frame and antenna boresight in degrees.
                 # TBD This will likely be parameter in a separate cal file.
@@ -371,6 +372,13 @@ runconfig:
                     range: 2000.0
                     # Lookup table Azimuth spacing in s
                     azimuth: 1.0
+                
+                # Extra margin added to the Doppler LUT
+                margin_in_pixels:
+                    # Extra margin added to lookup table in azimuth, in pixels.
+                    azimuth: 11
+                    # Extra margin added to lookup table in range, in pixels.
+                    range: 11
 
             # Settings for range compression algorithm.
             rangecomp:

--- a/share/nisar/defaults/focus.yaml
+++ b/share/nisar/defaults/focus.yaml
@@ -220,19 +220,19 @@ runconfig:
                 # 5 x cpi_len to avoid discrepancy from true covariance matrix.
                 # In addition, in order to avoid a run-time error for ST-EVD,
                 # this parameter needs to be at least 2 x cpi
-                num_samples_rng_blk: 256
+                num_samples_rng_blk: 1000
                 # Ignore any values passed in for parameter num_samples_rng_blk.
                 # Instead use all samples in the pulses for detection if this is true.
                 use_entire_pulse: False
 
                 slow_time_evd:
                     # Coherent processing interval length (pulses).  Defaults to 32.
-                    cpi_length: 32
+                    cpi_length: 16
                     # Maximum allowable number of emitters can be detected and
                     # suppressed per CPI. ST-EVD would ignore emitters exceeding
                     # this limit. This number should be less than cpi_length.
                     # Defaults to 16.
-                    max_emitters: 16
+                    max_emitters: 4
                     # Number of large value outliers to be trimmed in slow-time
                     # minimum Eigenvalues.
                     num_max_trim: 0
@@ -249,7 +249,15 @@ runconfig:
                     max_num_rfi_ev: 2
                     # Number of slow-time CPIs grouped together for determining and
                     # applying a common EV slope threshold.
-                    num_cpi_per_threshold_block: 20
+                    num_cpi_per_threshold_block: 15
+                    # minimum fraction of samples required for cross-variance terms
+                    # of sample covariance matrix
+                    off_diag_overlap_ratio: 0.1
+                    # minimum fraction of samples required for covariance terms
+                    # of sample covariance matrix
+                    diag_valid_ratio: 0.05
+                    # The Eigenvalue index of minimum Eigenvalue
+                    noise_ev_idx: 10
                     # Parameters used to adaptively determine RFI eigenvalue
                     # difference thresholds
                     threshold_hyperparameters:
@@ -283,13 +291,15 @@ runconfig:
                     # computed, 'trim_frac/2' proportion of outliers will be removed from 
                     # both tails of the distribution.
                     trim_frac: 0.01
+                    # RFI False alarm rate for spectra analysis frequency bins
+                    false_alarm_rate: 1e-3
                     # If FDNF is applied, a threshold for pvalue needs to be selected. 
                     # pvalue is a measure of confidence against a null hypothesis. 
                     # In FDNF: Null Hypothesis: NO RFI, Alternative Hypothesis: RFI present
                     # If p-value of the range-frequency power spectra is less than p-value 
                     # threshold, alternative hypothesis is accepted. Otherwise, null hypothesis 
                     # is accepted.
-                    pvalue_threshold: 0.005
+                    # pvalue_threshold: 0.005
                     # If FDNF is applied, the cumulative probability density function (CDF)
                     # of the input Time Stationary Narrowband (TSNB) and Time Varying Wideband
                     # (TVWB) masks will be compared with this threshold. It represents 
@@ -304,6 +314,21 @@ runconfig:
                     # This should be enabled unless for the purpose of debugging.
                     # Defaults to True
                     wb_detect: True
+                    # Parameters used to adaptively determine RFI eigenvalue
+                    # # difference thresholds
+                    threshold_hyperparameters:
+                        # The computed sigma ratio of maximum and minimum Eigenvalue
+                        # first differences. It is a dimensionless figure of merit.
+                        # Larger value of x indicates higher likelihood of RFI
+                        # presence.
+                        x: [0.25, 5.0]
+                        # Estimated range of number of sigmas of the first
+                        # difference of minimum Eigenvalues across threshold block
+                        # as a function of input x, e.g., smaller x results in
+                        # larger value of y, therefore relaxing the final threshold.
+                        # The values of x outside of the defined range of y are
+                        # extrapolated.
+                        y: [6.0, 1]
 
             # Range filter parameters for mixed-mode cases.
             range_common_band_filter:
@@ -332,24 +357,6 @@ runconfig:
                 # epoch.  null for automatic selection
                 time_end: null
 
-            # Calibration and processing information look-up tables (LUTs)
-            # excluding Doppler
-            lookup_tables:
-
-                # Downsampling factors with respect to the RSLC grid
-                downsampling_factor:
-                    # Downsampling factor in azimuth direction
-                    azimuth: 50
-                    # Downsampling factor in range direction
-                    range: 50
-
-                # Extra margin added to LUTs
-                margin_in_pixels:
-                    # Extra margin added to lookup table in azimuth, in pixels.
-                    azimuth: 11
-                    # Extra margin added to lookup table in range, in pixels.
-                    range: 11
-
             doppler:
                 # Offset between quaternion frame and antenna boresight in degrees.
                 # TBD This will likely be parameter in a separate cal file.
@@ -364,13 +371,6 @@ runconfig:
                     range: 2000.0
                     # Lookup table Azimuth spacing in s
                     azimuth: 1.0
-                
-                # Extra margin added to the Doppler LUT
-                margin_in_pixels:
-                    # Extra margin added to lookup table in azimuth, in pixels.
-                    azimuth: 11
-                    # Extra margin added to lookup table in range, in pixels.
-                    range: 11
 
             # Settings for range compression algorithm.
             rangecomp:

--- a/share/nisar/defaults/focus.yaml
+++ b/share/nisar/defaults/focus.yaml
@@ -257,8 +257,8 @@ runconfig:
                     # of sample covariance matrix
                     diag_valid_ratio: 0.20
                     # This ratio will be used to determine the minimum number of valid Eigenvalues
-                    # required for a CPI. min_ev_valid_idx = int(np.floor(normalized_min_rank_ratio * cpi_len))
-                    normalized_min_rank_ratio: 0.65
+                    # required for a CPI. min_ev_valid_idx = int(np.floor(min_rank_frac * cpi_len)) - 1
+                    min_rank_frac: 0.70
                     # radar platform receiver dynamic range, e.g. 50 dB. This is applied as a threshold
                     # to determine if the Eigenvalue under test is meaningfully signficant.
                     rx_dynamic_range_db: 50.0

--- a/share/nisar/defaults/focus.yaml
+++ b/share/nisar/defaults/focus.yaml
@@ -227,12 +227,12 @@ runconfig:
 
                 slow_time_evd:
                     # Coherent processing interval length (pulses).  Defaults to 32.
-                    cpi_length: 32
+                    cpi_length: 16
                     # Maximum allowable number of emitters can be detected and
                     # suppressed per CPI. ST-EVD would ignore emitters exceeding
                     # this limit. This number should be less than cpi_length.
                     # Defaults to 16.
-                    max_emitters: 16
+                    max_emitters: 4
                     # Number of large value outliers to be trimmed in slow-time
                     # minimum Eigenvalues.
                     num_max_trim: 0
@@ -249,15 +249,19 @@ runconfig:
                     max_num_rfi_ev: 2
                     # Number of slow-time CPIs grouped together for determining and
                     # applying a common EV slope threshold.
-                    num_cpi_per_threshold_block: 20
+                    num_cpi_per_threshold_block: 15
                     # minimum fraction of samples required for cross-variance terms
                     # of sample covariance matrix
-                    off_diag_overlap_ratio: 0.1
+                    off_diag_overlap_ratio: 0.25
                     # minimum fraction of samples required for covariance terms
                     # of sample covariance matrix
-                    diag_valid_ratio: 0.05
-                    # The Eigenvalue index of minimum Eigenvalue
-                    noise_ev_idx: 10
+                    diag_valid_ratio: 0.20
+                    # This ratio will be used to determine the minimum number of valid Eigenvalues
+                    # required for a CPI. min_ev_valid_idx = min_valid_ev_ratio * cpi_len
+                    min_valid_ev_ratio: 0.65
+                    # radar platform receiver dynamic range, e.g. -50 dB. This is applied as a threshold
+                    # to determine if the Eigenvalue under test is meaningfully signficant.
+                    rx_dynamic_range_db: -50.0
                     # Parameters used to adaptively determine RFI eigenvalue
                     # difference thresholds
                     threshold_hyperparameters:

--- a/share/nisar/defaults/focus.yaml
+++ b/share/nisar/defaults/focus.yaml
@@ -257,11 +257,11 @@ runconfig:
                     # of sample covariance matrix
                     diag_valid_ratio: 0.20
                     # This ratio will be used to determine the minimum number of valid Eigenvalues
-                    # required for a CPI. min_ev_valid_idx = min_valid_ev_ratio * cpi_len
-                    min_valid_ev_ratio: 0.65
-                    # radar platform receiver dynamic range, e.g. -50 dB. This is applied as a threshold
+                    # required for a CPI. min_ev_valid_idx = int(np.floor(normalized_min_rank_ratio * cpi_len))
+                    normalized_min_rank_ratio: 0.65
+                    # radar platform receiver dynamic range, e.g. 50 dB. This is applied as a threshold
                     # to determine if the Eigenvalue under test is meaningfully signficant.
-                    rx_dynamic_range_db: -50.0
+                    rx_dynamic_range_db: 50.0
                     # Parameters used to adaptively determine RFI eigenvalue
                     # difference thresholds
                     threshold_hyperparameters:

--- a/share/nisar/defaults/focus.yaml
+++ b/share/nisar/defaults/focus.yaml
@@ -257,7 +257,7 @@ runconfig:
                     # of sample covariance matrix
                     diag_valid_ratio: 0.20
                     # This ratio will be used to determine the minimum number of valid Eigenvalues
-                    # required for a CPI. min_ev_valid_idx = int(np.floor(min_rank_frac * cpi_len)) - 1
+                    # required for a CPI. min_ev_valid_idx = int(np.round(min_rank_frac * cpi_len)) - 1
                     min_rank_frac: 0.70
                     # radar platform receiver dynamic range, e.g. 50 dB. This is applied as a threshold
                     # to determine if the Eigenvalue under test is meaningfully signficant.

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -163,10 +163,6 @@ runconfig:
       # Geographic-to-radar coordinate transforms
       geo2rdr: include('geo2rdr_options', required=False)
 
-      # Calibration and processing information look-up tables (LUTs)
-      # excluding Doppler
-      lookup_tables: include('lookup_tables_options', required=False)
-
       doppler:
         # Offset between quaternion frame and antenna boresight in degrees.
         azimuth_boresight_deg: num(required=False)
@@ -180,9 +176,6 @@ runconfig:
           range: num(min=0.0, required=False)
           # Lookup table Azimuth spacing in s
           azimuth: num(min=0.0, required=False)
-
-        # Extra margin added to the Doppler LUT
-        margin_in_pixels: include('margin_in_pixels_options', required=False)
 
       # Settings for range compression algorithm.
       rangecomp:
@@ -291,7 +284,7 @@ notch:
 caltone_options:
   frequency: num(min=0, required=False)
   algorithm: enum('wavelet', 'azimuth_mean', 'auto', 'disabled', required=False)
-  wavelet_size: num(min=2, required=False)
+  block_size: num(min=2, required=False)
 
 spectral_window:
   kind: enum('Kaiser', 'Cosine', required=False)
@@ -321,23 +314,6 @@ geo2rdr_options:
   # Latest time in search interval, in s past orbit reference epoch
   # null for automatic selection
   time_end: num(required=False)
-
-lookup_tables_options:
-  # Downsampling factors with respect to the RSLC grid
-  downsampling_factor:
-    # Downsampling factor in azimuth direction
-    azimuth: int(min=1, required=False)
-    # Downsampling factor in range direction
-    range: int(min=1, required=False)
-
-  # Extra margin added to LUTs
-  margin_in_pixels: include('margin_in_pixels_options', required=False)
-
-margin_in_pixels_options:
-  # Extra margin added to lookup table in azimuth, in pixels.
-  azimuth: int(min=0, required=False)
-  # Extra margin added to lookup table in range, in pixels.
-  range: int(min=0, required=False)
 
 nesz_options:
   # supported noise estimator algorithms:
@@ -421,6 +397,14 @@ slow_time_evd_options:
   # Number of slow-time CPIs grouped together for determining and applying a
   # common EV slope threshold.
   num_cpi_per_threshold_block: int(min=2, required=False)
+  # minimum fraction of samples required for cross-variance terms
+  # # of sample covariance matrix
+  off_diag_overlap_ratio: num(min=0.0, required=False) 
+  # minimum fraction of samples required for co-variance terms
+  # # of sample covariance matrix
+  diag_valid_ratio: num(min=0.0, required=False)
+  # The Eigenvalue index of minimum Eigenvalue
+  noise_ev_idx: int(min=2, required=False)
   # Parameters used to adaptively determine RFI eigenvalue difference thresholds
   threshold_hyperparameters: include('rfi_threshold_options', required=False)
 
@@ -439,12 +423,14 @@ freq_notch_filter_options:
   # 'trim_frac/2' proportion of outliers will be removed from both tails of 
   # the distribution.
   trim_frac: num(min=0.0, required=False)
+  # RFI False alarm rate for spectra analysis frequency bins
+  false_alarm_rate: num(min=0.0, required=False)
   # If FDNF is applied, a threshold for pvalue needs to be selected. pvalue is a
   # measure of confidence against a null hypothesis. In FDNF:
   # Null Hypothesis: NO RFI, Alternative Hypothesis: RFI present
   # If p-value of the range-frequency power spectra is less than p-value threshold,
   # alternative hypothesis is accepted. Otherwise, null hypothesis is accepted.
-  pvalue_threshold: num(min=0.0, required=False)
+  #pvalue_threshold: num(min=0.0, required=False)
   # If FDNF is applied, the cumulative probability density function (CDF) 
   # of the input Time Stationary Narrowband (TSNB) and Time Varying Wideband 
   # (TVWB) masks will be compared with this threshold. It represents an estimate of 
@@ -459,6 +445,8 @@ freq_notch_filter_options:
   # This should be enabled unless for the purpose of debugging.
   # Defaults to True
   wb_detect: bool(required=False)
+  # Parameters used to adaptively determine RFI eigenvalue difference thresholds
+  threshold_hyperparameters_notch: include('rfi_threshold_options', required=False)
 
 rfi_threshold_options:
     # The computed sigma ratio of maximum and minimum Eigenvalue
@@ -498,38 +486,30 @@ qa_validation_options:
   metadata_luts_fail_if_all_nan: bool(required=False)
 
 qa_reports_options:
-  backscatter_img: include('backscatter_img_options', required=False)
-  histogram: include('histogram_options', required=False)
-  range_spectra: include('range_spectra_options', required=False)
-  azimuth_spectra: include('azimuth_spectra_options', required=False)
-
-backscatter_img_options:
-  linear_units: bool(required=False)
-  nlooks_freqa: list(int(min=1), min=2, max=2, required=False)
-  nlooks_freqb: list(int(min=1), min=2, max=2, required=False)
-  longest_side_max: int(min=1, required=False)
-  percentile_for_clipping: list(num(min=0.0, max=100.0), min=2, max=2, required=False)
-  gamma: num(min=0.0, required=False)
-  nan_color_in_pdf: str(required=False)
-  tile_shape: list(int(min=-1), min=2, max=2, required=False)
-  output_individual_pngs: bool(required=False)
-
-histogram_options:
-  decimation_ratio: list(int(min=1), min=2, max=2, required=False)
-  backscatter_histogram_bin_edges_range: list(num(), min=2, max=2, required=False)
-  phase_histogram_y_axis_range: list(any(num(), null()), min=2, max=2, required=False)
-  phs_in_radians: bool(required=False)
-  tile_shape: list(int(min=-1), min=2, max=2, required=False)
-
-range_spectra_options:
-  az_decimation: int(min=1, required=False)
-  hz_to_mhz: bool(required=False)
-  tile_height: int(min=-1, required=False)
-
-azimuth_spectra_options:
-  num_columns: int(min=-1, required=False)
-  hz_to_mhz: bool(required=False)
-  tile_width: int(min=-1, required=False)
+  backscatter_img:
+    linear_units: bool(required=False)
+    nlooks_freqa: list(int(min=1), min=2, max=2, required=False)
+    nlooks_freqb: list(int(min=1), min=2, max=2, required=False)
+    longest_side_max: int(min=1, required=False)
+    percentile_for_clipping: list(num(min=0.0, max=100.0), min=2, max=2, required=False)
+    gamma: num(min=0.0, required=False)
+    nan_color_in_pdf: str(required=False)
+    tile_shape: list(int(min=-1), min=2, max=2, required=False)
+    output_individual_pngs: bool(required=False)
+  histogram:
+    decimation_ratio: list(int(min=1), min=2, max=2, required=False)
+    backscatter_histogram_bin_edges_range: list(num(), min=2, max=2, required=False)
+    phase_histogram_y_axis_range: list(any(num(), null()), min=2, max=2, required=False)
+    phs_in_radians: bool(required=False)
+    tile_shape: list(int(min=-1), min=2, max=2, required=False)
+  range_spectra:
+    az_decimation: int(min=1, required=False)
+    hz_to_mhz: bool(required=False)
+    tile_height: int(min=-1, required=False)
+  azimuth_spectra:
+    num_columns: int(min=-1, required=False)
+    hz_to_mhz: bool(required=False)
+    tile_width: int(min=-1, required=False)
 
 absolute_radiometric_calibration_options:
   nchip: int(min=1, required=False)

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -163,6 +163,10 @@ runconfig:
       # Geographic-to-radar coordinate transforms
       geo2rdr: include('geo2rdr_options', required=False)
 
+      # Calibration and processing information look-up tables (LUTs)
+      # excluding Doppler
+      lookup_tables: include('lookup_tables_options', required=False)
+
       doppler:
         # Offset between quaternion frame and antenna boresight in degrees.
         azimuth_boresight_deg: num(required=False)
@@ -176,6 +180,9 @@ runconfig:
           range: num(min=0.0, required=False)
           # Lookup table Azimuth spacing in s
           azimuth: num(min=0.0, required=False)
+
+        # Extra margin added to the Doppler LUT
+        margin_in_pixels: include('margin_in_pixels_options', required=False)
 
       # Settings for range compression algorithm.
       rangecomp:
@@ -284,7 +291,7 @@ notch:
 caltone_options:
   frequency: num(min=0, required=False)
   algorithm: enum('wavelet', 'azimuth_mean', 'auto', 'disabled', required=False)
-  block_size: num(min=2, required=False)
+  wavelet_size: num(min=2, required=False)
 
 spectral_window:
   kind: enum('Kaiser', 'Cosine', required=False)
@@ -314,6 +321,23 @@ geo2rdr_options:
   # Latest time in search interval, in s past orbit reference epoch
   # null for automatic selection
   time_end: num(required=False)
+
+lookup_tables_options:
+  # Downsampling factors with respect to the RSLC grid
+  downsampling_factor:
+    # Downsampling factor in azimuth direction
+    azimuth: int(min=1, required=False)
+    # Downsampling factor in range direction
+    range: int(min=1, required=False)
+
+  # Extra margin added to LUTs
+  margin_in_pixels: include('margin_in_pixels_options', required=False)
+
+margin_in_pixels_options:
+  # Extra margin added to lookup table in azimuth, in pixels.
+  azimuth: int(min=0, required=False)
+  # Extra margin added to lookup table in range, in pixels.
+  range: int(min=0, required=False)
 
 nesz_options:
   # supported noise estimator algorithms:
@@ -398,10 +422,10 @@ slow_time_evd_options:
   # common EV slope threshold.
   num_cpi_per_threshold_block: int(min=2, required=False)
   # minimum fraction of samples required for cross-variance terms
-  # # of sample covariance matrix
-  off_diag_overlap_ratio: num(min=0.0, required=False) 
+  # of sample covariance matrix
+  off_diag_overlap_ratio: num(min=0.0, required=False)
   # minimum fraction of samples required for co-variance terms
-  # # of sample covariance matrix
+  # of sample covariance matrix
   diag_valid_ratio: num(min=0.0, required=False)
   # The Eigenvalue index of minimum Eigenvalue
   noise_ev_idx: int(min=2, required=False)
@@ -423,14 +447,12 @@ freq_notch_filter_options:
   # 'trim_frac/2' proportion of outliers will be removed from both tails of 
   # the distribution.
   trim_frac: num(min=0.0, required=False)
-  # RFI False alarm rate for spectra analysis frequency bins
-  false_alarm_rate: num(min=0.0, required=False)
   # If FDNF is applied, a threshold for pvalue needs to be selected. pvalue is a
   # measure of confidence against a null hypothesis. In FDNF:
   # Null Hypothesis: NO RFI, Alternative Hypothesis: RFI present
   # If p-value of the range-frequency power spectra is less than p-value threshold,
   # alternative hypothesis is accepted. Otherwise, null hypothesis is accepted.
-  #pvalue_threshold: num(min=0.0, required=False)
+  pvalue_threshold: num(min=0.0, required=False)
   # If FDNF is applied, the cumulative probability density function (CDF) 
   # of the input Time Stationary Narrowband (TSNB) and Time Varying Wideband 
   # (TVWB) masks will be compared with this threshold. It represents an estimate of 
@@ -445,8 +467,6 @@ freq_notch_filter_options:
   # This should be enabled unless for the purpose of debugging.
   # Defaults to True
   wb_detect: bool(required=False)
-  # Parameters used to adaptively determine RFI eigenvalue difference thresholds
-  threshold_hyperparameters_notch: include('rfi_threshold_options', required=False)
 
 rfi_threshold_options:
     # The computed sigma ratio of maximum and minimum Eigenvalue
@@ -486,30 +506,38 @@ qa_validation_options:
   metadata_luts_fail_if_all_nan: bool(required=False)
 
 qa_reports_options:
-  backscatter_img:
-    linear_units: bool(required=False)
-    nlooks_freqa: list(int(min=1), min=2, max=2, required=False)
-    nlooks_freqb: list(int(min=1), min=2, max=2, required=False)
-    longest_side_max: int(min=1, required=False)
-    percentile_for_clipping: list(num(min=0.0, max=100.0), min=2, max=2, required=False)
-    gamma: num(min=0.0, required=False)
-    nan_color_in_pdf: str(required=False)
-    tile_shape: list(int(min=-1), min=2, max=2, required=False)
-    output_individual_pngs: bool(required=False)
-  histogram:
-    decimation_ratio: list(int(min=1), min=2, max=2, required=False)
-    backscatter_histogram_bin_edges_range: list(num(), min=2, max=2, required=False)
-    phase_histogram_y_axis_range: list(any(num(), null()), min=2, max=2, required=False)
-    phs_in_radians: bool(required=False)
-    tile_shape: list(int(min=-1), min=2, max=2, required=False)
-  range_spectra:
-    az_decimation: int(min=1, required=False)
-    hz_to_mhz: bool(required=False)
-    tile_height: int(min=-1, required=False)
-  azimuth_spectra:
-    num_columns: int(min=-1, required=False)
-    hz_to_mhz: bool(required=False)
-    tile_width: int(min=-1, required=False)
+  backscatter_img: include('backscatter_img_options', required=False)
+  histogram: include('histogram_options', required=False)
+  range_spectra: include('range_spectra_options', required=False)
+  azimuth_spectra: include('azimuth_spectra_options', required=False)
+
+backscatter_img_options:
+  linear_units: bool(required=False)
+  nlooks_freqa: list(int(min=1), min=2, max=2, required=False)
+  nlooks_freqb: list(int(min=1), min=2, max=2, required=False)
+  longest_side_max: int(min=1, required=False)
+  percentile_for_clipping: list(num(min=0.0, max=100.0), min=2, max=2, required=False)
+  gamma: num(min=0.0, required=False)
+  nan_color_in_pdf: str(required=False)
+  tile_shape: list(int(min=-1), min=2, max=2, required=False)
+  output_individual_pngs: bool(required=False)
+
+histogram_options:
+  decimation_ratio: list(int(min=1), min=2, max=2, required=False)
+  backscatter_histogram_bin_edges_range: list(num(), min=2, max=2, required=False)
+  phase_histogram_y_axis_range: list(any(num(), null()), min=2, max=2, required=False)
+  phs_in_radians: bool(required=False)
+  tile_shape: list(int(min=-1), min=2, max=2, required=False)
+
+range_spectra_options:
+  az_decimation: int(min=1, required=False)
+  hz_to_mhz: bool(required=False)
+  tile_height: int(min=-1, required=False)
+
+azimuth_spectra_options:
+  num_columns: int(min=-1, required=False)
+  hz_to_mhz: bool(required=False)
+  tile_width: int(min=-1, required=False)
 
 absolute_radiometric_calibration_options:
   nchip: int(min=1, required=False)

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -432,7 +432,7 @@ slow_time_evd_options:
   normalized_min_rank_ratio: num(min=0.0, required=False)
   # radar platform receiver dynamic range, e.g. 50 dB. This is applied as a threshold
   # to determine if the Eigenvalue under test is meaningfully signficant.
-  rx_dynamic_range_db: num(min=-100.0, max=0.0, required=False)
+  rx_dynamic_range_db: num(min=0.0, max=100.0, required=False)
   # Parameters used to adaptively determine RFI eigenvalue difference thresholds
   threshold_hyperparameters: include('rfi_threshold_options', required=False)
 

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -429,10 +429,10 @@ slow_time_evd_options:
   diag_valid_ratio: num(min=0.0, required=False)
   #This ratio will be used to determine the minimum number of valid Eigenvalues
   ##required for a CPI. min_ev_valid_idx = min_valid_ev_ratio * cpi_len
-  min_valid_ev_ratio: int(min=0.0, required=False)
+  min_valid_ev_ratio: num(min=0.0, required=False)
   # radar platform receiver dynamic range, e.g. -50 dB. This is applied as a threshold
   # to determine if the Eigenvalue under test is meaningfully signficant.
-  rx_dynamic_range_db: float(min=-100.0, max=0.0, required=False)
+  rx_dynamic_range_db: num(min=-100.0, max=0.0, required=False)
   # Parameters used to adaptively determine RFI eigenvalue difference thresholds
   threshold_hyperparameters: include('rfi_threshold_options', required=False)
 

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -427,8 +427,12 @@ slow_time_evd_options:
   # minimum fraction of samples required for co-variance terms
   # of sample covariance matrix
   diag_valid_ratio: num(min=0.0, required=False)
-  # The Eigenvalue index of minimum Eigenvalue
-  noise_ev_idx: int(min=2, required=False)
+  #This ratio will be used to determine the minimum number of valid Eigenvalues
+  ##required for a CPI. min_ev_valid_idx = min_valid_ev_ratio * cpi_len
+  min_valid_ev_ratio: int(min=0.0, required=False)
+  # radar platform receiver dynamic range, e.g. -50 dB. This is applied as a threshold
+  # to determine if the Eigenvalue under test is meaningfully signficant.
+  rx_dynamic_range_db: float(min=-100.0, max=0.0, required=False)
   # Parameters used to adaptively determine RFI eigenvalue difference thresholds
   threshold_hyperparameters: include('rfi_threshold_options', required=False)
 

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -429,7 +429,7 @@ slow_time_evd_options:
   diag_valid_ratio: num(min=0.0, required=False)
   #This ratio will be used to determine the minimum number of valid Eigenvalues
   ##required for a CPI. min_ev_valid_idx = int(np.floor(normalized_min_rank_ratio * cpi_len))
-  normalized_min_rank_ratio: num(min=0.0, required=False)
+  normalized_min_rank_ratio: num(min=0.0, max=1.0, required=False)
   # radar platform receiver dynamic range, e.g. 50 dB. This is applied as a threshold
   # to determine if the Eigenvalue under test is meaningfully signficant.
   rx_dynamic_range_db: num(min=0.0, max=100.0, required=False)

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -428,9 +428,9 @@ slow_time_evd_options:
   # of sample covariance matrix
   diag_valid_ratio: num(min=0.0, required=False)
   #This ratio will be used to determine the minimum number of valid Eigenvalues
-  ##required for a CPI. min_ev_valid_idx = min_valid_ev_ratio * cpi_len
-  min_valid_ev_ratio: num(min=0.0, required=False)
-  # radar platform receiver dynamic range, e.g. -50 dB. This is applied as a threshold
+  ##required for a CPI. min_ev_valid_idx = int(np.floor(normalized_min_rank_ratio * cpi_len))
+  normalized_min_rank_ratio: num(min=0.0, required=False)
+  # radar platform receiver dynamic range, e.g. 50 dB. This is applied as a threshold
   # to determine if the Eigenvalue under test is meaningfully signficant.
   rx_dynamic_range_db: num(min=-100.0, max=0.0, required=False)
   # Parameters used to adaptively determine RFI eigenvalue difference thresholds

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -428,8 +428,8 @@ slow_time_evd_options:
   # of sample covariance matrix
   diag_valid_ratio: num(min=0.0, required=False)
   #This ratio will be used to determine the minimum number of valid Eigenvalues
-  ##required for a CPI. min_ev_valid_idx = int(np.floor(normalized_min_rank_ratio * cpi_len))
-  normalized_min_rank_ratio: num(min=0.0, max=1.0, required=False)
+  ##required for a CPI. min_ev_valid_idx = int(np.floor(min_rank_frac * cpi_len)) - 1
+  min_rank_frac: num(min=0.0, max=1.0, required=False)
   # radar platform receiver dynamic range, e.g. 50 dB. This is applied as a threshold
   # to determine if the Eigenvalue under test is meaningfully signficant.
   rx_dynamic_range_db: num(min=0.0, max=100.0, required=False)

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -449,7 +449,7 @@ slow_time_evd_options:
   # of sample covariance matrix
   diag_valid_ratio: num(min=0.0, required=False)
   #This ratio will be used to determine the minimum number of valid Eigenvalues
-  ##required for a CPI. min_ev_valid_idx = int(np.floor(min_rank_frac * cpi_len)) - 1
+  ##required for a CPI. min_ev_valid_idx = int(np.round(min_rank_frac * cpi_len)) - 1
   min_rank_frac: num(min=0.0, max=1.0, required=False)
   # radar platform receiver dynamic range, e.g. 50 dB. This is applied as a threshold
   # to determine if the Eigenvalue under test is meaningfully signficant.

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -450,7 +450,7 @@ slow_time_evd_options:
   diag_valid_ratio: num(min=0.0, required=False)
   #This ratio will be used to determine the minimum number of valid Eigenvalues
   ##required for a CPI. min_ev_valid_idx = int(np.floor(normalized_min_rank_ratio * cpi_len))
-  normalized_min_rank_ratio: num(min=0.0, required=False)
+  normalized_min_rank_ratio: num(min=0.0, max=1.0, required=False)
   # radar platform receiver dynamic range, e.g. 50 dB. This is applied as a threshold
   # to determine if the Eigenvalue under test is meaningfully signficant.
   rx_dynamic_range_db: num(min=0.0, max=100.0, required=False)

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -453,7 +453,7 @@ slow_time_evd_options:
   normalized_min_rank_ratio: num(min=0.0, required=False)
   # radar platform receiver dynamic range, e.g. 50 dB. This is applied as a threshold
   # to determine if the Eigenvalue under test is meaningfully signficant.
-  rx_dynamic_range_db: num(min=-100.0, max=0.0, required=False)
+  rx_dynamic_range_db: num(min=0.0, max=100.0, required=False)
   # Parameters used to adaptively determine RFI eigenvalue difference thresholds
   threshold_hyperparameters: include('rfi_threshold_options', required=False)
 

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -163,6 +163,10 @@ runconfig:
       # Geographic-to-radar coordinate transforms
       geo2rdr: include('geo2rdr_options', required=False)
 
+      # Calibration and processing information look-up tables (LUTs)
+      # excluding Doppler
+      lookup_tables: include('lookup_tables_options', required=False)
+
       doppler:
         # Offset between quaternion frame and antenna boresight in degrees.
         azimuth_boresight_deg: num(required=False)
@@ -176,6 +180,9 @@ runconfig:
           range: num(min=0.0, required=False)
           # Lookup table Azimuth spacing in s
           azimuth: num(min=0.0, required=False)
+
+        # Extra margin added to the Doppler LUT
+        margin_in_pixels: include('margin_in_pixels_options', required=False)
 
       # Settings for range compression algorithm.
       rangecomp:
@@ -305,7 +312,7 @@ mask_options:
 caltone_options:
   frequency: num(min=0, required=False)
   algorithm: enum('wavelet', 'azimuth_mean', 'auto', 'disabled', required=False)
-  block_size: num(min=2, required=False)
+  wavelet_size: num(min=2, required=False)
 
 spectral_window:
   kind: enum('Kaiser', 'Cosine', required=False)
@@ -335,6 +342,23 @@ geo2rdr_options:
   # Latest time in search interval, in s past orbit reference epoch
   # null for automatic selection
   time_end: num(required=False)
+
+lookup_tables_options:
+  # Downsampling factors with respect to the RSLC grid
+  downsampling_factor:
+    # Downsampling factor in azimuth direction
+    azimuth: int(min=1, required=False)
+    # Downsampling factor in range direction
+    range: int(min=1, required=False)
+
+  # Extra margin added to LUTs
+  margin_in_pixels: include('margin_in_pixels_options', required=False)
+
+margin_in_pixels_options:
+  # Extra margin added to lookup table in azimuth, in pixels.
+  azimuth: int(min=0, required=False)
+  # Extra margin added to lookup table in range, in pixels.
+  range: int(min=0, required=False)
 
 nesz_options:
   # supported noise estimator algorithms:
@@ -419,10 +443,10 @@ slow_time_evd_options:
   # common EV slope threshold.
   num_cpi_per_threshold_block: int(min=2, required=False)
   # minimum fraction of samples required for cross-variance terms
-  # # of sample covariance matrix
-  off_diag_overlap_ratio: num(min=0.0, required=False) 
+  # of sample covariance matrix
+  off_diag_overlap_ratio: num(min=0.0, required=False)
   # minimum fraction of samples required for co-variance terms
-  # # of sample covariance matrix
+  # of sample covariance matrix
   diag_valid_ratio: num(min=0.0, required=False)
   # The Eigenvalue index of minimum Eigenvalue
   noise_ev_idx: int(min=2, required=False)
@@ -444,14 +468,12 @@ freq_notch_filter_options:
   # 'trim_frac/2' proportion of outliers will be removed from both tails of 
   # the distribution.
   trim_frac: num(min=0.0, required=False)
-  # RFI False alarm rate for spectra analysis frequency bins
-  false_alarm_rate: num(min=0.0, required=False)
   # If FDNF is applied, a threshold for pvalue needs to be selected. pvalue is a
   # measure of confidence against a null hypothesis. In FDNF:
   # Null Hypothesis: NO RFI, Alternative Hypothesis: RFI present
   # If p-value of the range-frequency power spectra is less than p-value threshold,
   # alternative hypothesis is accepted. Otherwise, null hypothesis is accepted.
-  #pvalue_threshold: num(min=0.0, required=False)
+  pvalue_threshold: num(min=0.0, required=False)
   # If FDNF is applied, the cumulative probability density function (CDF) 
   # of the input Time Stationary Narrowband (TSNB) and Time Varying Wideband 
   # (TVWB) masks will be compared with this threshold. It represents an estimate of 
@@ -466,8 +488,6 @@ freq_notch_filter_options:
   # This should be enabled unless for the purpose of debugging.
   # Defaults to True
   wb_detect: bool(required=False)
-  # Parameters used to adaptively determine RFI eigenvalue difference thresholds
-  threshold_hyperparameters_notch: include('rfi_threshold_options', required=False)
 
 rfi_threshold_options:
     # The computed sigma ratio of maximum and minimum Eigenvalue
@@ -507,30 +527,38 @@ qa_validation_options:
   metadata_luts_fail_if_all_nan: bool(required=False)
 
 qa_reports_options:
-  backscatter_img:
-    linear_units: bool(required=False)
-    nlooks_freqa: list(int(min=1), min=2, max=2, required=False)
-    nlooks_freqb: list(int(min=1), min=2, max=2, required=False)
-    longest_side_max: int(min=1, required=False)
-    percentile_for_clipping: list(num(min=0.0, max=100.0), min=2, max=2, required=False)
-    gamma: num(min=0.0, required=False)
-    nan_color_in_pdf: str(required=False)
-    tile_shape: list(int(min=-1), min=2, max=2, required=False)
-    output_individual_pngs: bool(required=False)
-  histogram:
-    decimation_ratio: list(int(min=1), min=2, max=2, required=False)
-    backscatter_histogram_bin_edges_range: list(num(), min=2, max=2, required=False)
-    phase_histogram_y_axis_range: list(any(num(), null()), min=2, max=2, required=False)
-    phs_in_radians: bool(required=False)
-    tile_shape: list(int(min=-1), min=2, max=2, required=False)
-  range_spectra:
-    az_decimation: int(min=1, required=False)
-    hz_to_mhz: bool(required=False)
-    tile_height: int(min=-1, required=False)
-  azimuth_spectra:
-    num_columns: int(min=-1, required=False)
-    hz_to_mhz: bool(required=False)
-    tile_width: int(min=-1, required=False)
+  backscatter_img: include('backscatter_img_options', required=False)
+  histogram: include('histogram_options', required=False)
+  range_spectra: include('range_spectra_options', required=False)
+  azimuth_spectra: include('azimuth_spectra_options', required=False)
+
+backscatter_img_options:
+  linear_units: bool(required=False)
+  nlooks_freqa: list(int(min=1), min=2, max=2, required=False)
+  nlooks_freqb: list(int(min=1), min=2, max=2, required=False)
+  longest_side_max: int(min=1, required=False)
+  percentile_for_clipping: list(num(min=0.0, max=100.0), min=2, max=2, required=False)
+  gamma: num(min=0.0, required=False)
+  nan_color_in_pdf: str(required=False)
+  tile_shape: list(int(min=-1), min=2, max=2, required=False)
+  output_individual_pngs: bool(required=False)
+
+histogram_options:
+  decimation_ratio: list(int(min=1), min=2, max=2, required=False)
+  backscatter_histogram_bin_edges_range: list(num(), min=2, max=2, required=False)
+  phase_histogram_y_axis_range: list(any(num(), null()), min=2, max=2, required=False)
+  phs_in_radians: bool(required=False)
+  tile_shape: list(int(min=-1), min=2, max=2, required=False)
+
+range_spectra_options:
+  az_decimation: int(min=1, required=False)
+  hz_to_mhz: bool(required=False)
+  tile_height: int(min=-1, required=False)
+
+azimuth_spectra_options:
+  num_columns: int(min=-1, required=False)
+  hz_to_mhz: bool(required=False)
+  tile_width: int(min=-1, required=False)
 
 absolute_radiometric_calibration_options:
   nchip: int(min=1, required=False)

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -450,7 +450,7 @@ slow_time_evd_options:
   diag_valid_ratio: num(min=0.0, required=False)
   #This ratio will be used to determine the minimum number of valid Eigenvalues
   ##required for a CPI. min_ev_valid_idx = int(np.round(min_rank_frac * cpi_len)) - 1
-  min_rank_frac: num(min=0.0, max=1.0, required=False)
+  min_rank_frac: num(exclusiveMinimum=0.0, max=1.0, required=False)
   # radar platform receiver dynamic range, e.g. 50 dB. This is applied as a threshold
   # to determine if the Eigenvalue under test is meaningfully signficant.
   rx_dynamic_range_db: num(min=0.0, max=100.0, required=False)

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -449,8 +449,8 @@ slow_time_evd_options:
   # of sample covariance matrix
   diag_valid_ratio: num(min=0.0, required=False)
   #This ratio will be used to determine the minimum number of valid Eigenvalues
-  ##required for a CPI. min_ev_valid_idx = int(np.floor(normalized_min_rank_ratio * cpi_len))
-  normalized_min_rank_ratio: num(min=0.0, max=1.0, required=False)
+  ##required for a CPI. min_ev_valid_idx = int(np.floor(min_rank_frac * cpi_len)) - 1
+  min_rank_frac: num(min=0.0, max=1.0, required=False)
   # radar platform receiver dynamic range, e.g. 50 dB. This is applied as a threshold
   # to determine if the Eigenvalue under test is meaningfully signficant.
   rx_dynamic_range_db: num(min=0.0, max=100.0, required=False)

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -449,9 +449,9 @@ slow_time_evd_options:
   # of sample covariance matrix
   diag_valid_ratio: num(min=0.0, required=False)
   #This ratio will be used to determine the minimum number of valid Eigenvalues
-  ##required for a CPI. min_ev_valid_idx = min_valid_ev_ratio * cpi_len
-  min_valid_ev_ratio: num(min=0.0, required=False)
-  # radar platform receiver dynamic range, e.g. -50 dB. This is applied as a threshold
+  ##required for a CPI. min_ev_valid_idx = int(np.floor(normalized_min_rank_ratio * cpi_len))
+  normalized_min_rank_ratio: num(min=0.0, required=False)
+  # radar platform receiver dynamic range, e.g. 50 dB. This is applied as a threshold
   # to determine if the Eigenvalue under test is meaningfully signficant.
   rx_dynamic_range_db: num(min=-100.0, max=0.0, required=False)
   # Parameters used to adaptively determine RFI eigenvalue difference thresholds

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -448,8 +448,12 @@ slow_time_evd_options:
   # minimum fraction of samples required for co-variance terms
   # of sample covariance matrix
   diag_valid_ratio: num(min=0.0, required=False)
-  # The Eigenvalue index of minimum Eigenvalue
-  noise_ev_idx: int(min=2, required=False)
+  #This ratio will be used to determine the minimum number of valid Eigenvalues
+  ##required for a CPI. min_ev_valid_idx = min_valid_ev_ratio * cpi_len
+  min_valid_ev_ratio: int(min=0.0, required=False)
+  # radar platform receiver dynamic range, e.g. -50 dB. This is applied as a threshold
+  # to determine if the Eigenvalue under test is meaningfully signficant.
+  rx_dynamic_range_db: float(min=-100.0, max=0.0, required=False)
   # Parameters used to adaptively determine RFI eigenvalue difference thresholds
   threshold_hyperparameters: include('rfi_threshold_options', required=False)
 

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -163,10 +163,6 @@ runconfig:
       # Geographic-to-radar coordinate transforms
       geo2rdr: include('geo2rdr_options', required=False)
 
-      # Calibration and processing information look-up tables (LUTs)
-      # excluding Doppler
-      lookup_tables: include('lookup_tables_options', required=False)
-
       doppler:
         # Offset between quaternion frame and antenna boresight in degrees.
         azimuth_boresight_deg: num(required=False)
@@ -180,9 +176,6 @@ runconfig:
           range: num(min=0.0, required=False)
           # Lookup table Azimuth spacing in s
           azimuth: num(min=0.0, required=False)
-
-        # Extra margin added to the Doppler LUT
-        margin_in_pixels: include('margin_in_pixels_options', required=False)
 
       # Settings for range compression algorithm.
       rangecomp:
@@ -312,7 +305,7 @@ mask_options:
 caltone_options:
   frequency: num(min=0, required=False)
   algorithm: enum('wavelet', 'azimuth_mean', 'auto', 'disabled', required=False)
-  wavelet_size: num(min=2, required=False)
+  block_size: num(min=2, required=False)
 
 spectral_window:
   kind: enum('Kaiser', 'Cosine', required=False)
@@ -342,23 +335,6 @@ geo2rdr_options:
   # Latest time in search interval, in s past orbit reference epoch
   # null for automatic selection
   time_end: num(required=False)
-
-lookup_tables_options:
-  # Downsampling factors with respect to the RSLC grid
-  downsampling_factor:
-    # Downsampling factor in azimuth direction
-    azimuth: int(min=1, required=False)
-    # Downsampling factor in range direction
-    range: int(min=1, required=False)
-
-  # Extra margin added to LUTs
-  margin_in_pixels: include('margin_in_pixels_options', required=False)
-
-margin_in_pixels_options:
-  # Extra margin added to lookup table in azimuth, in pixels.
-  azimuth: int(min=0, required=False)
-  # Extra margin added to lookup table in range, in pixels.
-  range: int(min=0, required=False)
 
 nesz_options:
   # supported noise estimator algorithms:
@@ -442,6 +418,14 @@ slow_time_evd_options:
   # Number of slow-time CPIs grouped together for determining and applying a
   # common EV slope threshold.
   num_cpi_per_threshold_block: int(min=2, required=False)
+  # minimum fraction of samples required for cross-variance terms
+  # # of sample covariance matrix
+  off_diag_overlap_ratio: num(min=0.0, required=False) 
+  # minimum fraction of samples required for co-variance terms
+  # # of sample covariance matrix
+  diag_valid_ratio: num(min=0.0, required=False)
+  # The Eigenvalue index of minimum Eigenvalue
+  noise_ev_idx: int(min=2, required=False)
   # Parameters used to adaptively determine RFI eigenvalue difference thresholds
   threshold_hyperparameters: include('rfi_threshold_options', required=False)
 
@@ -460,12 +444,14 @@ freq_notch_filter_options:
   # 'trim_frac/2' proportion of outliers will be removed from both tails of 
   # the distribution.
   trim_frac: num(min=0.0, required=False)
+  # RFI False alarm rate for spectra analysis frequency bins
+  false_alarm_rate: num(min=0.0, required=False)
   # If FDNF is applied, a threshold for pvalue needs to be selected. pvalue is a
   # measure of confidence against a null hypothesis. In FDNF:
   # Null Hypothesis: NO RFI, Alternative Hypothesis: RFI present
   # If p-value of the range-frequency power spectra is less than p-value threshold,
   # alternative hypothesis is accepted. Otherwise, null hypothesis is accepted.
-  pvalue_threshold: num(min=0.0, required=False)
+  #pvalue_threshold: num(min=0.0, required=False)
   # If FDNF is applied, the cumulative probability density function (CDF) 
   # of the input Time Stationary Narrowband (TSNB) and Time Varying Wideband 
   # (TVWB) masks will be compared with this threshold. It represents an estimate of 
@@ -480,6 +466,8 @@ freq_notch_filter_options:
   # This should be enabled unless for the purpose of debugging.
   # Defaults to True
   wb_detect: bool(required=False)
+  # Parameters used to adaptively determine RFI eigenvalue difference thresholds
+  threshold_hyperparameters_notch: include('rfi_threshold_options', required=False)
 
 rfi_threshold_options:
     # The computed sigma ratio of maximum and minimum Eigenvalue
@@ -519,38 +507,30 @@ qa_validation_options:
   metadata_luts_fail_if_all_nan: bool(required=False)
 
 qa_reports_options:
-  backscatter_img: include('backscatter_img_options', required=False)
-  histogram: include('histogram_options', required=False)
-  range_spectra: include('range_spectra_options', required=False)
-  azimuth_spectra: include('azimuth_spectra_options', required=False)
-
-backscatter_img_options:
-  linear_units: bool(required=False)
-  nlooks_freqa: list(int(min=1), min=2, max=2, required=False)
-  nlooks_freqb: list(int(min=1), min=2, max=2, required=False)
-  longest_side_max: int(min=1, required=False)
-  percentile_for_clipping: list(num(min=0.0, max=100.0), min=2, max=2, required=False)
-  gamma: num(min=0.0, required=False)
-  nan_color_in_pdf: str(required=False)
-  tile_shape: list(int(min=-1), min=2, max=2, required=False)
-  output_individual_pngs: bool(required=False)
-
-histogram_options:
-  decimation_ratio: list(int(min=1), min=2, max=2, required=False)
-  backscatter_histogram_bin_edges_range: list(num(), min=2, max=2, required=False)
-  phase_histogram_y_axis_range: list(any(num(), null()), min=2, max=2, required=False)
-  phs_in_radians: bool(required=False)
-  tile_shape: list(int(min=-1), min=2, max=2, required=False)
-
-range_spectra_options:
-  az_decimation: int(min=1, required=False)
-  hz_to_mhz: bool(required=False)
-  tile_height: int(min=-1, required=False)
-
-azimuth_spectra_options:
-  num_columns: int(min=-1, required=False)
-  hz_to_mhz: bool(required=False)
-  tile_width: int(min=-1, required=False)
+  backscatter_img:
+    linear_units: bool(required=False)
+    nlooks_freqa: list(int(min=1), min=2, max=2, required=False)
+    nlooks_freqb: list(int(min=1), min=2, max=2, required=False)
+    longest_side_max: int(min=1, required=False)
+    percentile_for_clipping: list(num(min=0.0, max=100.0), min=2, max=2, required=False)
+    gamma: num(min=0.0, required=False)
+    nan_color_in_pdf: str(required=False)
+    tile_shape: list(int(min=-1), min=2, max=2, required=False)
+    output_individual_pngs: bool(required=False)
+  histogram:
+    decimation_ratio: list(int(min=1), min=2, max=2, required=False)
+    backscatter_histogram_bin_edges_range: list(num(), min=2, max=2, required=False)
+    phase_histogram_y_axis_range: list(any(num(), null()), min=2, max=2, required=False)
+    phs_in_radians: bool(required=False)
+    tile_shape: list(int(min=-1), min=2, max=2, required=False)
+  range_spectra:
+    az_decimation: int(min=1, required=False)
+    hz_to_mhz: bool(required=False)
+    tile_height: int(min=-1, required=False)
+  azimuth_spectra:
+    num_columns: int(min=-1, required=False)
+    hz_to_mhz: bool(required=False)
+    tile_width: int(min=-1, required=False)
 
 absolute_radiometric_calibration_options:
   nchip: int(min=1, required=False)

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -450,10 +450,10 @@ slow_time_evd_options:
   diag_valid_ratio: num(min=0.0, required=False)
   #This ratio will be used to determine the minimum number of valid Eigenvalues
   ##required for a CPI. min_ev_valid_idx = min_valid_ev_ratio * cpi_len
-  min_valid_ev_ratio: int(min=0.0, required=False)
+  min_valid_ev_ratio: num(min=0.0, required=False)
   # radar platform receiver dynamic range, e.g. -50 dB. This is applied as a threshold
   # to determine if the Eigenvalue under test is meaningfully signficant.
-  rx_dynamic_range_db: float(min=-100.0, max=0.0, required=False)
+  rx_dynamic_range_db: num(min=-100.0, max=0.0, required=False)
   # Parameters used to adaptively determine RFI eigenvalue difference thresholds
   threshold_hyperparameters: include('rfi_threshold_options', required=False)
 

--- a/tests/python/packages/isce3/signal/rfi_process_evd.py
+++ b/tests/python/packages/isce3/signal/rfi_process_evd.py
@@ -177,6 +177,9 @@ def rfi_wb_gen(
         (32, 2148, 20, 10, 0, 0, 2, True, False, False, 'no-op'),  # No-op: no rng blks
         (32, 256, 20, 10, 0, 0, 2, False, False, False, 'no-op'),  # No-op: 256 range samples / range block
         (32, 2148, 20, 10, 0, 0, 2, True, False, False, 'no-op'),  # No-op: detection only
+        (32, 2148, 20, 10, 1, 1, 2, True, True, True, 'mitigate'),  # No range blks, prf_dither_mode = True
+        (32, 256, 20, 10, 1, 1, 2, False, True, True, 'mitigate'),  # 256 range samples / range blocks, prf_dither_mode = True
+        (32, 2148, 20, 10, 0, 0, 2, True, False, True, 'no-op'),  # No-op: detection only, prf_dither_mode = True
     ],
 )
 def test_slow_time_evd(
@@ -301,7 +304,8 @@ def test_slow_time_evd(
     threshold_params = ThresholdParams([2, 10], [5, 2])
     off_diag_overlap_ratio = 0.1
     diag_valid_ratio = 0.05
-    noise_ev_idx = 10
+    min_valid_ev_ratio = 0.8
+    rx_dynamic_range_db = -50
     mask_valid = np.ones(raw_data_rfi.shape, dtype=bool)
 
     rfi_likelihood = run_slow_time_evd(
@@ -319,7 +323,8 @@ def test_slow_time_evd(
         diag_valid_ratio=diag_valid_ratio,
         mitigate_enable=mitigate_enable,
         prf_dither_mode=prf_dither_mode,
-        noise_ev_idx=noise_ev_idx,
+        min_valid_ev_ratio=min_valid_ev_ratio,
+        rx_dynamic_range_db=rx_dynamic_range_db,
         mask_valid=mask_valid,
         raw_data_mitigated=raw_data_mitigated,
     )

--- a/tests/python/packages/isce3/signal/rfi_process_evd.py
+++ b/tests/python/packages/isce3/signal/rfi_process_evd.py
@@ -302,10 +302,10 @@ def test_slow_time_evd(
     # Compute Eigenvalues and Eigenvectors
 
     threshold_params = ThresholdParams([2, 10], [5, 2])
-    off_diag_overlap_ratio = 0.1
-    diag_valid_ratio = 0.05
-    min_valid_ev_ratio = 0.8
-    rx_dynamic_range_db = -50
+    off_diag_overlap_ratio = 0.25
+    diag_valid_ratio = 0.20
+    normalized_min_rank_ratio = 0.8
+    rx_dynamic_range_db = 50
     mask_valid = np.ones(raw_data_rfi.shape, dtype=bool)
 
     rfi_likelihood = run_slow_time_evd(
@@ -323,7 +323,7 @@ def test_slow_time_evd(
         diag_valid_ratio=diag_valid_ratio,
         mitigate_enable=mitigate_enable,
         prf_dither_mode=prf_dither_mode,
-        min_valid_ev_ratio=min_valid_ev_ratio,
+        normalized_min_rank_ratio=normalized_min_rank_ratio,
         rx_dynamic_range_db=rx_dynamic_range_db,
         mask_valid=mask_valid,
         raw_data_mitigated=raw_data_mitigated,

--- a/tests/python/packages/isce3/signal/rfi_process_evd.py
+++ b/tests/python/packages/isce3/signal/rfi_process_evd.py
@@ -170,13 +170,13 @@ def rfi_wb_gen(
 
 
 @pytest.mark.parametrize(
-    "cpi_len, num_samples_rng_blk, num_cpi_tb, max_deg_freedom, num_max_trim, num_min_trim, max_num_rfi_ev, use_entire_pulse, mitigate_enable, test_case",
+    "cpi_len, num_samples_rng_blk, num_cpi_tb, max_deg_freedom, num_max_trim, num_min_trim, max_num_rfi_ev, use_entire_pulse, mitigate_enable, prf_dither_mode, test_case",
     [  
-        (32, 2148, 20, 16, 1, 1, 2, True, True, 'mitigate'),  # No range blks
-        (32, 256, 20, 16, 1, 1, 2, False, True, 'mitigate'),  # 256 range samples / range blocks
-        (32, 2148, 20, 16, 0, 0, 2, True, True, 'no-op'),  # No-op: no rng blks
-        (32, 256, 20, 16, 0, 0, 2, False, True, 'no-op'),  # No-op: 256 range samples / range block
-        (32, 2148, 20, 16, 0, 0, 2, True, False,'no-op'),  # No-op: detection only
+        (32, 2148, 20, 10, 1, 1, 2, True, True, False, 'mitigate'),  # No range blks
+        (32, 256, 20, 10, 1, 1, 2, False, True, False, 'mitigate'),  # 256 range samples / range blocks
+        (32, 2148, 20, 10, 0, 0, 2, True, False, False, 'no-op'),  # No-op: no rng blks
+        (32, 256, 20, 10, 0, 0, 2, False, False, False, 'no-op'),  # No-op: 256 range samples / range block
+        (32, 2148, 20, 10, 0, 0, 2, True, False, False, 'no-op'),  # No-op: detection only
     ],
 )
 def test_slow_time_evd(
@@ -189,18 +189,19 @@ def test_slow_time_evd(
     max_num_rfi_ev,
     use_entire_pulse,
     mitigate_enable,
+    prf_dither_mode,
     test_case,
 ):
     """Verify slow-time EVD with five test cases:
-    1: cpi_len=32, no range blocking, 20 cpi/thresh blk, max_deg_freedom=16,
+    1: cpi_len=32, no range blocking, 20 cpi/thresh blk, max_deg_freedom=10,
        num_max_trim=1, num_min_trim=1, max_num_rfi_ev=2, mitigate_enable=True, test_case=mitigate
-    2: cpi_len=32, 8 range blocks, 20 cpi/thresh blk, max_deg_freedom=16,
+    2: cpi_len=32, 8 range blocks, 20 cpi/thresh blk, max_deg_freedom=10,
        num_max_trim=1, num_min_trim=1, max_num_rfi_ev=2, mitigate_enable=True, test_case=mitigate
-    3: cpi_len=32, no range blocking, 20 cpi/thresh blk, max_deg_freedom=16,
+    3: cpi_len=32, no range blocking, 20 cpi/thresh blk, max_deg_freedom=10,
        num_max_trim=1, num_min_trim=1, max_num_rfi_ev=2, mitigate_enable=True, test_case=no-op
-    4: cpi_len=32, 8 range blocks, 20 cpi/thresh blk, max_deg_freedom=16,
+    4: cpi_len=32, 8 range blocks, 20 cpi/thresh blk, max_deg_freedom=10,
        num_max_trim=1, num_min_trim=1, max_num_rfi_ev=2, mitigate_enable=True, test_case=no-op
-    5: cpi_len=32, no range blocking, 20 cpi/thresh blk, max_deg_freedom=16, 
+    5: cpi_len=32, no range blocking, 20 cpi/thresh blk, max_deg_freedom=10, 
        num_max_trim=1, num_min_trim=1, max_num_rfi_ev=2, mitigate_enable=False, 
        test_case=no-op, detection only
 
@@ -232,7 +233,7 @@ def test_slow_time_evd(
     # If test case is mitigate, add narrowband and wideband RFI
     if test_case == 'mitigate':
         # Narrowband RFI parameters
-        num_nb_rfi = 10
+        num_nb_rfi = 5
 
         # Interference to Noise Ratio
         inr_nb_low = 15
@@ -249,7 +250,7 @@ def test_slow_time_evd(
         rfi_nb_pulse_idx = randint(50, num_pulses, num_rfi_nb_pulses)
 
         # Wideband RFI parameters
-        num_wb_rfi = 10
+        num_wb_rfi = 5
         inr_wb = 20
         pwr_rfi_wb_db = inr_wb * np.ones(num_wb_rfi)
 
@@ -297,7 +298,11 @@ def test_slow_time_evd(
     # Perform Slow-Time EVD Detection and Mitigation
     # Compute Eigenvalues and Eigenvectors
 
-    threshold_params = ThresholdParams([2, 20], [5, 2])
+    threshold_params = ThresholdParams([2, 10], [5, 2])
+    off_diag_overlap_ratio = 0.1
+    diag_valid_ratio = 0.05
+    noise_ev_idx = 10
+    mask_valid = np.ones(raw_data_rfi.shape, dtype=bool)
 
     rfi_likelihood = run_slow_time_evd(
         raw_data_rfi,
@@ -310,7 +315,12 @@ def test_slow_time_evd(
         use_entire_pulse=use_entire_pulse,
         threshold_params=threshold_params,
         num_cpi_tb=num_cpi_tb,
+        off_diag_overlap_ratio=off_diag_overlap_ratio,
+        diag_valid_ratio=diag_valid_ratio,
         mitigate_enable=mitigate_enable,
+        prf_dither_mode=prf_dither_mode,
+        noise_ev_idx=noise_ev_idx,
+        mask_valid=mask_valid,
         raw_data_mitigated=raw_data_mitigated,
     )
 

--- a/tests/python/packages/isce3/signal/rfi_process_evd.py
+++ b/tests/python/packages/isce3/signal/rfi_process_evd.py
@@ -170,16 +170,13 @@ def rfi_wb_gen(
 
 
 @pytest.mark.parametrize(
-    "cpi_len, num_samples_rng_blk, num_cpi_tb, max_deg_freedom, num_max_trim, num_min_trim, max_num_rfi_ev, use_entire_pulse, mitigate_enable, prf_dither_mode, test_case",
+    "cpi_len, num_samples_rng_blk, num_cpi_tb, max_deg_freedom, num_max_trim, num_min_trim, max_num_rfi_ev, use_entire_pulse, mitigate_enable, test_case",
     [  
-        (32, 2148, 20, 10, 1, 1, 2, True, True, False, 'mitigate'),  # No range blks
-        (32, 256, 20, 10, 1, 1, 2, False, True, False, 'mitigate'),  # 256 range samples / range blocks
-        (32, 2148, 20, 10, 0, 0, 2, True, False, False, 'no-op'),  # No-op: no rng blks
-        (32, 256, 20, 10, 0, 0, 2, False, False, False, 'no-op'),  # No-op: 256 range samples / range block
-        (32, 2148, 20, 10, 0, 0, 2, True, False, False, 'no-op'),  # No-op: detection only
-        (32, 2148, 20, 10, 1, 1, 2, True, True, True, 'mitigate'),  # No range blks, prf_dither_mode = True
-        (32, 256, 20, 10, 1, 1, 2, False, True, True, 'mitigate'),  # 256 range samples / range blocks, prf_dither_mode = True
-        (32, 2148, 20, 10, 0, 0, 2, True, False, True, 'no-op'),  # No-op: detection only, prf_dither_mode = True
+        (32, 2148, 20, 10, 1, 1, 2, True, False, 'mitigate'),  # No range blks
+        (32, 256, 20, 10, 1, 1, 2, False, False, 'mitigate'),  # 256 range samples / range blocks
+        (32, 2148, 20, 10, 0, 0, 2, True, False, 'no-op'),  # No-op: no rng blks
+        (32, 256, 20, 10, 0, 0, 2, False, False, 'no-op'),  # No-op: 256 range samples / range block
+        (32, 2148, 20, 10, 0, 0, 2, True, False, 'no-op'),  # No-op: detection only
     ],
 )
 def test_slow_time_evd(
@@ -192,7 +189,6 @@ def test_slow_time_evd(
     max_num_rfi_ev,
     use_entire_pulse,
     mitigate_enable,
-    prf_dither_mode,
     test_case,
 ):
     """Verify slow-time EVD with five test cases:
@@ -304,7 +300,7 @@ def test_slow_time_evd(
     threshold_params = ThresholdParams([2, 10], [5, 2])
     off_diag_overlap_ratio = 0.25
     diag_valid_ratio = 0.20
-    normalized_min_rank_ratio = 0.8
+    min_rank_frac = 0.8
     rx_dynamic_range_db = 50
     mask_valid = np.ones(raw_data_rfi.shape, dtype=bool)
 
@@ -322,8 +318,7 @@ def test_slow_time_evd(
         off_diag_overlap_ratio=off_diag_overlap_ratio,
         diag_valid_ratio=diag_valid_ratio,
         mitigate_enable=mitigate_enable,
-        prf_dither_mode=prf_dither_mode,
-        normalized_min_rank_ratio=normalized_min_rank_ratio,
+        min_rank_frac=min_rank_frac,
         rx_dynamic_range_db=rx_dynamic_range_db,
         mask_valid=mask_valid,
         raw_data_mitigated=raw_data_mitigated,

--- a/tests/python/packages/isce3/signal/rfi_process_evd.py
+++ b/tests/python/packages/isce3/signal/rfi_process_evd.py
@@ -302,7 +302,6 @@ def test_slow_time_evd(
     diag_valid_ratio = 0.20
     min_rank_frac = 0.8
     rx_dynamic_range_db = 50
-    mask_valid = np.ones(raw_data_rfi.shape, dtype=bool)
 
     rfi_likelihood = run_slow_time_evd(
         raw_data_rfi,
@@ -320,7 +319,6 @@ def test_slow_time_evd(
         mitigate_enable=mitigate_enable,
         min_rank_frac=min_rank_frac,
         rx_dynamic_range_db=rx_dynamic_range_db,
-        mask_valid=mask_valid,
         raw_data_mitigated=raw_data_mitigated,
     )
 

--- a/tests/python/packages/isce3/signal/rfi_process_evd.py
+++ b/tests/python/packages/isce3/signal/rfi_process_evd.py
@@ -172,8 +172,8 @@ def rfi_wb_gen(
 @pytest.mark.parametrize(
     "cpi_len, num_samples_rng_blk, num_cpi_tb, max_deg_freedom, num_max_trim, num_min_trim, max_num_rfi_ev, use_entire_pulse, mitigate_enable, test_case",
     [  
-        (32, 2148, 20, 10, 1, 1, 2, True, False, 'mitigate'),  # No range blks
-        (32, 256, 20, 10, 1, 1, 2, False, False, 'mitigate'),  # 256 range samples / range blocks
+        (32, 2148, 20, 10, 1, 1, 2, True, True, 'mitigate'),  # No range blks
+        (32, 256, 20, 10, 1, 1, 2, False, True, 'mitigate'),  # 256 range samples / range blocks
         (32, 2148, 20, 10, 0, 0, 2, True, False, 'no-op'),  # No-op: no rng blks
         (32, 256, 20, 10, 0, 0, 2, False, False, 'no-op'),  # No-op: 256 range samples / range block
         (32, 2148, 20, 10, 0, 0, 2, True, False, 'no-op'),  # No-op: detection only
@@ -302,6 +302,7 @@ def test_slow_time_evd(
     diag_valid_ratio = 0.20
     min_rank_frac = 0.8
     rx_dynamic_range_db = 50
+    swaths=None
 
     rfi_likelihood = run_slow_time_evd(
         raw_data_rfi,
@@ -319,6 +320,7 @@ def test_slow_time_evd(
         mitigate_enable=mitigate_enable,
         min_rank_frac=min_rank_frac,
         rx_dynamic_range_db=rx_dynamic_range_db,
+        swaths=swaths,
         raw_data_mitigated=raw_data_mitigated,
     )
 

--- a/tools/imagesets/runconfigs/rslc_REE2.yaml
+++ b/tools/imagesets/runconfigs/rslc_REE2.yaml
@@ -165,8 +165,8 @@ runconfig:
                     # of sample covariance matrix
                     diag_valid_ratio: 0.20
                     # This ratio will be used to determine the minimum number of valid Eigenvalues
-                    # required for a CPI. min_ev_valid_idx = int(np.floor(normalized_min_rank_ratio * cpi_len))
-                    normalized_min_rank_ratio: 0.65
+                    # required for a CPI. min_ev_valid_idx = int(np.round(min_rank_frac * cpi_len)) - 1
+                    min_rank_frac: 0.70
                     # radar platform receiver dynamic range, e.g. 50 dB. This is applied as a threshold
                     # to determine if the Eigenvalue under test is meaningfully signficant.
                     rx_dynamic_range_db: 50.0

--- a/tools/imagesets/runconfigs/rslc_REE2.yaml
+++ b/tools/imagesets/runconfigs/rslc_REE2.yaml
@@ -158,6 +158,14 @@ runconfig:
                     # Number of slow-time CPIs grouped together for determining and
                     # applying a common EV slope threshold.
                     num_cpi_per_threshold_block: 20
+                    # minimum fraction of samples required for cross-variance terms
+                    # of sample covariance matrix
+                    off_diag_overlap_ratio: 0.1
+                    # minimum fraction of samples required for covariance terms
+                    # of sample covariance matrix
+                    diag_valid_ratio: 0.05
+                    # The Eigenvalue index of minimum Eigenvalue
+                    noise_ev_idx: 10
                     # Parameters used to adaptively determine RFI eigenvalue
                     # difference thresholds
                     threshold_hyperparameters:

--- a/tools/imagesets/runconfigs/rslc_REE2.yaml
+++ b/tools/imagesets/runconfigs/rslc_REE2.yaml
@@ -165,11 +165,11 @@ runconfig:
                     # of sample covariance matrix
                     diag_valid_ratio: 0.20
                     # This ratio will be used to determine the minimum number of valid Eigenvalues
-                    # required for a CPI. min_ev_valid_idx = min_valid_ev_ratio * cpi_len
-                    min_valid_ev_ratio: 0.65
-                    # radar platform receiver dynamic range, e.g. -50 dB. This is applied as a threshold
+                    # required for a CPI. min_ev_valid_idx = int(np.floor(normalized_min_rank_ratio * cpi_len))
+                    normalized_min_rank_ratio: 0.65
+                    # radar platform receiver dynamic range, e.g. 50 dB. This is applied as a threshold
                     # to determine if the Eigenvalue under test is meaningfully signficant.
-                    rx_dynamic_range_db: -50.0
+                    rx_dynamic_range_db: 50.0
                     # Parameters used to adaptively determine RFI eigenvalue
                     # difference thresholds
                     threshold_hyperparameters:

--- a/tools/imagesets/runconfigs/rslc_REE2.yaml
+++ b/tools/imagesets/runconfigs/rslc_REE2.yaml
@@ -136,11 +136,11 @@ runconfig:
 
                 slow_time_evd:
                     # Coherent processing interval length (pulses).  Defaults to 32.
-                    cpi_length: 32
+                    cpi_length: 16
                     # Maximum allowable number of emitters can be detected and
                     # suppressed per CPI. ST-EVD would ignore emitters exceeding
                     # this limit. This number should be less than cpi_length.
-                    max_emitters: 16
+                    max_emitters: 4
                     # Number of large value outliers to be trimmed in slow-time
                     # minimum Eigenvalues.
                     num_max_trim: 0
@@ -157,15 +157,19 @@ runconfig:
                     max_num_rfi_ev: 2
                     # Number of slow-time CPIs grouped together for determining and
                     # applying a common EV slope threshold.
-                    num_cpi_per_threshold_block: 20
+                    num_cpi_per_threshold_block: 15
                     # minimum fraction of samples required for cross-variance terms
                     # of sample covariance matrix
-                    off_diag_overlap_ratio: 0.1
+                    off_diag_overlap_ratio: 0.25
                     # minimum fraction of samples required for covariance terms
                     # of sample covariance matrix
-                    diag_valid_ratio: 0.05
-                    # The Eigenvalue index of minimum Eigenvalue
-                    noise_ev_idx: 10
+                    diag_valid_ratio: 0.20
+                    # This ratio will be used to determine the minimum number of valid Eigenvalues
+                    # required for a CPI. min_ev_valid_idx = min_valid_ev_ratio * cpi_len
+                    min_valid_ev_ratio: 0.65
+                    # radar platform receiver dynamic range, e.g. -50 dB. This is applied as a threshold
+                    # to determine if the Eigenvalue under test is meaningfully signficant.
+                    rx_dynamic_range_db: -50.0
                     # Parameters used to adaptively determine RFI eigenvalue
                     # difference thresholds
                     threshold_hyperparameters:

--- a/tools/imagesets/runconfigs/rslc_REE3.yaml
+++ b/tools/imagesets/runconfigs/rslc_REE3.yaml
@@ -105,11 +105,11 @@ runconfig:
                     # of sample covariance matrix
                     diag_valid_ratio: 0.20
                     # This ratio will be used to determine the minimum number of valid Eigenvalues
-                    # required for a CPI. min_ev_valid_idx = min_valid_ev_ratio * cpi_len
-                    min_valid_ev_ratio: 0.65
+                    # required for a CPI. min_ev_valid_idx = int(np.floor(min_valid_ev_ratio * cpi_len))
+                    min_valid_rank_ratio: 0.65
                     # radar platform receiver dynamic range, e.g. -50 dB. This is applied as a threshold
                     # to determine if the Eigenvalue under test is meaningfully signficant.
-                    rx_dynamic_range_db: -50.0
+                    rx_dynamic_range_db: 50.0
                     # Parameters used to adaptively determine RFI eigenvalue
                     # difference thresholds
                     threshold_hyperparameters:

--- a/tools/imagesets/runconfigs/rslc_REE3.yaml
+++ b/tools/imagesets/runconfigs/rslc_REE3.yaml
@@ -105,9 +105,9 @@ runconfig:
                     # of sample covariance matrix
                     diag_valid_ratio: 0.20
                     # This ratio will be used to determine the minimum number of valid Eigenvalues
-                    # required for a CPI. min_ev_valid_idx = int(np.floor(min_valid_ev_ratio * cpi_len))
-                    min_valid_rank_ratio: 0.65
-                    # radar platform receiver dynamic range, e.g. -50 dB. This is applied as a threshold
+                    # required for a CPI. min_ev_valid_idx = int(np.floor(normalized_min_rank_ratio * cpi_len))
+                    normalized_min_rank_ratio: 0.65
+                    # radar platform receiver dynamic range, e.g. 50 dB. This is applied as a threshold
                     # to determine if the Eigenvalue under test is meaningfully signficant.
                     rx_dynamic_range_db: 50.0
                     # Parameters used to adaptively determine RFI eigenvalue

--- a/tools/imagesets/runconfigs/rslc_REE3.yaml
+++ b/tools/imagesets/runconfigs/rslc_REE3.yaml
@@ -76,11 +76,11 @@ runconfig:
 
                 slow_time_evd:
                     # Coherent processing interval length (pulses).  Defaults to 32.
-                    cpi_length: 32
+                    cpi_length: 16
                     # Maximum allowable number of emitters can be detected and
                     # suppressed per CPI. ST-EVD would ignore emitters exceeding
                     # this limit. This number should be less than cpi_length.
-                    max_emitters: 16
+                    max_emitters: 4
                     # Number of large value outliers to be trimmed in slow-time
                     # minimum Eigenvalues.
                     num_max_trim: 0
@@ -97,15 +97,19 @@ runconfig:
                     max_num_rfi_ev: 2
                     # Number of slow-time CPIs grouped together for determining and
                     # applying a common EV slope threshold.
-                    num_cpi_per_threshold_block: 20
+                    num_cpi_per_threshold_block: 15
                     # minimum fraction of samples required for cross-variance terms
                     # of sample covariance matrix
-                    off_diag_overlap_ratio: 0.1
+                    off_diag_overlap_ratio: 0.25
                     # minimum fraction of samples required for covariance terms
                     # of sample covariance matrix
-                    diag_valid_ratio: 0.05
-                    # The Eigenvalue index of minimum Eigenvalue
-                    noise_ev_idx: 10
+                    diag_valid_ratio: 0.20
+                    # This ratio will be used to determine the minimum number of valid Eigenvalues
+                    # required for a CPI. min_ev_valid_idx = min_valid_ev_ratio * cpi_len
+                    min_valid_ev_ratio: 0.65
+                    # radar platform receiver dynamic range, e.g. -50 dB. This is applied as a threshold
+                    # to determine if the Eigenvalue under test is meaningfully signficant.
+                    rx_dynamic_range_db: -50.0
                     # Parameters used to adaptively determine RFI eigenvalue
                     # difference thresholds
                     threshold_hyperparameters:

--- a/tools/imagesets/runconfigs/rslc_REE3.yaml
+++ b/tools/imagesets/runconfigs/rslc_REE3.yaml
@@ -98,6 +98,14 @@ runconfig:
                     # Number of slow-time CPIs grouped together for determining and
                     # applying a common EV slope threshold.
                     num_cpi_per_threshold_block: 20
+                    # minimum fraction of samples required for cross-variance terms
+                    # of sample covariance matrix
+                    off_diag_overlap_ratio: 0.1
+                    # minimum fraction of samples required for covariance terms
+                    # of sample covariance matrix
+                    diag_valid_ratio: 0.05
+                    # The Eigenvalue index of minimum Eigenvalue
+                    noise_ev_idx: 10
                     # Parameters used to adaptively determine RFI eigenvalue
                     # difference thresholds
                     threshold_hyperparameters:

--- a/tools/imagesets/runconfigs/rslc_REE3.yaml
+++ b/tools/imagesets/runconfigs/rslc_REE3.yaml
@@ -105,8 +105,8 @@ runconfig:
                     # of sample covariance matrix
                     diag_valid_ratio: 0.20
                     # This ratio will be used to determine the minimum number of valid Eigenvalues
-                    # required for a CPI. min_ev_valid_idx = int(np.floor(normalized_min_rank_ratio * cpi_len))
-                    normalized_min_rank_ratio: 0.65
+                    # required for a CPI. min_ev_valid_idx = int(np.round(min_rank_frac * cpi_len)) - 1
+                    min_rank_frac: 0.70
                     # radar platform receiver dynamic range, e.g. 50 dB. This is applied as a threshold
                     # to determine if the Eigenvalue under test is meaningfully signficant.
                     rx_dynamic_range_db: 50.0


### PR DESCRIPTION
This PR makes the following changes:

1. Separately computes sample covariance matrix for dithered-PRF and constant-PRF modes of operations
2. Skip threshold blocks when there are not enough valid samples for dithered-PRF mode

