### PR TITLE
Add qFSP boundary mask to RSLC

### DIFF
--- a/cxx/isce3/core/LUT2d.cpp
+++ b/cxx/isce3/core/LUT2d.cpp
@@ -7,7 +7,10 @@
 #include "LUT2d.h"
 
 #include <complex>
+#include <isce3/except/Error.h>
 #include <pyre/journal.h>
+#include <sstream>
+#include <string>
 
 #include "Interpolator.h"
 
@@ -184,6 +187,40 @@ eval(double y, const Eigen::Ref<const Eigen::VectorXd>& x) const
     _Pragma("omp parallel for")
     for (long i = 0; i < n; ++i) {
         out(i) = eval(y, x(i));
+    }
+    return out;
+}
+
+template<typename T>
+Eigen::Matrix<T, Eigen::Dynamic, 1> isce3::core::LUT2d<T>::
+eval(const Eigen::Ref<const Eigen::VectorXd>& y,
+    const Eigen::Ref<const Eigen::VectorXd>& x) const
+{
+    const auto n = x.size();
+    if (y.size() != n) {
+        throw isce3::except::LengthError(ISCE_SRCINFO(),
+            "Arguments to LUT2d::eval must have same size");
+    }
+    Eigen::Matrix<T, Eigen::Dynamic, 1> out(n);
+
+    // Check bounds before parallel region to avoid exceptions in OpenMP threads
+    if (_boundsError && _haveData) {
+        for (long i = 0; i < n; ++i) {
+            if (!contains(y(i), x(i))) {
+                std::ostringstream msg;
+                msg << "Out of bounds LUT2d evaluation at y=" << y(i) << " x="
+                    << x(i) << "\n" << " - bounds are " << _ystart << " "
+                    << _ystart + _dy * (_data.length() - 1.0) << " "
+                    << _xstart << " " << _xstart + _dx * (_data.width() - 1.0)
+                    << std::endl;
+                throw isce3::except::OutOfRange(ISCE_SRCINFO(), msg.str());
+            }
+        }
+    }
+
+    _Pragma("omp parallel for")
+    for (long i = 0; i < n; ++i) {
+        out(i) = eval(y(i), x(i));
     }
     return out;
 }

--- a/cxx/isce3/core/LUT2d.h
+++ b/cxx/isce3/core/LUT2d.h
@@ -89,8 +89,14 @@ class isce3::core::LUT2d {
         // Evaluate LUT
         T eval(const double y, const double x) const;
 
+        // Evaluate LUT, vectorized on x
         Eigen::Matrix<T, Eigen::Dynamic, 1>
         eval(double y, const Eigen::Ref<const Eigen::VectorXd>& x) const;
+
+        // Evaluate LUT, vectorized on y and x (same size)
+        Eigen::Matrix<T, Eigen::Dynamic, 1>
+        eval(const Eigen::Ref<const Eigen::VectorXd>& y,
+            const Eigen::Ref<const Eigen::VectorXd>& x) const;
 
         /** Check if point resides in domain of LUT */
         inline bool contains(double y, double x) const

--- a/python/extensions/pybind_isce3/core/LUT2d.cpp
+++ b/python/extensions/pybind_isce3/core/LUT2d.cpp
@@ -22,6 +22,7 @@ template<typename T>
 void addbinding(py::class_<LUT2d<T>> &pyLUT2d)
 {
 
+    using const_vec_t = const Eigen::Ref<const Eigen::VectorXd>;
     pyLUT2d
         .def(py::init<>())
         .def(py::init<const T&>())
@@ -138,7 +139,8 @@ void addbinding(py::class_<LUT2d<T>> &pyLUT2d)
             return self.data().map();
         })
         .def("eval", py::overload_cast<const double, const double>(&LUT2d<T>::eval, py::const_))
-        .def("eval", py::overload_cast<double,const Eigen::Ref<const Eigen::VectorXd>&>(&LUT2d<T>::eval, py::const_))
+        .def("eval", py::overload_cast<double,const const_vec_t&>(&LUT2d<T>::eval, py::const_))
+        .def("eval", py::overload_cast<const_vec_t&, const_vec_t&>(&LUT2d<T>::eval, py::const_))
         ;
 }
 

--- a/python/extensions/pybind_isce3/core/LUT2d.cpp
+++ b/python/extensions/pybind_isce3/core/LUT2d.cpp
@@ -139,7 +139,7 @@ void addbinding(py::class_<LUT2d<T>> &pyLUT2d)
             return self.data().map();
         })
         .def("eval", py::overload_cast<const double, const double>(&LUT2d<T>::eval, py::const_))
-        .def("eval", py::overload_cast<double,const const_vec_t&>(&LUT2d<T>::eval, py::const_))
+        .def("eval", py::overload_cast<double, const_vec_t&>(&LUT2d<T>::eval, py::const_))
         .def("eval", py::overload_cast<const_vec_t&, const_vec_t&>(&LUT2d<T>::eval, py::const_))
         ;
 }

--- a/python/packages/isce3/geometry/__init__.py
+++ b/python/packages/isce3/geometry/__init__.py
@@ -1,5 +1,5 @@
 from isce3.ext.isce3.geometry import *
