### PR TITLE
Fix a subtle frequency ID bookkeeping issue

### DIFF
--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1986,7 +1986,7 @@ def focus(runconfig, runconfig_path=""):
                 antpat = AntennaPattern(raw, dem, antparser,
                                         instparser, orbit, attitude,
                                         el_lut=el_lut,
-                                        freq_band=frequency,
+                                        freq_band=channel_in.freq_id,
                                         caltone_freq=cfg.processing.caltone.frequency,
                                         delay_ofs_dbf=-2.1474e-6)
 


### PR DESCRIPTION
In #231 we introduced a `freq_band` argument to the `AntennaPattern` constructor. The corresponding modification to focus.py script accidentally used the output frequency label instead of the one for the input file. These can be different for quasi-dual modes or mixed mode cases involving 77 MHz, which can result in an error message like
```console
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/opt/conda/lib/python3.12/site-packages/nisar/workflows/focus.py", line 2234, in <module>
    main(sys.argv[1:])
  File "/opt/conda/lib/python3.12/site-packages/nisar/workflows/focus.py", line 2230, in main
    focus(cfg, args.run_config_path)
  File "/opt/conda/lib/python3.12/site-packages/nisar/workflows/focus.py", line 1972, in focus
    antpat = AntennaPattern(raw, dem, antparser,
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/site-packages/nisar/antenna/pattern.py", line 194, in __init__
    raise ValueError(
ValueError: freq_band A is out of range ['B']!
```

This one-line patch just makes sure to use the subband label from the input data.