### PR TITLE
Update SM SAS Version to v0.4.1 for R05.01.3 

### DIFF
--- a/tools/imagesets/oracle8conda/distrib_nisar/Dockerfile
+++ b/tools/imagesets/oracle8conda/distrib_nisar/Dockerfile
@@ -12,7 +12,7 @@ RUN cd /opt \
  && git clone https://$GIT_OAUTH_TOKEN@github-fn.jpl.nasa.gov/NISAR-ADT/SoilMoisture \
  && git clone https://github.com/isce-framework/nisarqa.git \
  && cd /opt/nisarqa && git checkout v16.0.1 && rm -rf .git \
- && cd /opt/SoilMoisture && git checkout v0.3.2 && rm -rf .git
+ && cd /opt/SoilMoisture && git checkout v0.4.2 && rm -rf .git
 
 FROM $distrib_img
 

--- a/tools/imagesets/oracle8conda/distrib_nisar/Dockerfile
+++ b/tools/imagesets/oracle8conda/distrib_nisar/Dockerfile
@@ -12,7 +12,7 @@ RUN cd /opt \
  && git clone https://$GIT_OAUTH_TOKEN@github-fn.jpl.nasa.gov/NISAR-ADT/SoilMoisture \
  && git clone https://github.com/isce-framework/nisarqa.git \
  && cd /opt/nisarqa && git checkout v16.0.1 && rm -rf .git \
- && cd /opt/SoilMoisture && git checkout v0.4.2 && rm -rf .git
+ && cd /opt/SoilMoisture && git checkout v0.4.1 && rm -rf .git
 
 FROM $distrib_img
 


### PR DESCRIPTION
This PR is to update the SM SAS version to v0.4.1 for the R05.01.3 where we bring back the historical SM products to replace the GCOV, which will significantly reduce the runtime, in addition, the common mask based on the surface flag is applied to the sigma0; and the updates for each algorithm. 