### PR TITLE
Update eigen version in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - backoff
   - cmake>=3.18
   - cxx-compiler
-  - eigen>=3.3
+  - eigen>=3.3.7
   - fftw>=3.3
   # GDAL 3.6.0 was the first to build with cmake, needed for FindGDAL module
   # https://github.com/conda-forge/gdal-feedstock/pull/651


### PR DESCRIPTION
This PR updates the Eigen version in the basic environment.yml to match the version present in tools/imagesets/oracle8conda/dev/environment.yml and the checked in our cmake build files.