-from .rdr2rdr import rdr2rdr
+from .rdr2rdr import rdr2rdr, make_reskew_lut
 from .bounding_polygon import make_geo_grid_bounding_polygon
 from .bounding_radar_grid import get_bounding_radar_grid
 from .compute_incidence import (compute_incidence_angle,

--- a/python/packages/isce3/geometry/rdr2rdr.py
+++ b/python/packages/isce3/geometry/rdr2rdr.py
@@ -120,10 +120,10 @@ def make_reskew_lut(t_axis: Linspace,
         Dictionary specifying convergence parameters for geo2rdr solver.
         Keys among {"tol_height", "time_start", "time_start"}
         See isce3.geometry.geo2rdr_bracket
-    method: str
-        LUT2d interpolation method
-    b_error: bool
-        Enable LUT2d bounds error checking
+    method: str, optional
+        LUT2d interpolation method. Defaults to "bilinear".
+    b_error: bool, optional
+        Enable LUT2d bounds error checking. Defaults to True.
 
     Returns
     -------

--- a/python/packages/isce3/geometry/rdr2rdr.py
+++ b/python/packages/isce3/geometry/rdr2rdr.py
@@ -1,4 +1,5 @@
-from isce3.core import Ellipsoid, LookSide, LUT2d, Orbit
+import numpy as np
+from isce3.core import Ellipsoid, LookSide, LUT2d, Orbit, Linspace
 from isce3.geometry import DEMInterpolator, rdr2geo_bracket, geo2rdr_bracket
 from typing import Union, Optional
 
@@ -70,3 +71,79 @@ def rdr2rdr(t: float,
     tout, rout = geo2rdr_bracket(xyz, orbit_out, doppler_out, wavelength, side,
                                  **geo2rdr_params)
     return tout, rout
+
+
+def make_reskew_lut(t_axis: Linspace,
+                    r_axis: Linspace,
+                    orbit: Orbit,
+                    side: Union[str, LookSide],
+                    doppler_in: LUT2d,
+                    wavelength: float,
+                    dem: DEMInterpolator = DEMInterpolator(),
+                    doppler_out: Optional[LUT2d] = None,
+                    orbit_out: Optional[Orbit] = None,
+                    rdr2geo_params=dict(),
+                    geo2rdr_params=dict(),
+                    method: str = "bilinear",
+                    b_error: bool = True):
+    """
+    Generate a 2D look-up table for converting coordinates from one radar
+    geometry to another with a different Doppler (reskew) or orbit (motion
+    compensation).
+
+    Parameters
+    ----------
+    t_axis : isce3.core.Linspace
+	    Input azimuth time axis for the table, seconds past orbit epoch
+    r_axis : isce3.core.Linspace
+	    Input slant range axis for the table, m
+    orbit : isce3.core.Orbit
+	    Orbit defining radar motion on input path
+    side : {"left", "right", isce3.core.LookSide.Left, isce3.core.LookSide.Right}
+	    Flag describing which side the radar is looking.
+    doppler_in : isce3.core.LUT2d
+        Doppler look up table associated with `t_axis` and `r_axis`, Hz
+    wavelength : float
+        Wavelength associated with `doppler_in`, m
+    dem : isce3.geometry.DEMInterpolator, optional
+        Digital elevation model, m above ellipsoid.  Defaults to h=0.
+    doppler_out : isce3.core.LUT2d, optional
+        Doppler look up table vs output range and azimuth time, Hz
+        Defaults to `doppler_in`.
+    orbit_out : isce3.core.Orbit, optional
+        Orbit defining radar motion on output path.  Defaults to input `orbit`.
+    rdr2geo_params : dict, optional
+        Dictionary specifying convergence parameters for rdr2geo solver.
+        Keys among {"tol_aztime", "look_min", "look_max"}
+        See isce3.geometry.rdr2geo_bracket
+    geo2rdr_params: dict, optional
+        Dictionary specifying convergence parameters for geo2rdr solver.
+        Keys among {"tol_height", "time_start", "time_start"}
+        See isce3.geometry.geo2rdr_bracket
+    method: str
+        LUT2d interpolation method
+    b_error: bool
+        Enable LUT2d bounds error checking
+
+    Returns
+    -------
+    t_lut : isce3.core.LUT2d
+        Azimuth time in output geometry as a 2D function of (time, range) in the
+        input geometry, seconds past orbit epoch
+    r_lut : isce3.core.LUT2d
+        Range in output geometry as a 2D function of (time, range) in the input
+        geometry, m
+    """
+    m = len(t_axis)
+    n = len(r_axis)
+    t_out = np.zeros((m, n))
+    r_out = np.zeros((m, n))
+    for i, t_in in enumerate(t_axis):
+        for j, r_in in enumerate(r_axis):
+            t_out[i,j], r_out[i,j] = rdr2rdr(t_in, r_in, orbit, side,
+                doppler_in, wavelength, dem=dem, doppler_out=doppler_out,
+                orbit_out=orbit_out, rdr2geo_params=rdr2geo_params,
+                geo2rdr_params=geo2rdr_params)
+    t_lut = LUT2d(r_axis, t_axis, t_out, method=method, b_error=b_error)
+    r_lut = LUT2d(r_axis, t_axis, r_out, method=method, b_error=b_error)
+    return t_lut, r_lut

--- a/python/packages/nisar/cal/__init__.py
+++ b/python/packages/nisar/cal/__init__.py
@@ -24,3 +24,5 @@ from .faraday_rotation_angle_slc import (
     FaradayAngleProductCR,
     faraday_rot_angle_from_cr
 )
+
+from .qfsp_slip import AnomalyCode, get_qfsp_mask_boundaries

--- a/python/packages/nisar/cal/qfsp_slip.py
+++ b/python/packages/nisar/cal/qfsp_slip.py
@@ -2,6 +2,7 @@ from enum import Flag, unique
 import numpy as np
 from typing import Sequence
 
+from isce3.core import LUT2d
 from nisar.products.readers.instrument import InstrumentParser
 
 
@@ -80,3 +81,86 @@ def get_qfsp_mask_boundaries(anomaly_code: AnomalyCode | int,
         boundaries[AnomalyCode.SLIP_QFSP_V2] = (overlap_v_8_9,)
 
     return boundaries
+
+
+def write_anomaly_mask(anomaly_code, dataset, t0_axis, r0_axis, tn_lut, rn_lut,
+                       el_lut, int_cal):
+    """
+    Generate anomaly mask and save to HDF5 dataset
+
+    Parameters
+    ----------
+    anomaly_code : AnomalyCode | int
+        Bitwise OR of anomaly codes of interest.
+    dataset : h5py.Dataset | array_like
+        HDF5 dataset for storing mask.
+    t0_axis : isce3.core.Linspace
+        Zero-Doppler time axis associated with RSLC image.
+    r0_axis : isce3.core.Linspace
+        Zero-Doppler range axis associated with RSLC image.
+    tn_lut, rn_lut : isce3.core.LUT2d
+        Reskew tables providing native Doppler time and range as functions of
+        zero-Doppler (time, range).
+    el_lut : isce3.core.LUT2d
+        Table providing antenna EL angle as a function of native Doppler
+        (time, range).
+    int_cal : InstrumentParser
+        NISAR LSAR INT_CAL file containing the angle-to-coefficient (AC) tables.
+    """
+    nt = len(t0_axis)
+    nr = len(r0_axis)
+    if dataset.shape[0] != nt:
+        raise ValueError("Mask shape[0] is incompatible with time axis length")
+    if dataset.shape[1] != nr:
+        raise ValueError("Mask shape[1] is incompatible with range axis length")
+
+    # Full image mask may be too big to fit in memory.  If it's an HDF5 dataset
+    # then use chunk size as azimuth block size.
+    block_size = dataset.shape[0]
+    if getattr(dataset, "chunks", None) is not None:
+        block_size = dataset.chunks[0]
+
+    # Figure out the EL intervals we have to mask out.
+    boundaries = get_qfsp_mask_boundaries(anomaly_code, int_cal)
+
+    # Before doing anything else, check for no-anomaly since we can return
+    # early in that case.
+    if len(boundaries) == 0:
+        for block_start in range(0, nt, block_size):
+            block = slice(block_start, min(block_start + block_size, nt))
+            dataset[block, :] = AnomalyCode.NO_ANOMALY.value
+        return
+
+    # Not so lucky.  Now let's generate a mask based on the EL LUT data and the
+    # mask intervals.  EL LUT2d is small enough to hold in memory, so mask
+    # should be, too.
+    el_mask = np.zeros(el_lut.data.shape, dataset.dtype)
+    for anomaly_bit, el_intervals in boundaries:
+        code_mask = np.zeros(el_mask.shape, bool)
+        for el_low, el_high in el_intervals:
+            code_mask |= (el_lut.data >= el_low) & (el_lut.data <= el_high)
+        el_mask[code_mask] |= anomaly_bit.value
+
+    # Construct LUT2d with nearest-neighbor so mask values don't change.
+    # Domain of LUT is raw data (native Doppler), so we'll have to reskew it.
+    # NOTE This converts the dtype to float64, but that's okay as long as there
+    # are fewer than 52 bits in the mask (mantissa of float64).
+    mask_lut = LUT2d(el_lut.x_axis, el_lut.y_axis, el_mask, method="nearest",
+                     b_error=False)
+
+    for block_start in range(0, nt, block_size):
+        block_end = min(block_start + block_size, nt)
+        nb = block_end - block_start
+        # Allocate each chunk to avoid HDF5 I/O as much as possible.
+        mask_chunk = np.zeros((nb, nr), dataset.dtype)
+        for i_chunk, i_time in enumerate(range(block_start, block_end)):
+            t0 = t0_axis[i_time]
+            # Compute native Doppler (time, range) from zero-Doppler ones.
+            # Note vectorization along range-axis.
+            tn = tn_lut.eval(t0, r0_axis)
+            rn = rn_lut.eval(t0, r0_axis)
+            # TODO It'd be nice to have a C++ helper for this.
+            mask_chunk[i_chunk, :] = [mask_lut.eval(ti, ri)
+                for (ti, ri) in zip(tn, rn)]
+        # Write to output array / HDF5 dataset.
+        dataset[block_start : block_end, :] = mask_chunk

--- a/python/packages/nisar/cal/qfsp_slip.py
+++ b/python/packages/nisar/cal/qfsp_slip.py
@@ -167,8 +167,6 @@ def write_anomaly_mask(anomaly_code, dataset, t0_axis, r0_axis, tn_lut, rn_lut,
             # Note vectorization along range-axis.
             tn = tn_lut.eval(t0, r0_axis)
             rn = rn_lut.eval(t0, r0_axis)
-            # TODO It'd be nice to have a C++ helper for this.
-            mask_chunk[i_chunk, :] = [mask_lut.eval(ti, ri)
-                for (ti, ri) in zip(tn, rn)]
+            mask_chunk[i_chunk, :] = mask_lut.eval(tn, rn)
         # Write to output array / HDF5 dataset.
         write_block(mask_chunk, np.s_[block_start : block_end, :])

--- a/python/packages/nisar/cal/qfsp_slip.py
+++ b/python/packages/nisar/cal/qfsp_slip.py
@@ -34,7 +34,7 @@ Boundaries = dict[AnomalyCode, Sequence[ELAngleInterval]]
 def get_qfsp_mask_boundaries(anomaly_code: Union[AnomalyCode, int],
                              int_cal: InstrumentParser) -> Boundaries:
     """
-    Determine EL angle intervals associated with NISAR anomaly codes.
+    Determine EL angle intervals covering qFSP transition regions of 12-channel (three qFSPs) L-band NISAR associated with qFSP sample slip anomaly codes.
 
     Parameters
     ----------
@@ -61,6 +61,8 @@ def get_qfsp_mask_boundaries(anomaly_code: Union[AnomalyCode, int],
             enumerate(peak_indices)])
 
     # (start, end) EL angles between beam x and y peaks
+    if (peak_angles['H'].size != 12 or peak_angles['V'].size != 12):
+        raise ValueError(f'Number of channels for H/V is {peak_angles['H'].size}/{peak_angles['V'].size} instead of 12 expected for L-SAR NISAR!')
     overlap_h_4_5 = peak_angles["H"][3:5]
     overlap_h_8_9 = peak_angles["H"][7:9]
     overlap_v_4_5 = peak_angles["V"][3:5]
@@ -106,9 +108,12 @@ def write_anomaly_mask(anomaly_code, dataset, t0_axis, r0_axis, tn_lut, rn_lut,
         (time, range).
     int_cal : InstrumentParser
         NISAR LSAR INT_CAL file containing the angle-to-coefficient (AC) tables.
+    Notes
+    -------
+    This function generates invalid mask simply for 12-channel L-SAR product with qFSP sample slip anomaly.
     """
-    nt = len(t0_axis)
-    nr = len(r0_axis)
+    nt = t0_axis.size
+    nr = r0_axis.size
     if dataset.shape[0] != nt:
         raise ValueError("Mask shape[0] is incompatible with time axis length")
     if dataset.shape[1] != nr:
@@ -116,7 +121,7 @@ def write_anomaly_mask(anomaly_code, dataset, t0_axis, r0_axis, tn_lut, rn_lut,
 
     # Full image mask may be too big to fit in memory.  If it's an HDF5 dataset
     # then use chunk size as azimuth block size.
-    block_size = dataset.shape[0]
+    block_size = nt
     if getattr(dataset, "chunks", None) is not None:
         block_size = dataset.chunks[0]
 
@@ -135,7 +140,7 @@ def write_anomaly_mask(anomaly_code, dataset, t0_axis, r0_axis, tn_lut, rn_lut,
             block = slice(block_start, min(block_start + block_size, nt))
             nb = block.stop  - block.start
             buf = np.zeros((nb, dataset.shape[1]), dataset.dtype)
-            buf[...] = AnomalyCode.NO_ANOMALY.value
+            buf[...] = AnomalyCode(anomaly_code).value
             write_block(buf, np.s_[block, :])
         return
 
@@ -160,7 +165,7 @@ def write_anomaly_mask(anomaly_code, dataset, t0_axis, r0_axis, tn_lut, rn_lut,
         block_end = min(block_start + block_size, nt)
         nb = block_end - block_start
         # Allocate each chunk to avoid HDF5 I/O as much as possible.
-        mask_chunk = np.zeros((nb, nr), dataset.dtype)
+        mask_chunk = np.full(fill_value=AnomalyCode.NO_ANOMLAY.value, shape=(nb, nr), dtype=dataset.dtype)
         for i_chunk, i_time in enumerate(range(block_start, block_end)):
             t0 = t0_axis[i_time]
             # Compute native Doppler (time, range) from zero-Doppler ones.

--- a/python/packages/nisar/cal/qfsp_slip.py
+++ b/python/packages/nisar/cal/qfsp_slip.py
@@ -143,7 +143,7 @@ def write_anomaly_mask(anomaly_code, dataset, t0_axis, r0_axis, tn_lut, rn_lut,
     # mask intervals.  EL LUT2d is small enough to hold in memory, so mask
     # should be, too.
     el_mask = np.zeros(el_lut.data.shape, dataset.dtype)
-    for anomaly_bit, el_intervals in boundaries:
+    for anomaly_bit, el_intervals in boundaries.items():
         code_mask = np.zeros(el_mask.shape, bool)
         for el_low, el_high in el_intervals:
             code_mask |= (el_lut.data >= el_low) & (el_lut.data <= el_high)

--- a/python/packages/nisar/cal/qfsp_slip.py
+++ b/python/packages/nisar/cal/qfsp_slip.py
@@ -1,0 +1,82 @@
+from enum import Flag, unique
+import numpy as np
+from typing import Sequence
+
+from nisar.products.readers.instrument import InstrumentParser
+
+
+@unique
+class AnomalyCode(Flag):
+    """
+    NISAR data anomaly codes (bit flags)
+    """
+    NO_ANOMALY = 0
+    SLIP_QFSP_H0 = 1 << 0
+    SLIP_QFSP_H1 = 1 << 1  # only one seen in LSAR as of 2026-03-27
+    SLIP_QFSP_H2 = 1 << 2
+    SLIP_QFSP_V0 = 1 << 3
+    SLIP_QFSP_V1 = 1 << 4
+    SLIP_QFSP_V2 = 1 << 5
+    SLIP_SSAR = 1 << 6
+    RESERVED = 1 << 7
+
+
+def abs2(z):
+    return z.real**2 + z.imag**2
+
+
+# Type hints: (start, end) of elevation (EL) angle interval
+ELAngleInterval = tuple[float, float]
+# There can be multiple intervals associated with each anomaly.
+Boundaries = dict[AnomalyCode, Sequence[ELAngleInterval]]
+
+def get_qfsp_mask_boundaries(anomaly_code: AnomalyCode | int,
+                             int_cal: InstrumentParser) -> Boundaries:
+    """
+    Determine EL angle intervals associated with NISAR anomaly codes.
+
+    Parameters
+    ----------
+    anomaly_code : AnomalyCode | int
+        Bitwise OR of anomaly codes of interest.
+    int_cal : InstrumentParser
+        NISAR LSAR INT_CAL file containing the angle-to-coefficient (AC) tables.
+
+    Returns
+    -------
+    boundaries : Boundaries
+        Dictionary with a list of EL angle (start, end) intervals for each
+        nonzero bit in `anomaly_code`.  Angles are given in radians.
+    """
+    anomaly_code = AnomalyCode(anomaly_code)
+
+    peak_angles = dict()
+    for rxpol in ("H", "V"):
+        coeff = int_cal.get_angle2coef(rxpol)
+        angles = int_cal.el_angles_ac(rxpol)
+        peak_indices = np.argmax(abs2(coeff), axis=1)
+        # TODO Could interpolate to find peak.
+        peak_angles[rxpol] = np.array([angles[i, j] for (i, j) in
+            enumerate(peak_indices)])
+
+    # (start, end) EL angles between beam x and y peaks
+    overlap_h_4_5 = peak_angles["H"][3:5]
+    overlap_h_8_9 = peak_angles["H"][7:9]
+    overlap_v_4_5 = peak_angles["V"][3:5]
+    overlap_v_8_9 = peak_angles["V"][7:9]
+
+    boundaries = dict()
+    if anomaly_code & AnomalyCode.SLIP_QFSP_H0:
+        boundaries[AnomalyCode.SLIP_QFSP_H0] = (overlap_h_4_5,)
+    if anomaly_code & AnomalyCode.SLIP_QFSP_H1:
+        boundaries[AnomalyCode.SLIP_QFSP_H1] = (overlap_h_4_5, overlap_h_8_9)
+    if anomaly_code & AnomalyCode.SLIP_QFSP_H2:
+        boundaries[AnomalyCode.SLIP_QFSP_H2] = (overlap_h_8_9,)
+    if anomaly_code & AnomalyCode.SLIP_QFSP_V0:
+        boundaries[AnomalyCode.SLIP_QFSP_V0] = (overlap_v_4_5,)
+    if anomaly_code & AnomalyCode.SLIP_QFSP_V1:
+        boundaries[AnomalyCode.SLIP_QFSP_V1] = (overlap_v_4_5, overlap_v_8_9)
+    if anomaly_code & AnomalyCode.SLIP_QFSP_V2:
+        boundaries[AnomalyCode.SLIP_QFSP_V2] = (overlap_v_8_9,)
+
+    return boundaries

--- a/python/packages/nisar/cal/qfsp_slip.py
+++ b/python/packages/nisar/cal/qfsp_slip.py
@@ -61,8 +61,13 @@ def get_qfsp_mask_boundaries(anomaly_code: Union[AnomalyCode, int],
             enumerate(peak_indices)])
 
     # (start, end) EL angles between beam x and y peaks
-    if (peak_angles['H'].size != 12 or peak_angles['V'].size != 12):
-        raise ValueError(f'Number of channels for H/V is {peak_angles['H'].size}/{peak_angles['V'].size} instead of 12 expected for L-SAR NISAR!')
+    if not (peak_angles["H"].size == peak_angles["V"].size == 12):
+        nh = peak_angles["H"].size
+        nv = peak_angles["V"].size
+        raise ValueError(
+            f"Expected 12 channels for NISAR L-SAR but got {nh} on H and "
+            f"{nv} on V."
+        )
     overlap_h_4_5 = peak_angles["H"][3:5]
     overlap_h_8_9 = peak_angles["H"][7:9]
     overlap_v_4_5 = peak_angles["V"][3:5]

--- a/python/packages/nisar/cal/qfsp_slip.py
+++ b/python/packages/nisar/cal/qfsp_slip.py
@@ -1,6 +1,6 @@
 from enum import Flag, unique
 import numpy as np
-from typing import Sequence
+from typing import Sequence, Union
 
 from isce3.core import LUT2d
 from nisar.products.readers.instrument import InstrumentParser
@@ -31,7 +31,7 @@ ELAngleInterval = tuple[float, float]
 # There can be multiple intervals associated with each anomaly.
 Boundaries = dict[AnomalyCode, Sequence[ELAngleInterval]]
 
-def get_qfsp_mask_boundaries(anomaly_code: AnomalyCode | int,
+def get_qfsp_mask_boundaries(anomaly_code: Union[AnomalyCode, int],
                              int_cal: InstrumentParser) -> Boundaries:
     """
     Determine EL angle intervals associated with NISAR anomaly codes.

--- a/python/packages/nisar/cal/qfsp_slip.py
+++ b/python/packages/nisar/cal/qfsp_slip.py
@@ -34,7 +34,8 @@ Boundaries = dict[AnomalyCode, Sequence[ELAngleInterval]]
 def get_qfsp_mask_boundaries(anomaly_code: Union[AnomalyCode, int],
                              int_cal: InstrumentParser) -> Boundaries:
     """
-    Determine EL angle intervals covering qFSP transition regions of 12-channel (three qFSPs) L-band NISAR associated with qFSP sample slip anomaly codes.
+    Determine EL angle intervals covering qFSP transition regions of 12-channel
+    (three qFSPs) L-band NISAR associated with qFSP sample slip anomaly codes.
 
     Parameters
     ----------
@@ -115,7 +116,8 @@ def write_anomaly_mask(anomaly_code, dataset, t0_axis, r0_axis, tn_lut, rn_lut,
         NISAR LSAR INT_CAL file containing the angle-to-coefficient (AC) tables.
     Notes
     -------
-    This function generates invalid mask simply for 12-channel L-SAR product with qFSP sample slip anomaly.
+    This function generates invalid mask simply for 12-channel L-SAR product
+    with qFSP sample slip anomaly.
     """
     nt = t0_axis.size
     nr = r0_axis.size
@@ -170,7 +172,8 @@ def write_anomaly_mask(anomaly_code, dataset, t0_axis, r0_axis, tn_lut, rn_lut,
         block_end = min(block_start + block_size, nt)
         nb = block_end - block_start
         # Allocate each chunk to avoid HDF5 I/O as much as possible.
-        mask_chunk = np.full(fill_value=AnomalyCode.NO_ANOMLAY.value, shape=(nb, nr), dtype=dataset.dtype)
+        mask_chunk = np.full(fill_value=AnomalyCode.NO_ANOMALY.value,
+            shape=(nb, nr), dtype=dataset.dtype)
         for i_chunk, i_time in enumerate(range(block_start, block_end)):
             t0 = t0_axis[i_time]
             # Compute native Doppler (time, range) from zero-Doppler ones.

--- a/python/packages/nisar/cal/qfsp_slip.py
+++ b/python/packages/nisar/cal/qfsp_slip.py
@@ -120,6 +120,11 @@ def write_anomaly_mask(anomaly_code, dataset, t0_axis, r0_axis, tn_lut, rn_lut,
     if getattr(dataset, "chunks", None) is not None:
         block_size = dataset.chunks[0]
 
+    def write_block(buf, block):
+        dataset[block] = buf
+    if hasattr(dataset, "write_direct"):
+        write_block = lambda buf, block: dataset.write_direct(buf, dest_sel=block)
+
     # Figure out the EL intervals we have to mask out.
     boundaries = get_qfsp_mask_boundaries(anomaly_code, int_cal)
 
@@ -128,7 +133,10 @@ def write_anomaly_mask(anomaly_code, dataset, t0_axis, r0_axis, tn_lut, rn_lut,
     if len(boundaries) == 0:
         for block_start in range(0, nt, block_size):
             block = slice(block_start, min(block_start + block_size, nt))
-            dataset[block, :] = AnomalyCode.NO_ANOMALY.value
+            nb = block.stop  - block.start
+            buf = np.zeros((nb, dataset.shape[1]), dataset.dtype)
+            buf[...] = AnomalyCode.NO_ANOMALY.value
+            write_block(buf, np.s_[block, :])
         return
 
     # Not so lucky.  Now let's generate a mask based on the EL LUT data and the
@@ -163,4 +171,4 @@ def write_anomaly_mask(anomaly_code, dataset, t0_axis, r0_axis, tn_lut, rn_lut,
             mask_chunk[i_chunk, :] = [mask_lut.eval(ti, ri)
                 for (ti, ri) in zip(tn, rn)]
         # Write to output array / HDF5 dataset.
-        dataset[block_start : block_end, :] = mask_chunk
+        write_block(mask_chunk, np.s_[block_start : block_end, :])

--- a/python/packages/nisar/products/readers/Base/Identification.py
+++ b/python/packages/nisar/products/readers/Base/Identification.py
@@ -103,6 +103,7 @@ class Identification(object):
         self.plannedDatatake = None
         self.plannedObservation = None
 
+        self.hasInputDataException = None
 
 
         import h5py
@@ -237,6 +238,12 @@ class Identification(object):
             warn("Could not find isJointObservation in product identification.")
             # leave as None
 
-        ###Processing type info to be added
-
-# end of file
+        # Added in NISAR_PIX PR #351
+        try:
+            self.hasInputDataException = extractScalar(h5grp,
+                                       "hasInputDataException",
+                                       int, self.context['info'])
+        except KeyError:
+            warn("Could not find hasInputDataException in product "
+                 "identification.  Assuming there are no anomalies.")
+            self.hasInputDataException = 0

--- a/python/packages/nisar/products/writers/SLC.py
+++ b/python/packages/nisar/products/writers/SLC.py
@@ -526,6 +526,18 @@ class SLC(h5py.File):
         dset.attrs["units"] = np.bytes_("1")
         return dset
 
+    def create_anomaly_mask(self, frequency="A", **kw) -> h5py.Dataset:
+        log.info("Initializing storage for anomaly mask for "
+            f"frequency={frequency} with HDF5 options={kw}")
+        kw.setdefault("dtype", np.uint8)
+        dset = self.swath(frequency).create_dataset("inputDataExceptionMask",
+            **kw)
+        dset.attrs["description"] = np.bytes_("Bitwise OR of input data "
+            "exception codes for each image pixel (0: no anomaly, 2: NISAR "
+            "LSAR qFSP-H1 sample slip)")
+        dset.attrs["units"] = np.bytes_("1")
+        return dset
+
     def update_swath(self, grid: RadarGridParameters, orbit: Orbit,
                      range_bandwidth: float, frequency: str,
                      azimuth_bandwidth: float, acquired_prf: float,

--- a/python/packages/nisar/products/writers/SLC.py
+++ b/python/packages/nisar/products/writers/SLC.py
@@ -687,6 +687,7 @@ class SLC(h5py.File):
                             frequencies: Optional[str] = None,
                             planned_datatake_id: Optional[str] = None,
                             planned_observation_id: Optional[str] = None,
+                            has_input_data_exception: int = None,
                             is_urgent: Optional[bool] = None,
                             is_joint: Optional[bool] = None,
                             product_spec_version: str = "1.4.0",
@@ -715,6 +716,7 @@ class SLC(h5py.File):
             absoluteOrbitNumber
             boundingPolygon
             instrumentName
+            hasInputDataException
             isJointObservation
             isUrgentObservation
             listOfFrequencies
@@ -843,6 +845,14 @@ class SLC(h5py.File):
             d.attrs["description"] = np.bytes_(
                 'Flag indicating if observation is nominal ("False") '
                 'or urgent ("True")')
+
+        if has_input_data_exception is not None:
+            d = g.require_dataset("hasInputDataException", (), np.uint8)
+            d[()] = np.uint8(has_input_data_exception)
+            d.attrs["description"] = np.bytes_("Indication of input data "
+                "exceptions or anomalies present in this granule. Bitwise OR "
+                "of instrument exception codes for all image pixels (0: no "
+                "anomaly, 2: NISAR LSAR qFSP-H1 sample slip)")
 
         d = set_string(g, "productSpecificationVersion", product_spec_version)
         d.attrs["description"] = np.bytes_("Product specification version "

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1403,7 +1403,8 @@ def get_identification_data_from_runconfig(cfg: Struct) -> dict:
 def get_identification_data_from_raw(rawlist: list[Raw]) -> dict:
     """
     Populate a dict containing the keys
-        {"planned_datatake_id", "planned_observation_id", "is_urgent"}
+        {"planned_datatake_id", "planned_observation_id", "is_urgent",
+         "has_input_data_exception"}
     by combining the relevant identification metadata keys from all raw data
     files in the provided list.
     """
@@ -1416,7 +1417,9 @@ def get_identification_data_from_raw(rawlist: list[Raw]) -> dict:
         is_urgent = any(raw.identification.isUrgentObservation
             for raw in rawlist),
         is_joint = any(raw.identification.isJointObservation
-            for raw in rawlist)
+            for raw in rawlist),
+        has_input_data_exception = reduce(lambda a, b: a | b,
+            (raw.identification.hasInputDataException for raw in rawlist)),
     )
 
 

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1716,6 +1716,25 @@ def focus(runconfig, runconfig_path=""):
                                        dem, get_rdr2geo_params(cfg))
     beta0_lut, sigma0_lut, gamma0_lut = make_cal_luts(inc_lut)
 
+    # Compute luts for zero-doppler (t,r) -> native-doppler (t,r)
+    reskew_grid = ref_grid.multilook(
+            cfg.processing.lookup_tables.downsampling_factor.azimuth,
+            cfg.processing.lookup_tables.downsampling_factor.range
+        ).add_margin(
+            cfg.processing.lookup_tables.margin_in_pixels.azimuth,
+            cfg.processing.lookup_tables.margin_in_pixels.range
+        )
+    log.info(f"Computing reskew look-up-tables with shape={reskew_grid.shape}")
+    tn_lut, rn_lut = isce3.geometry.make_reskew_lut(
+        reskew_grid.sensing_times, reskew_grid.slant_ranges, orbit, side,
+        zerodop, wvl_ref, dem=dem, doppler_out=dop_ref,
+        rdr2geo_params=get_rdr2geo_params(cfg),
+        geo2rdr_params=get_geo2rdr_params(cfg))
+
+    anomaly_code = reduce(lambda a, b: a | b,
+        (raw.identification.hasInputDataException for raw in rawlist))
+    log.info(f"Data anomaly code = {anomaly_code}")
+
     # Frequency A/B specific setup for output grid, doppler, and blocks.
     ogrid, dop, blocks_bounds, areas = dict(), dict(), dict(), dict()
     for frequency, band in get_bands(common_mode).items():
@@ -1838,6 +1857,19 @@ def focus(runconfig, runconfig_path=""):
                                         orbit.reference_epoch,
                                         extended_radar_grid.slant_ranges,
                                         beta0_lut, sigma0_lut, gamma0_lut)
+
+        # Set anomaly mask. Need to do some geometry.
+        opts = get_dataset_creation_options(cfg, og.shape)
+        del opts["dtype"]
+        mask = slc.create_anomaly_mask(frequency, shape=og.shape, **opts)
+        if instparser is not None:
+            log.info(f"Writing inputDataExceptionMask for frequency{frequency}")
+            nisar.cal.qfsp_slip.write_anomaly_mask(anomaly_code, mask,
+                og.sensing_times, og.slant_ranges, tn_lut, rn_lut, el_lut,
+                instparser)
+        else:
+            log.warning("Internal calibration (INT_CAL) file was not provided "
+                "so unable to populate inputDataExceptionMask")
 
     freq = next(iter(get_bands(common_mode)))
     slc.set_geolocation_grid(orbit, ogrid[freq], dop[freq],

--- a/tests/python/extensions/pybind/core/LUT2d.py
+++ b/tests/python/extensions/pybind/core/LUT2d.py
@@ -3,6 +3,7 @@
 import iscetest
 import journal
 import numpy as np
+import pytest
 
 import isce3.ext.isce3 as isce
 
@@ -47,6 +48,15 @@ def test_LUT2d():
     lut = isce.core.LUT2d(2.0)
     assert lut.ref_value == 2.0
 
+    # Call vectorized vs x
+    lut2d.eval(d_refs[0,0], d_refs[:,1])
+    # Call vectorized vs y and x
+    lut2d.eval(d_refs[:,0], d_refs[:,1])
+
+    # Call vectorized with size mismatch
+    with pytest.raises(ValueError):
+        lut2d.eval(d_refs[:10,0], d_refs[:,1])
+
 
 def test_bounds_error():
     """Test that out-of-bounds evaluation raises exceptions.
@@ -54,8 +64,6 @@ def test_bounds_error():
     Regression test for bug where vectorized .eval crashes Python instead of
     raising a catchable exception when bounds_error=True.
     """
-    import pytest
-
     # Create a simple LUT with known bounds: 10 points in x, 2 points in y
     x = np.linspace(0, 5, 10)
     y = np.linspace(10, 20, 2)
@@ -78,6 +86,8 @@ def test_bounds_error():
     # Test vectorized out-of-bounds (should raise, not crash)
     with pytest.raises((RuntimeError, journal.ApplicationError)):
         lut2d.eval(y, np.array([x_oob, x_oob]))
+    with pytest.raises(IndexError):
+        lut2d.eval([y, y], np.array([x_oob, x_oob]))
 
     # Test vectorized, all in-bounds
     result = lut2d.eval(y, np.array([1.0, 2.0, 3.0]))

--- a/tests/python/packages/CMakeLists.txt
+++ b/tests/python/packages/CMakeLists.txt
@@ -37,6 +37,7 @@ nisar/cal/corner_reflector_slc_func.py
 nisar/cal/corner_reflector.py
 nisar/cal/faraday_rotation_angle_slc.py
 nisar/cal/pol_channel_imbalance_slc.py
+nisar/cal/qfsp_slip.py
 nisar/mixed_mode/logic.py
 nisar/mixed_mode/processing.py
 nisar/noise/noise_estimation_from_raw.py

--- a/tests/python/packages/nisar/cal/qfsp_slip.py
+++ b/tests/python/packages/nisar/cal/qfsp_slip.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+import iscetest
+from pathlib import Path
+import numpy as np
+
+from nisar.cal.qfsp_slip import AnomalyCode, get_qfsp_mask_boundaries
+from nisar.products.readers.instrument import InstrumentParser
+
+
+def test_qfsp_boundaries():
+    fn = Path(iscetest.data) / "bf" / "REE_INSTRUMENT_TABLE.h5"
+    int_cal = InstrumentParser(fn)
+
+    # Call with integer code (don't require enum type).
+    boundaries = get_qfsp_mask_boundaries(2, int_cal)
+    print(boundaries)
+
+    # We only set a single bit, so we should only have one key.
+    assert len(boundaries) == 1
+
+    # There should be two bad regions for middle qFSP slip.
+    el_intervals = boundaries[AnomalyCode.SLIP_QFSP_H1]
+    assert len(el_intervals) == 2
+
+    # There should be two numbers (start, end) for each interval.
+    for start, end in el_intervals:
+        # They should be sorted.
+        assert end >= start
+        # NISAR beams are around one degree wide and spacing isn't much bigger,
+        # each region should be roughly that size.
+        assert (end - start) < np.deg2rad(1.5)


### PR DESCRIPTION
This PR implements the `inputDataExceptionMask` in RSLC products for the LSAR qFSP-related exception codes. It handles all six possible qFSP exception codes. For now, the strategy to is locate the peaks of the AC table weights in the EL angle domain and use the EL-angle LUT to generate the mask. This mask is in the raw data domain, so it's resampled to the RSLC grid using reskew LUTs. (These could be used to reskew other tables in some future PR, too). I added a vectorized `LUT2d::eval` overload to make this faster.

Eyeballing the plots for the case I tested on, I'm not sure the mask covers everything where there's obvious residual phase. So maybe instead of defining the overlap region as peak-to-peak, we should be more conservative and use a -6 dB threshold or something. I hope folks can do some InSAR tests to help figure out the best approach. 

Note that the mask is populated based on the contents of the input L0B `hasInputDataException` flag, so that must be populated to see any effect.

Another question is what to do about mixed-mode frames where one L0B has a qFSP slip and its neighbor doesn't. For now, the qFSP overlap region is marked invalid for the entirety of the output product.