### PR TITLE
Correct rdr_geometry argument for gpu-enabled ionosphere screen geocoding

### DIFF
--- a/python/packages/nisar/workflows/geocode_insar.py
+++ b/python/packages/nisar/workflows/geocode_insar.py
@@ -1161,7 +1161,7 @@ def gpu_run(cfg, input_hdf5, output_hdf5, input_product_type=InputProduct.RUNW):
                                             interpolation_methods,
                                             invalid_values,
                                             iono_freq, pol_list_iono,
-                                            geogrid, rdr_geometry, dem_raster,
+                                            geogrid, rdr_geometry_iono, dem_raster,
                                             lines_per_block, input_hdf5_iono, dst_h5,
                                             subswaths=None,
                                             iono_sideband=iono_sideband_bool,


### PR DESCRIPTION
When using the `main_diff_ms_band` method and geocoding the resultant ionospheric correction there is a dimension/shape mismatch as the radar geometry argument is not multilooked (`rdr_geometry`). Using the multilooked geometry (`rdr_geometry_iono`) corrects this.

```
ERROR 5: HDF5:/opt/outputs/ionosphere/main_diff_ms_band/RUNW.h5://science/LSAR/RUNW/swaths/frequencyB/interferogram/HH/ionospherePhaseScreen, band 1: Access window out of range in RasterIO().  Requested
(0,0) of size 3781x2280 on raster of 945x2280.
```