### PR TITLE
PTA: Add chip to outputs and estimate signal-to-clutter ratio.

### DIFF
--- a/python/packages/isce3/cal/point_target_info.py
+++ b/python/packages/isce3/cal/point_target_info.py
@@ -621,7 +621,7 @@ def analyze_point_target(
             peak_magnitude=results[0]["magnitude"],
         )
 
-        results[0]["signal_clutter_ratio"] = scr
+        results[0]["signal clutter ratio"] = scr
 
     return results
 
@@ -1134,11 +1134,20 @@ def tofloatvals(x):
 
     Modifies the dictionary in-place and returns None.
     """
+    def list2floats(my_list):
+        """
+        Convert a list of any dimensions into a list of floats. The list must either
+        contain only other lists or only values that can be converted into floats.
+        """
+        if all(isinstance(xi, list) for xi in my_list):
+            return [list2floats(xi) for xi in my_list]
+        return [float(xi) for xi in my_list]
+
     for k in x:
         if type(x[k]) == dict:
             tofloatvals(x[k])
         elif type(x[k]) == list:
-            x[k] = [float(xki) for xki in x[k]]
+            x[k] = list2floats(x[k])
         else:
             x[k] = float(x[k])
 

--- a/python/packages/isce3/cal/point_target_info.py
+++ b/python/packages/isce3/cal/point_target_info.py
@@ -986,7 +986,7 @@ def estimate_scr(
         )
         return np.nan
 
-    # Create an estimated chip that is the column and row of the peak magnitude plus
+    # Create an estimation chip that is the column and row of the peak magnitude plus
     # clutter_half_width pixels in either direction, converted to units of linear power.
     scr_est_chip = np.abs(
         chip[

--- a/python/packages/isce3/cal/point_target_info.py
+++ b/python/packages/isce3/cal/point_target_info.py
@@ -966,7 +966,7 @@ def estimate_scr(
 
     # If the peak magnitude was not passed in, estimate it.
     if peak_magnitude is None:
-        peak_magnitude = np.nanmax(chip)
+        peak_magnitude = np.nanmax(np.abs(chip))
 
     # Get the location of the peak magnitude.
     k = np.nanargmax(np.abs(chip))

--- a/python/packages/isce3/cal/point_target_info.py
+++ b/python/packages/isce3/cal/point_target_info.py
@@ -610,6 +610,10 @@ def analyze_point_target(
         pixel_spacing=pixel_spacing,
     )
 
+    # XXX: The current method of estimating SCR does not work for geolocated products
+    # which may have skewed sidelobes. Doing this would require resampling these
+    # products to acquire a chip usable by the SCR estimator, or else finding some new
+    # means of estimating and masking the locations of the side lobes on the chip.
     if geo_heading is None:
 
         scr = estimate_scr(

--- a/python/packages/isce3/cal/point_target_info.py
+++ b/python/packages/isce3/cal/point_target_info.py
@@ -591,7 +591,7 @@ def analyze_point_target(
 
     chip, chip_min_i, chip_min_j = generate_chip_on_slc(slc, i, j, chipsize=chipsize)
 
-    return analyze_point_target_chip(
+    results = analyze_point_target_chip(
         chip=chip,
         chip_min_i=chip_min_i,
         chip_min_j=chip_min_j,
@@ -609,6 +609,17 @@ def analyze_point_target(
         geo_heading=geo_heading,
         pixel_spacing=pixel_spacing,
     )
+
+    if geo_heading is None:
+
+        scr = estimate_scr(
+            chip=chip,
+            peak_magnitude=results[0]["magnitude"],
+        )
+
+        results[0]["signal_clutter_ratio"] = scr
+
+    return results
 
 
 def generate_chip_on_slc(

--- a/python/packages/isce3/cal/point_target_info.py
+++ b/python/packages/isce3/cal/point_target_info.py
@@ -846,6 +846,8 @@ def analyze_point_target_chip(
     return_dict = {
         "magnitude": np.abs(chipmax),
         "phase": np.angle(chipmax),
+        "chip magnitude": np.abs(chip).tolist(),
+        "chip phase": np.angle(chip).tolist(),
         "azimuth": {
             "ISLR": azimuth_islr_db,
             "PSLR": azimuth_pslr_db,
@@ -912,6 +914,92 @@ def analyze_point_target_chip(
         ]
         return return_dict, figs
     return return_dict, None
+
+
+def estimate_scr(
+    chip,
+    clutter_half_width: int = 12,
+    peak_magnitude: float | None = None,
+) -> float:
+    """
+    Estimate the signal-to-clutter ratio (SCR), in dB, for a chip of data around a point
+    target.
+
+    Parameters
+    ----------
+    chip : np.ndarray of complex64
+        The data chip.
+    clutter_half_width : int, optional
+        An integer greater than 3 and smaller than half the width or length of `chip`.
+        Defines half the region used for estimating SCR. Defaults to 12.
+    peak_magnitude : float, optional
+        The identified peak magnitude of the data, or None for a rough estimate.
+        Defaults to None.
+
+    Returns
+    -------
+    float
+        The chip SCR, in dB.
+    """
+    if clutter_half_width < 3:
+        raise ValueError("clutter_half_width must be a positive number greater than 2.")
+    if clutter_half_width > chip.shape[0] / 2 or clutter_half_width > chip.shape[1] / 2:
+        raise ValueError(
+            f"clutter_half_width of {clutter_half_width} must be less than half of "
+            f"chip dimensions {chip.shape[0]} and {chip.shape[1]}."
+        )
+
+    # If the peak magnitude was not passed in, estimate it.
+    if peak_magnitude is None:
+        peak_magnitude = np.nanmax(chip)
+
+    # Get the location of the peak magnitude.
+    k = np.nanargmax(np.abs(chip))
+    ichip, jchip = np.unravel_index(k, chip.shape)
+
+    # Make sure that the point target is far enough from the edge of the chip that
+    # an estimation region can be selected.
+    if (
+        ichip < clutter_half_width
+        or jchip < clutter_half_width
+        or ichip > chip.shape[0] - clutter_half_width
+        or jchip > chip.shape[1] - clutter_half_width
+    ):
+        warn(
+            "PTA Warning: Detected peak location too close to edge of chip. SCR could "
+            "not be calculated. SCR value will be returned as NaN."
+        )
+        return np.nan
+
+    # Create an estimated chip that is the column and row of the peak magnitude plus
+    # clutter_half_width pixels in either direction, converted to units of linear power.
+    scr_est_chip = np.abs(
+        chip[
+            ichip - clutter_half_width : ichip + clutter_half_width + 1,
+            jchip - clutter_half_width : jchip + clutter_half_width + 1,
+        ]
+    ) ** 2
+
+    # Set the row and column of peak power, plus one row and column on either side, to
+    # 0. This creates a "+" on the image of zeroed pixels corresponding to the IRF peak
+    # and its side lobes. The remaining nonzero pixels are the clutter region.
+    scr_est_chip[clutter_half_width - 1:clutter_half_width + 2, :] = 0
+    scr_est_chip[:, clutter_half_width - 1:clutter_half_width + 2] = 0
+
+    # Calculate the number of pixels that were not zeroed out, which is four regions
+    # of clutter_half_width -1 pixels squared.
+    sampled_area = (clutter_half_width - 1) ** 2 * 4
+
+    # The clutter power is the total power of the clutter region divided by the total
+    # number of pixels constituting that region.
+    clutter = np.sum(scr_est_chip) / sampled_area
+
+    # Calculate the peak power divided by average clutter power to get signal to clutter
+    # ratio.
+    scr = peak_magnitude ** 2 / clutter
+
+    # Convert to dB and then return.
+    return 10 * np.log10(scr)
 
 
 def sample_geocoded_side_lobe(

--- a/python/packages/isce3/cal/point_target_info.py
+++ b/python/packages/isce3/cal/point_target_info.py
@@ -518,7 +518,8 @@ def analyze_point_target(
     window_parameter: float = 0.0,
     shift_domain: str = "time",
     geo_heading: float | None = None,
-    pixel_spacing: tuple[float, float] = (1.0, 1.0)
+    pixel_spacing: tuple[float, float] = (1.0, 1.0),
+    nchip_clutter: int = 25,
 ) -> tuple[dict, list["matplotlib.figure.Figure"] | None]:
     """
     Measure point-target attributes.
