### PR TITLE
RSLC: Fix broadcasting of subswath assignment in constant-PRF case

### DIFF
--- a/python/packages/nisar/products/readers/Raw/Raw.py
+++ b/python/packages/nisar/products/readers/Raw/Raw.py
@@ -936,7 +936,9 @@ class RawBase(Base, family='nisar.productreader.raw'):
                 log.warning(f"Asked to ignore {num_ignore} pulses but there "
                     f"are only {nt} total.")
                 num_ignore = nt
-            subswaths[:, -num_ignore:, :] = subswaths[:, -num_ignore, :]
+            # NOTE Need singleton middle dimension for proper broadcasting.
+            i = subswaths.shape[1] - num_ignore
+            subswaths[:, i:, :] = subswaths[:, i:(i + 1), :]
 
         # For dithered replace subswaths (gap mask) with a single subswath
         # that merely tracks min/max valid sample.  Note that gaps may still


### PR DESCRIPTION
A bug related to numpy broadcasting was introduced in #221 for fixed-PRF cases.  For code like
```Python
reader = nisar.products.readers.Raw.open_rrsd(fn)
bboxes = reader.getSubSwathBboxes("A", "HH", num_ignore=25)
```
You might get an error like
```console
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[6], line 1
----> 1 bboxes = reader.getSubSwathBboxes("A", "HH", num_ignore=25)
      2 bboxes

File ~/isce3-dev/packages/nisar/products/readers/Raw/Raw.py:939, in RawBase.getSubSwathBboxes(self, frequency, polarization, epoch, num_ignore)
    936         log.warning(f"Asked to ignore {num_ignore} pulses but there "
    937             f"are only {nt} total.")
    938         num_ignore = nt
--> 939     subswaths[:, -num_ignore:, :] = subswaths[:, -num_ignore, :]
    941 # For dithered replace subswaths (gap mask) with a single subswath
    942 # that merely tracks min[/max](https://nisar-adt-ondemand.jpl.nasa.gov/max) valid sample.  Note that gaps may still
    943 # interfere with min[/max](https://nisar-adt-ondemand.jpl.nasa.gov/max), though.
    944 if is_dithered:
    945     # Determine non-empty ranges.

ValueError: could not broadcast input array from shape (3,2) into shape (3,25,2)
```

I was surprised by this failure since the workflow unit test is fixed PRF. However, it didn't catch this case because it only has a single subswath, so numpy was able to figure out the broadcasting rule. The other data I tested with was all dithered PRF.

It's easy to fix just by leaving a singleton dimension so that numpy knows to broadcast over the other two.