@@ -615,9 +616,13 @@ def analyze_point_target(
     # products to acquire a chip usable by the SCR estimator, or else finding some new
     # means of estimating and masking the locations of the side lobes on the chip.
     if geo_heading is None:
-
+        max_i = i + results[0]["azimuth"]["offset"]
+        max_j = j + results[0]["range"]["offset"]
+        
+        clutter_chip = generate_chip_on_slc(slc, max_i, max_j, chipsize=nchip_clutter)
+        
         scr = estimate_scr(
-            chip=chip,
+            chip=clutter_chip,
             peak_magnitude=results[0]["magnitude"],
         )
 
@@ -932,8 +937,7 @@ def analyze_point_target_chip(
 
 
 def estimate_scr(
-    chip,
-    clutter_half_width: int = 12,
+    chip: np.ndarray,
     peak_magnitude: float | None = None,
 ) -> float:
     """
@@ -942,11 +946,8 @@ def estimate_scr(
 
     Parameters
     ----------
-    chip : np.ndarray of complex64
-        The data chip.
-    clutter_half_width : int, optional
-        An integer greater than 3 and smaller than half the width or length of `chip`.
-        Defines half the region used for estimating SCR. Defaults to 12.
+    chip : 2D np.ndarray of complex64
+        The data chip. Must be square with an odd number of pixels in each dimension.
     peak_magnitude : float, optional
         The identified peak magnitude of the data, or None for a rough estimate.
         Defaults to None.
@@ -956,13 +957,22 @@ def estimate_scr(
     float
         The chip SCR, in dB.
     """
-    if clutter_half_width < 3:
-        raise ValueError("clutter_half_width must be a positive number greater than 2.")
-    if clutter_half_width > chip.shape[0] / 2 or clutter_half_width > chip.shape[1] / 2:
+    length, width = chip.shape
+    if length != width:
         raise ValueError(
-            f"clutter_half_width of {clutter_half_width} must be less than half of "
-            f"chip dimensions {chip.shape[0]} and {chip.shape[1]}."
+            f"estimate_scr: Chip must be square. Shape was given as {length} x {width}."
         )
+    if length % 2 == 0:
+        raise ValueError(
+            f"estimate_scr: Chip must have an odd number of pixels"
+        )
+    if length < 5:
+        raise ValueError(
+            "estimate_scr: Chip side length must be at least 5. "
+            f"Length given was {length}."
+        )
+    
+    clutter_half_width = width // 2
 
     # If the peak magnitude was not passed in, estimate it.
     if peak_magnitude is None:
@@ -971,20 +981,6 @@ def estimate_scr(
     # Get the location of the peak magnitude.
     k = np.nanargmax(np.abs(chip))
     ichip, jchip = np.unravel_index(k, chip.shape)
-
-    # Make sure that the point target is far enough from the edge of the chip that
-    # an estimation region can be selected.
-    if (
-        ichip < clutter_half_width
-        or jchip < clutter_half_width
-        or ichip > chip.shape[0] - clutter_half_width
-        or jchip > chip.shape[1] - clutter_half_width
-    ):
-        warn(
-            "PTA Warning: Detected peak location too close to edge of chip. SCR could "
-            "not be calculated. SCR value will be returned as NaN."
-        )
-        return np.nan
 
     # Create an estimation chip that is the column and row of the peak magnitude plus
     # clutter_half_width pixels in either direction, converted to units of linear power.

--- a/tests/python/packages/nisar/workflows/point_target_analysis.py
+++ b/tests/python/packages/nisar/workflows/point_target_analysis.py
@@ -137,6 +137,9 @@ def test_nisar_csv():
             "survey_date",
             "validity",
             "velocity",
+            "chip magnitude",
+            "chip phase",
+            "signal clutter ratio",
         }
         assert set(cr_info.keys()) == expected_keys
 
@@ -246,6 +249,9 @@ def test_uavsar_csv():
             "phase",
             "range",
             "azimuth",
+            "chip magnitude",
+            "chip phase",
+            "signal clutter ratio",
         }
         assert set(cr_info.keys()) == expected_keys
 


### PR DESCRIPTION
This PR adds the PTA chip as a PTA output, and incorporates a method of calculating signal-to-clutter (SCR) ratio in dB. This value would be useful for populating error bars in PTA trending.