### PR TITLE
Alternative frequency domain RFI filter (tone-rank)

### DIFF
--- a/python/packages/isce3/noise/noise_power_est_func.py
+++ b/python/packages/isce3/noise/noise_power_est_func.py
@@ -203,7 +203,7 @@ def noise_pow_min_eigval_est(dset, cpi=2, *, scalar=1, remove_mean=False,
     # all CPIs/range lines. This will lead to noise power est closer to the
     # thermal noise. The assumption is that noise stat is stationary over
     # all range lines.
-    cpi_slices = _cpi_slice_gen(nrgls, cpi)
+    cpi_slices = cpi_slice_gen(nrgls, cpi)
     pw_ns_all = []
     for cpi_slice in cpi_slices:
         d = dset[cpi_slice]
@@ -233,7 +233,7 @@ def noise_pow_min_eigval_est(dset, cpi=2, *, scalar=1, remove_mean=False,
 
 
 # helper function
-def _cpi_slice_gen(nrgl, cpi):
+def cpi_slice_gen(nrgl, cpi):
     """Helper function for CPI slice generator
 
     Parameters

--- a/python/packages/isce3/signal/__init__.py
+++ b/python/packages/isce3/signal/__init__.py
@@ -13,6 +13,7 @@ from . import rfi_detection_evd
 from . import rfi_freq_null
 from . import rfi_mitigation_evd
 from . import rfi_process_evd
+from . import rfi_tone_rank
 from .multi_channel_analysis import (
     form_single_tap_dbf_echo,
     dbf_onetap_from_dm2,

--- a/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/python/packages/isce3/signal/rfi_tone_rank.py
@@ -32,6 +32,8 @@ def get_spectral_mask(
     # small.
     k = round(reference_quantile * n)
     kth_power = np.partition(power_spectra, k)[k]
+    if kth_power == 0.0:
+        return np.zeros(spectra.shape, dtype=bool), 0.0
     # Estimate the parameter of a lifted exponential distribution.
     λ = exp_from_quantile(reference_quantile, kth_power, bandwidth)
     # Determine threshold.  Since we've estimated a statistical model, we can

--- a/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/python/packages/isce3/signal/rfi_tone_rank.py
@@ -1,3 +1,4 @@
+import h5py
 import logging
 import numpy as np
 from scipy.fft import fft, ifft, fftfreq, fftshift
@@ -245,23 +246,74 @@ def remove_loud_tones(
     fill_value="noise",
 ):
     """
-    t : np.ndarray [float64]
-        Pulse times (seconds since orbit/grid epoch).
+    Detect and optionally mitigate narrowband RFI using spectral rank method.
+
+    Processes raw data in overlapping blocks using a Short-Time Fourier Transform
+    (STFT) approach. RFI is detected in the spectral domain using a lifted
+    exponential statistical model. Detected RFI samples are replaced using
+    temporal interpolation or fill values.
+
+    Parameters
+    ----------
+    z : np.ndarray[complex64]
+        Raw data, shape (num_pulses, num_range_bins).
+    t : np.ndarray[float64]
+        Pulse times in seconds since orbit/grid epoch, length num_pulses.
     r : isce3.core.Linspace
-        Range to each sample (meters).
-    swaths : np.ndarray [int]
-        Valid subswath samples, dims = (ns, nt, 2) where ns is the number of
-        sub-swaths, nt is the number of pulses, and the trailing dimension is
-        the [start, stop) indices of the sub-swath.
-    doppler : isce3.core.LUT2d [double]
-        Raw data Doppler look up table.  Must be valid over entire grid.
+        Slant range to each sample in meters.
+    swaths : np.ndarray[int]
+        Valid subswath samples, shape (num_subswaths, num_pulses, 2).
+        Last dimension contains [start, stop) indices of each subswath.
+    doppler : isce3.core.LUT2d
+        Raw data Doppler centroid look-up table in Hz. Must be valid over
+        entire grid.
+    block_dims : tuple[int, int], optional
+        Processing block size (azimuth, range). Default is (512, 1024).
+    reference_quantile : float, optional
+        Quantile used to estimate the rate parameter of the lifted exponential
+        distribution, in [1-bandwidth, 1). Default is 0.5 (median).
+    nominal_false_positive_rate : float, optional
+        Target false positive rate for RFI detection, in (0, 1].
+    bandwidth : float, optional
+        Ratio of chirp bandwidth to sample rate, in (0, 1].
+    detect_only : bool, optional
+        If True, only detect RFI without mitigation. If False, replace
+        detected RFI samples.
+    zout : np.ndarray[complex64], optional
+        Output buffer for mitigated data. Must have same shape as z.
+        If None, z is modified in-place.
     interpolate : bool, optional
         If True, attempt linear/nearest-neighbor interpolation for RFI samples.
-        If False, replace directly with fill_value. Default is True.
+        If False, replace directly with fill_value.
     fill_value : str, optional
         Fallback value when interpolation fails or is disabled.
         "noise": use random Gaussian noise (default)
         "zero": use zero
+
+    Returns
+    -------
+    means : np.ndarray[float]
+        Estimated mean signal power per block from lifted exponential model,
+        shape (num_az_blocks, num_range_blocks). Equal to 1/λ where λ is the
+        rate parameter.
+    isr : np.ndarray[float]
+        Interference-to-signal ratio per block,
+        shape (num_az_blocks, num_range_blocks).
+    f : np.ndarray[float]
+        Normalized frequency axis for hits array, length block_dims[1].
+        Units are cycles per sample.
+    hits : np.ndarray[uint32]
+        Count of detected RFI samples at each frequency bin,
+        shape (num_az_blocks, num_range_blocks, block_dims[1]).
+
+    Notes
+    -----
+    The algorithm processes data in overlapping blocks using COLA (Constant
+    Overlap-Add) windowing in range. Each block is transformed to the spectral
+    domain where RFI tones appear as anomalously loud samples. Detection uses
+    the lifted exponential model (see get_spectral_mask). When mitigation is
+    enabled, detected samples are replaced using temporal interpolation from
+    adjacent clean pulses, with fallback to random noise or zeros.
     """
     # Check inputs
     if not (z.ndim == len(block_dims) == 2):
@@ -298,6 +350,7 @@ def remove_loud_tones(
     f = fftshift(fftfreq(block_dims[1]))
     meta_shape = (num_az_blocks, num_range_blocks)
     isr = np.zeros(meta_shape)
+    means = np.zeros(meta_shape)
     hits = np.zeros(meta_shape + (block_dims[1],), dtype=np.uint32)
 
     block_ranges = np.zeros(num_range_blocks)
@@ -349,6 +402,7 @@ def remove_loud_tones(
                 spectra[:, j, :] = fill_missing(spectra[:,j,:], fd, block_times,
                     mask_replace, mask_valid_blk, noise, interpolate, fill_value)
             hits[iblock, j, :] = fftshift(np.sum(mask_replace, axis=0))
+            means[iblock, j] = 1 / λ
         # skip inverse FFTs and assignment if not required.
         if not detect_only:
             # range inverse STFT
@@ -359,4 +413,4 @@ def remove_loud_tones(
                 nw = len(window)
                 zout[rows, cols] += z_block[:nb, j, :nw]
 
-    return isr, f, hits
+    return means, isr, f, hits

--- a/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/python/packages/isce3/signal/rfi_tone_rank.py
@@ -390,6 +390,13 @@ def remove_loud_tones(
         # TODO could weight by window
         block_ranges[j] = r[(cols.start + cols.stop) // 2]
 
+    # Generate a pool of noise with σ=1 once, and we'll scale it for each
+    # block as needed.  We'll generate a random offset for each block to
+    # increase entropy without having to regenerate noise for each block.
+    max_offset = num_az_blocks * num_range_blocks
+    num_noise = max_offset + np.prod(block_dims)
+    std_noise = circular_gaussian_noise(num_noise)
+
     for iblock, rows in enumerate(az_blocks):
         block_results = []
         # calculate azimuth time of block
@@ -417,9 +424,7 @@ def remove_loud_tones(
             )
             if not detect_only:
                 σ = np.sqrt(0.5 / λ) if λ > 0.0 else 0.0
-                num_noise = min(np.sum(mask_replace),
-                    z_block.shape[1] * 991 // 97)
-                noise = circular_gaussian_noise(num_noise, σ)
+                noise = σ * std_noise[np.random.randint(0, max_offset):]
                 fd = doppler.eval(block_times[iblock], block_ranges[j])
                 cols, window = slices_windows[j]
                 nw = len(window)

--- a/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/python/packages/isce3/signal/rfi_tone_rank.py
@@ -3,6 +3,7 @@ import logging
 import numpy as np
 from scipy.fft import fft, ifft, fftfreq, fftshift
 from . import cola_windows
+from isce3.noise.noise_power_est_func import cpi_slice_gen
 
 log = logging.getLogger("isce3.signal.rfi")
 
@@ -350,7 +351,8 @@ def remove_loud_tones(
 
     slices_windows = list(cola_windows(z.shape[1], block_dims[1]))
     num_range_blocks = len(slices_windows)
-    num_az_blocks = 1 + (z.shape[0] - 1) // block_dims[0]
+    az_blocks = list(cpi_slice_gen(z.shape[0], block_dims[0]))
+    num_az_blocks = len(az_blocks)
     zbshape = (block_dims[0], num_range_blocks, block_dims[1])
     z_block = np.zeros(zbshape, z.dtype)
 
@@ -366,27 +368,20 @@ def remove_loud_tones(
         # TODO could weight by window
         block_ranges[j] = r[(cols.start + cols.stop) // 2]
 
-    for iblock, block_start in enumerate(range(0, z.shape[0], block_dims[0])):
+    for iblock, rows in enumerate(az_blocks):
         block_results = []
-        # last block is smaller
-        nb = min(block_dims[0], z.shape[0] - block_start)
-        block_end = block_start + nb
-        rows = slice(block_start, block_end)
         # calculate azimuth time of block
-        block_times[iblock] = t[block_start + nb // 2]
+        block_times[iblock] = t[rows].mean()
         pulse_times = t[rows]
         # populate valid data mask
         mask_valid[...] = False
-        for i, i_pulse in enumerate(range(block_start, block_end)):
+        for i, i_pulse in enumerate(range(rows.start, rows.stop)):
             for start, end in swaths[:, i_pulse, :]:
                 mask_valid[i, start:end] = True
         # apply window to each range block
         for j, (cols, window) in enumerate(slices_windows):
             nw = len(window)
-            z_block[:nb, j, :nw] = window[None, :] * z[rows, cols]
-        # crop for last azimuth block
-        if nb < block_dims[0]:
-            z_block = z_block[:nb, ...]
+            z_block[:, j, :nw] = window[None, :] * z[rows, cols]
         # Range STFT.  Use consistent FFT size even for edges where window
         # may be shorter so that frequency metadata are consistent.
         spectra = fft(z_block, n=block_dims[1], axis=2)
@@ -406,8 +401,8 @@ def remove_loud_tones(
                 fd = doppler.eval(block_times[iblock], block_ranges[j])
                 cols, window = slices_windows[j]
                 nw = len(window)
-                mask_valid_blk = np.zeros((nb, block_dims[1]), bool)
-                mask_valid_blk[:, :nw] = mask_valid[:nb, cols]
+                mask_valid_blk = np.zeros(block_dims, bool)
+                mask_valid_blk[:, :nw] = mask_valid[:, cols]
                 spectra[:, j, :] = fill_missing(spectra[:,j,:], fd, pulse_times,
                     mask_replace, mask_valid_blk, noise, interpolate, fill_value)
             hits[iblock, j, :] = fftshift(np.mean(mask_replace, axis=0))
@@ -420,7 +415,7 @@ def remove_loud_tones(
             zout[rows, ...] = 0
             for j, (cols, window) in enumerate(slices_windows):
                 nw = len(window)
-                zout[rows, cols] += z_block[:nb, j, :nw]
+                zout[rows, cols] += z_block[:, j, :nw]
 
     return block_times, block_ranges, f, means, isr, hits
 

--- a/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/python/packages/isce3/signal/rfi_tone_rank.py
@@ -27,7 +27,7 @@ def exp_from_quantile(p, vp, bw=1.0):
     Returns
     -------
     λ : float | np.ndarray
-        The rate parameter of the lifted expononential distribution.
+        The rate parameter of the lifted exponential distribution.
 
     Notes
     -----

--- a/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/python/packages/isce3/signal/rfi_tone_rank.py
@@ -33,7 +33,7 @@ def get_spectral_mask(
     k = round(reference_quantile * n)
     kth_power = np.partition(power_spectra, k)[k]
     if kth_power == 0.0:
-        return np.zeros(spectra.shape, dtype=bool), 0.0
+        return np.zeros(spectra.shape, dtype=bool), 0.0, 0.0
     # Estimate the parameter of a lifted exponential distribution.
     λ = exp_from_quantile(reference_quantile, kth_power, bandwidth)
     # Determine threshold.  Since we've estimated a statistical model, we can
@@ -45,18 +45,96 @@ def get_spectral_mask(
     mask = power_spectra >= too_loud
     isr = np.sum(power_spectra[mask]) / np.sum(power_spectra[~mask])
     mask.shape = spectra.shape
-    return mask, isr
+    return mask, isr, λ
+
+
+def fill_missing(z, fd, t, mask_replace, mask_valid, noise):
+    m, n = z.shape
+    if len(t) != m:
+        raise ValueError(f"expected len(t)=={m} got {len(t)}")
+    if mask_replace.shape != (m, n):
+        raise ValueError(f"{mask_replace.shape=} does not match {z.shape=}")
+    if mask_valid.shape != (m, n):
+        raise ValueError(f"{mask_valid.shape=} does not match {z.shape=}")
+
+    # Deramp Doppler.
+    deramp = np.exp(-1j * 2 * np.pi * fd * t).astype(z.dtype)
+    zout = deramp[:, None] * z
+
+    for i in range(m):
+        # Previous and next pulse, with reflection boundary condition.
+        iprev, inext = i - 1, i + 1
+        if i == 0:
+            iprev = i + 1
+        if i == m - 1:
+            inext = i - 1
+
+        # Non-uniform time sampling, so let's weight closer samples more.
+        # NOTE abs() since we might've reflected.
+        dt_prev = abs(t[i] - t[iprev])
+        dt_next = abs(t[inext] - t[i])
+        w_prev = dt_next / (dt_prev + dt_next)
+        w_next = dt_prev / (dt_prev + dt_next)
+
+        # copy for modification
+        cols_need_replacement = mask_replace[i, :].copy()
+
+        # Four cases for replacement:
+        # 1. prev and next both valid -> lerp between them
+        j = np.where(mask_valid[iprev, :] & mask_valid[inext, :]
+            & cols_need_replacement)[0]
+        zout[i, j] = w_prev * z[iprev, j] + w_next * z[inext, j]
+        cols_need_replacement[j] = False
+
+        # 2. only prev valid. use it
+        j = np.where(mask_valid[iprev, :] & cols_need_replacement)[0]
+        zout[i, j] = z[iprev, j]
+        cols_need_replacement[j] = False
+
+        # 3. only next valid. use it
+        j = np.where(mask_valid[inext, :] & cols_need_replacement)[0]
+        zout[i, j] = z[inext, j]
+        cols_need_replacement[j] = False
+
+        # 4. prev and next both invalid -> fill noise
+        j = np.where(cols_need_replacement)[0]
+        noise_idx = ((i * n) + j) % len(noise)
+        zout[i, j] = noise[noise_idx]
+
+    # Put Doppler back on.
+    zout *= deramp[:, None].conj()
+    return zout
+
+
+def circular_gaussian_noise(n, σ=1, dtype=np.complex64):
+    return σ * (np.random.normal(size=n) + 1j * np.random.normal(size=n))
 
 
 def remove_loud_tones(
     z,
-    block_dims,
+    t,
+    r,
+    swaths,
+    doppler,
+    block_dims=(512, 1024),
     reference_quantile=0.5,
     nominal_false_positive_rate=0.0005,
     bandwidth=5 / 6,
     detect_only=False,
     zout=None,
 ):
+    """
+    t : np.ndarray [float64]
+        Pulse times (seconds since orbit/grid epoch).
+    r : isce3.core.Linspace
+        Range to each sample (meters).
+    swaths : np.ndarray [int]
+        Valid subswath samples, dims = (ns, nt, 2) where ns is the number of
+        sub-swaths, nt is the number of pulses, and the trailing dimension is
+        the [start, stop) indices of the sub-swath.
+    doppler : isce3.core.LUT2d [double]
+        Raw data Doppler look up table.  Must be valid over entire grid.
+    """
     # Check inputs
     if not (z.ndim == len(block_dims) == 2):
         raise ValueError("Data and block_dims must be 2-dimensional")
@@ -81,6 +159,8 @@ def remove_loud_tones(
     if (not detect_only) and (zout.shape != z.shape):
         raise ValueError("output shape must match input shape")
 
+    mask_valid = np.zeros((block_dims[0], z.shape[1]), bool)
+
     slices_windows = list(cola_windows(z.shape[1], block_dims[1]))
     num_range_blocks = len(slices_windows)
     num_az_blocks = 1 + (z.shape[0] - 1) // block_dims[0]
@@ -92,12 +172,24 @@ def remove_loud_tones(
     isr = np.zeros(meta_shape)
     hits = np.zeros(meta_shape + (block_dims[1],), dtype=np.uint32)
 
+    block_ranges = np.zeros(num_range_blocks)
+    for j, (cols, _) in enumerate(slices_windows):
+        block_ranges[j] = r[(cols.start + cols.stop) // 2]
+
     for iblock, block_start in enumerate(range(0, z.shape[0], block_dims[0])):
         block_results = []
         # last block is smaller
         nb = min(block_dims[0], z.shape[0] - block_start)
         block_end = block_start + nb
         rows = slice(block_start, block_end)
+        # calculate azimuth time of block
+        block_time_mid = t[block_start + nb // 2]
+        block_times = t[rows]
+        # populate valid data mask
+        mask_valid[...] = False
+        for i, i_pulse in enumerate(range(block_start, block_end)):
+            for start, end in swaths[:, i_pulse, :]:
+                mask_valid[i, start:end] = True
         # apply window to each range block
         for j, (cols, window) in enumerate(slices_windows):
             nw = len(window)
@@ -110,15 +202,25 @@ def remove_loud_tones(
         spectra = fft(z_block, n=block_dims[1], axis=2)
         # filter RFI
         for j in range(z_block.shape[1]):
-            mask, isr[iblock,j] = get_spectral_mask(
+            mask_replace, isr[iblock,j], λ = get_spectral_mask(
                 spectra[:, j, :],
                 reference_quantile,
                 nominal_false_positive_rate,
                 bandwidth,
             )
             if not detect_only:
-                spectra[:, j, :][mask] = 0.0
-            hits[iblock, j, :] = fftshift(np.sum(mask, axis=0))
+                σ = np.sqrt(0.5 / λ) if λ > 0.0 else 0.0
+                num_noise = min(np.sum(mask_replace),
+                    z_block.shape[1] * 991 // 97)
+                noise = circular_gaussian_noise(num_noise, σ)
+                fd = doppler.eval(block_time_mid, block_ranges[j])
+                cols, window = slices_windows[j]
+                nw = len(window)
+                mask_valid_blk = np.zeros((nb, block_dims[1]), bool)
+                mask_valid_blk[:, :nw] = mask_valid[:nb, cols]
+                spectra[:, j, :] = fill_missing(spectra[:,j,:], fd, block_times,
+                    mask_replace, mask_valid_blk, noise)
+            hits[iblock, j, :] = fftshift(np.sum(mask_replace, axis=0))
         # skip inverse FFTs and assignment if not required.
         if not detect_only:
             # range inverse STFT

--- a/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/python/packages/isce3/signal/rfi_tone_rank.py
@@ -411,7 +411,7 @@ def remove_loud_tones(
                 spectra[:, j, :] = fill_missing(spectra[:,j,:], fd, pulse_times,
                     mask_replace, mask_valid_blk, noise, interpolate, fill_value)
             hits[iblock, j, :] = fftshift(np.mean(mask_replace, axis=0))
-            means[iblock, j] = 1 / λ
+            means[iblock, j] = 1 / λ if λ > 0.0 else 0.0
         # skip inverse FFTs and assignment if not required.
         if not detect_only:
             # range inverse STFT

--- a/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/python/packages/isce3/signal/rfi_tone_rank.py
@@ -358,7 +358,7 @@ def remove_loud_tones(
     meta_shape = (num_az_blocks, num_range_blocks)
     isr = np.zeros(meta_shape)
     means = np.zeros(meta_shape)
-    hits = np.zeros(meta_shape + (block_dims[1],), dtype=np.uint32)
+    hits = np.zeros(meta_shape + (block_dims[1],), dtype=np.float32)
 
     block_times = np.zeros(num_az_blocks)
     block_ranges = np.zeros(num_range_blocks)

--- a/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/python/packages/isce3/signal/rfi_tone_rank.py
@@ -427,7 +427,6 @@ def remove_loud_tones(
                 noise = σ * std_noise[np.random.randint(0, max_offset):]
                 fd = doppler.eval(block_times[iblock], block_ranges[j])
                 cols, window = slices_windows[j]
-                nw = len(window)
                 valid_rows = ((~mask_valid[:, cols]).mean(axis=1)
                     <= max_gap_fraction)
                 spectra[:, j, :] = fill_missing(spectra[:,j,:], fd, pulse_times,

--- a/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/python/packages/isce3/signal/rfi_tone_rank.py
@@ -292,6 +292,15 @@ def remove_loud_tones(
 
     Returns
     -------
+    block_times : np.ndarray[float]
+        Azimuth time at center of each azimuth block in seconds since epoch,
+        length num_az_blocks.
+    block_ranges : np.ndarray[float]
+        Slant range at center of each range block in meters,
+        length num_range_blocks.
+    f : np.ndarray[float]
+        Normalized frequency axis for hits array, length block_dims[1].
+        Units are cycles per sample.
     means : np.ndarray[float]
         Estimated mean signal power per block from lifted exponential model,
         shape (num_az_blocks, num_range_blocks). Equal to 1/λ where λ is the
@@ -299,9 +308,6 @@ def remove_loud_tones(
     isr : np.ndarray[float]
         Interference-to-signal ratio per block,
         shape (num_az_blocks, num_range_blocks).
-    f : np.ndarray[float]
-        Normalized frequency axis for hits array, length block_dims[1].
-        Units are cycles per sample.
     hits : np.ndarray[uint32]
         Count of detected RFI samples at each frequency bin,
         shape (num_az_blocks, num_range_blocks, block_dims[1]).
@@ -353,8 +359,10 @@ def remove_loud_tones(
     means = np.zeros(meta_shape)
     hits = np.zeros(meta_shape + (block_dims[1],), dtype=np.uint32)
 
+    block_times = np.zeros(num_az_blocks)
     block_ranges = np.zeros(num_range_blocks)
     for j, (cols, _) in enumerate(slices_windows):
+        # TODO could weight by window
         block_ranges[j] = r[(cols.start + cols.stop) // 2]
 
     for iblock, block_start in enumerate(range(0, z.shape[0], block_dims[0])):
@@ -364,8 +372,8 @@ def remove_loud_tones(
         block_end = block_start + nb
         rows = slice(block_start, block_end)
         # calculate azimuth time of block
-        block_time_mid = t[block_start + nb // 2]
-        block_times = t[rows]
+        block_times[iblock] = t[block_start + nb // 2]
+        pulse_times = t[rows]
         # populate valid data mask
         mask_valid[...] = False
         for i, i_pulse in enumerate(range(block_start, block_end)):
@@ -394,12 +402,12 @@ def remove_loud_tones(
                 num_noise = min(np.sum(mask_replace),
                     z_block.shape[1] * 991 // 97)
                 noise = circular_gaussian_noise(num_noise, σ)
-                fd = doppler.eval(block_time_mid, block_ranges[j])
+                fd = doppler.eval(block_times[iblock], block_ranges[j])
                 cols, window = slices_windows[j]
                 nw = len(window)
                 mask_valid_blk = np.zeros((nb, block_dims[1]), bool)
                 mask_valid_blk[:, :nw] = mask_valid[:nb, cols]
-                spectra[:, j, :] = fill_missing(spectra[:,j,:], fd, block_times,
+                spectra[:, j, :] = fill_missing(spectra[:,j,:], fd, pulse_times,
                     mask_replace, mask_valid_blk, noise, interpolate, fill_value)
             hits[iblock, j, :] = fftshift(np.sum(mask_replace, axis=0))
             means[iblock, j] = 1 / λ
@@ -413,4 +421,4 @@ def remove_loud_tones(
                 nw = len(window)
                 zout[rows, cols] += z_block[:nb, j, :nw]
 
-    return means, isr, f, hits
+    return block_times, block_ranges, f, means, isr, hits

--- a/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/python/packages/isce3/signal/rfi_tone_rank.py
@@ -60,6 +60,47 @@ def get_spectral_mask(
     nominal_false_positive_rate=0.0005,
     bandwidth=5 / 6,
 ):
+    """
+    Detect RFI in spectral domain data using lifted exponential model.
+
+    Uses a statistical model to identify spectral samples that are anomalously
+    loud compared to the expected distribution of the signal. The method assumes
+    that the power spectrum follows a lifted exponential distribution and uses
+    a quantile of the data to estimate the distribution parameters.
+
+    Parameters
+    ----------
+    spectra : np.ndarray
+        Complex spectral data, arbitrary shape.
+    reference_quantile : float, optional
+        Quantile (in [1-bandwidth, 1)) used to estimate the rate parameter
+        of the lifted exponential distribution. Default is 0.5 (median).
+    nominal_false_positive_rate : float, optional
+        Target false positive rate for RFI detection, in (0, 1).
+        Lower values result in more conservative detection (fewer false alarms
+        but potentially missed RFI).
+    bandwidth : float, optional
+        Fraction of samples in (0, 1] assumed to follow the exponential
+        distribution (as opposed to being noise, filter roll-off, etc).
+
+    Returns
+    -------
+    mask : np.ndarray[bool]
+        Boolean mask marking detected RFI samples, same shape as spectra.
+        True indicates RFI detection (sample exceeds threshold).
+    isr : float
+        Interference-to-signal ratio: ratio of total power in detected RFI
+        samples to total power in clean samples.
+    λ : float
+        Estimated rate parameter of the lifted exponential distribution.
+
+    Notes
+    -----
+    The detection threshold is determined by inverting the cumulative
+    distribution function of the lifted exponential model at the desired
+    false positive rate. See exp_from_quantile for details on the
+    statistical model.
+    """
     n = np.prod(spectra.shape)
     power_spectra = abs2(spectra)
     power_spectra.shape = (n,)

--- a/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/python/packages/isce3/signal/rfi_tone_rank.py
@@ -282,7 +282,8 @@ def remove_loud_tones(
         detected RFI samples.
     zout : np.ndarray[complex64], optional
         Output buffer for mitigated data. Must have same shape as z.
-        If None, z is modified in-place.
+        If None, z is modified in-place.  In that case some rows will be cleaned
+        twice if block_dims[0] doesn't divide evenly into z.shape[0].
     interpolate : bool, optional
         If True, attempt linear/nearest-neighbor interpolation for RFI samples.
         If False, replace directly with fill_value.

--- a/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/python/packages/isce3/signal/rfi_tone_rank.py
@@ -167,6 +167,10 @@ def fill_missing(z, fd, t, mask_replace, mask_valid, noise, interpolate=True,
         raise ValueError(f"{mask_replace.shape=} does not match {z.shape=}")
     if mask_valid.shape != (m, n):
         raise ValueError(f"{mask_valid.shape=} does not match {z.shape=}")
+    if interpolate and m < 2:
+        log.warning(f"Disabling interpolation for block of {m} rows "
+            "because there are no neighbors to use for interpolation.")
+        interpolate = False
 
     # Deramp Doppler.
     deramp = np.exp(-1j * 2 * np.pi * fd * t).astype(z.dtype)

--- a/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/python/packages/isce3/signal/rfi_tone_rank.py
@@ -380,8 +380,8 @@ def remove_loud_tones(
 
     f = fftshift(fftfreq(block_dims[1]))
     meta_shape = (num_az_blocks, num_range_blocks)
-    isr = np.zeros(meta_shape)
-    means = np.zeros(meta_shape)
+    isr = np.zeros(meta_shape, dtype=np.float32)
+    means = np.zeros(meta_shape, dtype=np.float32)
     hits = np.zeros(meta_shape + (block_dims[1],), dtype=np.float32)
 
     block_times = np.zeros(num_az_blocks)

--- a/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/python/packages/isce3/signal/rfi_tone_rank.py
@@ -308,9 +308,10 @@ def remove_loud_tones(
     isr : np.ndarray[float]
         Interference-to-signal ratio per block,
         shape (num_az_blocks, num_range_blocks).
-    hits : np.ndarray[uint32]
-        Count of detected RFI samples at each frequency bin,
+    hits : np.ndarray[float]
+        Fraction of pulses with detected RFI at each frequency bin,
         shape (num_az_blocks, num_range_blocks, block_dims[1]).
+        Values range from 0 (no RFI detected) to 1 (RFI detected in all pulses).
 
     Notes
     -----
@@ -409,7 +410,7 @@ def remove_loud_tones(
                 mask_valid_blk[:, :nw] = mask_valid[:nb, cols]
                 spectra[:, j, :] = fill_missing(spectra[:,j,:], fd, pulse_times,
                     mask_replace, mask_valid_blk, noise, interpolate, fill_value)
-            hits[iblock, j, :] = fftshift(np.sum(mask_replace, axis=0))
+            hits[iblock, j, :] = fftshift(np.mean(mask_replace, axis=0))
             means[iblock, j] = 1 / λ
         # skip inverse FFTs and assignment if not required.
         if not detect_only:

--- a/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/python/packages/isce3/signal/rfi_tone_rank.py
@@ -423,3 +423,38 @@ def remove_loud_tones(
                 zout[rows, cols] += z_block[:nb, j, :nw]
 
     return block_times, block_ranges, f, means, isr, hits
+
+
+def write_tone_rank_results(group: h5py.Group, t, r, freq, means, isr, hits):
+    m, n = means.shape
+    if isr.shape != (m, n):
+        raise ValueError(f"Expected isr.shape={(m,n)} but got {isr.shape}")
+    nf = len(freq)
+    if hits.shape != (m, n, nf):
+        raise ValueError(f"Expected hits.shape={(m,n,nf)} but got {hits.shape}")
+
+    ds_time = group.create_dataset("nativeDopplerTime", data=t.astype("f8"))
+    ds_range = group.create_dataset("slantRange", data=r.astype("f8"))
+    ds_freq = group.create_dataset("frequency", data=freq.astype("f8"))
+
+    ds_mean = group.create_dataset("signalMean", data=means.astype("f4"))
+    ds_hits = group.create_dataset("hitCount", data=hits.astype("f4"))
+    ds_isr = group.create_dataset("interferenceSignalRatio",
+        data=isr.astype("f4"))
+
+    ds_time.attrs["description"] = np.bytes_("Raw data slow-time midpoint of "
+        "each analysis block")
+    ds_time.attrs["units"] = np.bytes_("s")
+    ds_range.attrs["description"] = np.bytes_("Raw data slant range midpoint "
+        "of each analysis block")
+    ds_range.attrs["units"] = np.bytes_("m")
+    ds_freq.attrs["description"] = np.bytes_("Frequency axis for hitCount")
+    ds_freq.attrs["units"] = np.bytes_("Hz")
+
+    ds_mean.attrs["description"] = np.bytes_("Estimated mean signal power per "
+        "block from lifted exponential model.  Expressed in linear power units,"
+        " e.g., DN^2")
+    ds_hits.attrs["description"] = np.bytes_("Interference-to-signal ratio.  "
+        "Expressed in linear power units, e.g., DN^2 / DN^2")
+    ds_isr.attrs["description"] = np.bytes_("Count of detected RFI samples at "
+        "each frequency bin")

--- a/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/python/packages/isce3/signal/rfi_tone_rank.py
@@ -137,7 +137,9 @@ def fill_missing(z, fd, t, mask_replace, valid_rows, noise, interpolate=True,
     z : np.ndarray
         Complex spectral data to fill, shape (m, n)
     fd : float
-        Doppler centroid frequency in Hz
+        Doppler centroid frequency in Hz.  It is not scaled for each frequency
+        bin in `z`.  If wideband processing is needed, just baseband `z` before
+        calling this function and set `fd=0`.
     t : np.ndarray
         Pulse times in seconds since epoch, length m
     mask_replace : np.ndarray

--- a/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/python/packages/isce3/signal/rfi_tone_rank.py
@@ -61,6 +61,9 @@ def fill_missing(z, fd, t, mask_replace, mask_valid, noise):
     deramp = np.exp(-1j * 2 * np.pi * fd * t).astype(z.dtype)
     zout = deramp[:, None] * z
 
+    # Exclude RFI samples from being used as interpolation sources.
+    mask_valid_clean = mask_valid & ~mask_replace
+
     for i in range(m):
         # Previous and next pulse, with reflection boundary condition.
         iprev, inext = i - 1, i + 1
@@ -81,19 +84,19 @@ def fill_missing(z, fd, t, mask_replace, mask_valid, noise):
 
         # Four cases for replacement:
         # 1. prev and next both valid -> lerp between them
-        j = np.where(mask_valid[iprev, :] & mask_valid[inext, :]
+        j = np.where(mask_valid_clean[iprev, :] & mask_valid_clean[inext, :]
             & cols_need_replacement)[0]
-        zout[i, j] = w_prev * z[iprev, j] + w_next * z[inext, j]
+        zout[i, j] = w_prev * zout[iprev, j] + w_next * zout[inext, j]
         cols_need_replacement[j] = False
 
         # 2. only prev valid. use it
-        j = np.where(mask_valid[iprev, :] & cols_need_replacement)[0]
-        zout[i, j] = z[iprev, j]
+        j = np.where(mask_valid_clean[iprev, :] & cols_need_replacement)[0]
+        zout[i, j] = zout[iprev, j]
         cols_need_replacement[j] = False
 
         # 3. only next valid. use it
-        j = np.where(mask_valid[inext, :] & cols_need_replacement)[0]
-        zout[i, j] = z[inext, j]
+        j = np.where(mask_valid_clean[inext, :] & cols_need_replacement)[0]
+        zout[i, j] = zout[inext, j]
         cols_need_replacement[j] = False
 
         # 4. prev and next both invalid -> fill noise

--- a/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/python/packages/isce3/signal/rfi_tone_rank.py
@@ -16,13 +16,15 @@ def exp_from_quantile(p, vp, bw=1.0):
     Parameters
     ----------
     p : float | np.ndarray
-        Percentile in [1-bw, 1).  For example, 0.5 for the median.
+        Quantile in [1-bw, 1).  For example, 0.5 for the median.
     vp : float | np.ndarray
-        Value corresponding to the given percentile.  For example, the median
+        Value corresponding to the given quantile.  For example, the median
         value.
     bw : float, optional
         The portion of the distribution governed by an exponential distribution.
-        See notes below.  Values in interval (0, 1].
+        In the context of the tone-rank algorithm, it's the chirp bandwidth
+        normalized by the sample rate.  Values in interval (0, 1].
+        See notes below.
 
     Returns
     -------

--- a/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/python/packages/isce3/signal/rfi_tone_rank.py
@@ -1,0 +1,130 @@
+import logging
+import numpy as np
+from scipy.fft import fft, ifft, fftfreq, fftshift
+from . import cola_windows
+
+log = logging.getLogger("isce3.signal.rfi")
+
+
+def exp_from_quantile(p, vp, bw=1.0):
+    p = np.asarray(p)
+    if not np.all(p >= (1.0 - bw)):
+        raise ValueError("invalid quantile for lifted exponential")
+    vp = np.asarray(vp)
+    return -np.log((1 - p) / bw) / vp
+
+
+def abs2(z):
+    return z.real**2 + z.imag**2
+
+
+def get_spectral_mask(
+    spectra,
+    reference_quantile=0.5,
+    nominal_false_positive_rate=0.0005,
+    bandwidth=5 / 6,
+):
+    n = np.prod(spectra.shape)
+    power_spectra = abs2(spectra)
+    power_spectra.shape = (n,)
+    # partition seems to be a little faster than quantile, I guess because the
+    # latter does a full sort and interpolates?  For large n the difference is
+    # small.
+    k = round(reference_quantile * n)
+    kth_power = np.partition(power_spectra, k)[k]
+    # Estimate the parameter of a lifted exponential distribution.
+    λ = exp_from_quantile(reference_quantile, kth_power, bandwidth)
+    # Determine threshold.  Since we've estimated a statistical model, we can
+    # achieve a specified nominal false positive rate by thresholding the
+    # nominal CDF at one minus that value.
+    q = 1.0 - nominal_false_positive_rate
+    too_loud = exp_from_quantile(q, λ, bandwidth)
+    # Use threshold to generate mask.
+    mask = power_spectra >= too_loud
+    isr = np.sum(power_spectra[mask]) / np.sum(power_spectra[~mask])
+    mask.shape = spectra.shape
+    return mask, isr
+
+
+def remove_loud_tones(
+    z,
+    block_dims,
+    reference_quantile=0.5,
+    nominal_false_positive_rate=0.0005,
+    bandwidth=5 / 6,
+    detect_only=False,
+    zout=None,
+):
+    # Check inputs
+    if not (z.ndim == len(block_dims) == 2):
+        raise ValueError("Data and block_dims must be 2-dimensional")
+    block_dims = (block_dims[0], block_dims[1])  # copy
+    for idim in (0, 1):
+        if block_dims[idim] > z.shape[idim]:
+            log.warning(f"Truncating block_dims[{idim}] to z.shape[{idim}]")
+            block_dims[idim] = z.shape[idim]
+    if not (0 < nominal_false_positive_rate <= 1):
+        raise ValueError(
+            "nominal_false_positive rate must be normalized to interval (0, 1]"
+        )
+    if not (0 < bandwidth <= 1):
+        raise ValueError("bandwidth must be normalized to interval (0, 1]")
+    if not ((1 - bandwidth) < reference_quantile < 1):
+        raise ValueError(
+            "reference_quantile must fall in the normalized signal "
+            f"distribution ({1 - bandwidth}, 1)"
+        )
+    if zout is None:
+        zout = z
+    if (not detect_only) and (zout.shape != z.shape):
+        raise ValueError("output shape must match input shape")
+
+    slices_windows = list(cola_windows(z.shape[1], block_dims[1]))
+    num_range_blocks = len(slices_windows)
+    num_az_blocks = 1 + (z.shape[0] - 1) // block_dims[0]
+    zbshape = (block_dims[0], num_range_blocks, block_dims[1])
+    z_block = np.zeros(zbshape, z.dtype)
+
+    f = fftshift(fftfreq(block_dims[1]))
+    meta_shape = (num_az_blocks, num_range_blocks)
+    isr = np.zeros(meta_shape)
+    hits = np.zeros(meta_shape + (block_dims[1],), dtype=np.uint32)
+
+    for iblock, block_start in enumerate(range(0, z.shape[0], block_dims[0])):
+        block_results = []
+        # last block is smaller
+        nb = min(block_dims[0], z.shape[0] - block_start)
+        block_end = block_start + nb
+        rows = slice(block_start, block_end)
+        # apply window to each range block
+        for j, (cols, window) in enumerate(slices_windows):
+            nw = len(window)
+            z_block[:nb, j, :nw] = window[None, :] * z[rows, cols]
+        # crop for last azimuth block
+        if nb < block_dims[0]:
+            z_block = z_block[:nb, ...]
+        # Range STFT.  Use consistent FFT size even for edges where window
+        # may be shorter so that frequency metadata are consistent.
+        spectra = fft(z_block, n=block_dims[1], axis=2)
+        # filter RFI
+        for j in range(z_block.shape[1]):
+            mask, isr[iblock,j] = get_spectral_mask(
+                spectra[:, j, :],
+                reference_quantile,
+                nominal_false_positive_rate,
+                bandwidth,
+            )
+            if not detect_only:
+                spectra[:, j, :][mask] = 0.0
+            hits[iblock, j, :] = fftshift(np.sum(mask, axis=0))
+        # skip inverse FFTs and assignment if not required.
+        if not detect_only:
+            # range inverse STFT
+            z_block[...] = ifft(spectra, axis=2)
+            # sum COLA range blocks into output buffer
+            zout[rows, ...] = 0
+            for j, (cols, window) in enumerate(slices_windows):
+                nw = len(window)
+                zout[rows, cols] += z_block[:nb, j, :nw]
+
+    return isr, f, hits

--- a/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/python/packages/isce3/signal/rfi_tone_rank.py
@@ -7,6 +7,42 @@ log = logging.getLogger("isce3.signal.rfi")
 
 
 def exp_from_quantile(p, vp, bw=1.0):
+    """
+    Determine the rate parameter of the lifted exponential distribution from a
+    quantile and its corresponding value.
+
+    Parameters
+    ----------
+    p : float | np.ndarray
+        Percentile in [1-bw, 1).  For example, 0.5 for the median.
+    vp : float | np.ndarray
+        Value corresponding to the given percentile.  For example, the median
+        value.
+    bw : float, optional
+        The portion of the distribution governed by an exponential distribution.
+        See notes below.  Values in interval (0, 1].
+
+    Returns
+    -------
+    λ : float | np.ndarray
+        The rate parameter of the lifted expononential distribution.
+
+    Notes
+    -----
+    The definition of the "lifted" exponential distribution is as follows:
+        cdf(x) = (1 - bw) * u(x - x0) + bw * (1 - exp(-λ * x))
+    where u(x) is the unit step function, x0 is some small value (e.g., the
+    noise floor), and other parameters are as described above.
+
+    The idea here is that spectral power in the chirp band should follow an
+    exponential distribution, while the values outside the chirp band will be
+    smaller and follow some other distribution whose shape we don't care about
+    and just model with a step function.
+
+    The formula is the same to solve for a value given the rate parameter.
+    That is, you can also use this function to solve
+        vp = exp_from_quantile(p, λ, bw)
+    """
     p = np.asarray(p)
     if not np.all(p >= (1.0 - bw)):
         raise ValueError("invalid quantile for lifted exponential")

--- a/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/python/packages/isce3/signal/rfi_tone_rank.py
@@ -48,7 +48,39 @@ def get_spectral_mask(
     return mask, isr, λ
 
 
-def fill_missing(z, fd, t, mask_replace, mask_valid, noise):
+def fill_missing(z, fd, t, mask_replace, mask_valid, noise, interpolate=True,
+                 fill_value="noise"):
+    """
+    Fill missing/RFI-contaminated samples in spectral domain data.
+
+    Parameters
+    ----------
+    z : np.ndarray
+        Complex spectral data to fill, shape (m, n)
+    fd : float
+        Doppler centroid frequency in Hz
+    t : np.ndarray
+        Pulse times in seconds since epoch, length m
+    mask_replace : np.ndarray
+        Boolean mask marking samples to replace, shape (m, n)
+    mask_valid : np.ndarray
+        Boolean mask marking valid subswath samples, shape (m, n)
+    noise : np.ndarray
+        Random noise samples in 1D array for fallback replacement.  Values may
+        be used multiple times if length is less numpy.prod((m, n)).
+    interpolate : bool, optional
+        If True, attempt linear/nearest-neighbor interpolation. If False,
+        replace directly with fill_value. Default is True.
+    fill_value : str, optional
+        Fallback strategy when interpolation fails or is disabled.
+        "noise": use provided noise vector (default)
+        "zero": use zero
+
+    Returns
+    -------
+    zout : np.ndarray
+        Filled data, same shape as z
+    """
     m, n = z.shape
     if len(t) != m:
         raise ValueError(f"expected len(t)=={m} got {len(t)}")
@@ -65,44 +97,51 @@ def fill_missing(z, fd, t, mask_replace, mask_valid, noise):
     mask_valid_clean = mask_valid & ~mask_replace
 
     for i in range(m):
-        # Previous and next pulse, with reflection boundary condition.
-        iprev, inext = i - 1, i + 1
-        if i == 0:
-            iprev = i + 1
-        if i == m - 1:
-            inext = i - 1
-
-        # Non-uniform time sampling, so let's weight closer samples more.
-        # NOTE abs() since we might've reflected.
-        dt_prev = abs(t[i] - t[iprev])
-        dt_next = abs(t[inext] - t[i])
-        w_prev = dt_next / (dt_prev + dt_next)
-        w_next = dt_prev / (dt_prev + dt_next)
-
         # copy for modification
         cols_need_replacement = mask_replace[i, :].copy()
 
-        # Four cases for replacement:
-        # 1. prev and next both valid -> lerp between them
-        j = np.where(mask_valid_clean[iprev, :] & mask_valid_clean[inext, :]
-            & cols_need_replacement)[0]
-        zout[i, j] = w_prev * zout[iprev, j] + w_next * zout[inext, j]
-        cols_need_replacement[j] = False
+        if interpolate:
+            # Previous and next pulse, with reflection boundary condition.
+            iprev, inext = i - 1, i + 1
+            if i == 0:
+                iprev = i + 1
+            if i == m - 1:
+                inext = i - 1
 
-        # 2. only prev valid. use it
-        j = np.where(mask_valid_clean[iprev, :] & cols_need_replacement)[0]
-        zout[i, j] = zout[iprev, j]
-        cols_need_replacement[j] = False
+            # Non-uniform time sampling, so let's weight closer samples more.
+            # NOTE abs() since we might've reflected.
+            dt_prev = abs(t[i] - t[iprev])
+            dt_next = abs(t[inext] - t[i])
+            w_prev = dt_next / (dt_prev + dt_next)
+            w_next = dt_prev / (dt_prev + dt_next)
 
-        # 3. only next valid. use it
-        j = np.where(mask_valid_clean[inext, :] & cols_need_replacement)[0]
-        zout[i, j] = zout[inext, j]
-        cols_need_replacement[j] = False
+            # Four cases for replacement:
+            # 1. prev and next both valid -> lerp between them
+            j = np.where(mask_valid_clean[iprev, :] & mask_valid_clean[inext, :]
+                & cols_need_replacement)[0]
+            zout[i, j] = w_prev * zout[iprev, j] + w_next * zout[inext, j]
+            cols_need_replacement[j] = False
 
-        # 4. prev and next both invalid -> fill noise
+            # 2. only prev valid. use it
+            j = np.where(mask_valid_clean[iprev, :] & cols_need_replacement)[0]
+            zout[i, j] = zout[iprev, j]
+            cols_need_replacement[j] = False
+
+            # 3. only next valid. use it
+            j = np.where(mask_valid_clean[inext, :] & cols_need_replacement)[0]
+            zout[i, j] = zout[inext, j]
+            cols_need_replacement[j] = False
+
+        # 4. Fallback for remaining samples (or all if not interpolating)
         j = np.where(cols_need_replacement)[0]
-        noise_idx = ((i * n) + j) % len(noise)
-        zout[i, j] = noise[noise_idx]
+        if len(j) > 0:
+            if fill_value == "zero":
+                zout[i, j] = 0.0
+            elif fill_value == "noise":
+                noise_idx = ((i * n) + j) % len(noise)
+                zout[i, j] = noise[noise_idx]
+            else:
+                raise ValueError(f"Invalid fill_value: {fill_value}")
 
     # Put Doppler back on.
     zout *= deramp[:, None].conj()
@@ -125,6 +164,8 @@ def remove_loud_tones(
     bandwidth=5 / 6,
     detect_only=False,
     zout=None,
+    interpolate=True,
+    fill_value="noise",
 ):
     """
     t : np.ndarray [float64]
@@ -137,6 +178,13 @@ def remove_loud_tones(
         the [start, stop) indices of the sub-swath.
     doppler : isce3.core.LUT2d [double]
         Raw data Doppler look up table.  Must be valid over entire grid.
+    interpolate : bool, optional
+        If True, attempt linear/nearest-neighbor interpolation for RFI samples.
+        If False, replace directly with fill_value. Default is True.
+    fill_value : str, optional
+        Fallback value when interpolation fails or is disabled.
+        "noise": use random Gaussian noise (default)
+        "zero": use zero
     """
     # Check inputs
     if not (z.ndim == len(block_dims) == 2):
@@ -222,7 +270,7 @@ def remove_loud_tones(
                 mask_valid_blk = np.zeros((nb, block_dims[1]), bool)
                 mask_valid_blk[:, :nw] = mask_valid[:nb, cols]
                 spectra[:, j, :] = fill_missing(spectra[:,j,:], fd, block_times,
-                    mask_replace, mask_valid_blk, noise)
+                    mask_replace, mask_valid_blk, noise, interpolate, fill_value)
             hits[iblock, j, :] = fftshift(np.sum(mask_replace, axis=0))
         # skip inverse FFTs and assignment if not required.
         if not detect_only:

--- a/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/python/packages/isce3/signal/rfi_tone_rank.py
@@ -127,7 +127,7 @@ def get_spectral_mask(
     return mask, isr, λ
 
 
-def fill_missing(z, fd, t, mask_replace, mask_valid, noise, interpolate=True,
+def fill_missing(z, fd, t, mask_replace, valid_rows, noise, interpolate=True,
                  fill_value="noise"):
     """
     Fill missing/RFI-contaminated samples in spectral domain data.
@@ -142,8 +142,8 @@ def fill_missing(z, fd, t, mask_replace, mask_valid, noise, interpolate=True,
         Pulse times in seconds since epoch, length m
     mask_replace : np.ndarray
         Boolean mask marking samples to replace, shape (m, n)
-    mask_valid : np.ndarray
-        Boolean mask marking valid subswath samples, shape (m, n)
+    valid_rows : np.ndarray
+        Boolean mask marking valid rows, shape (m,)
     noise : np.ndarray
         Random noise samples in 1D array for fallback replacement.  Values may
         be used multiple times if length is less numpy.prod((m, n)).
@@ -165,8 +165,8 @@ def fill_missing(z, fd, t, mask_replace, mask_valid, noise, interpolate=True,
         raise ValueError(f"expected len(t)=={m} got {len(t)}")
     if mask_replace.shape != (m, n):
         raise ValueError(f"{mask_replace.shape=} does not match {z.shape=}")
-    if mask_valid.shape != (m, n):
-        raise ValueError(f"{mask_valid.shape=} does not match {z.shape=}")
+    if valid_rows.shape != (m,):
+        raise ValueError(f"{valid_rows.shape=} does not match {z.shape[0]=}")
     if interpolate and m < 2:
         log.warning(f"Disabling interpolation for block of {m} rows "
             "because there are no neighbors to use for interpolation.")
@@ -177,7 +177,7 @@ def fill_missing(z, fd, t, mask_replace, mask_valid, noise, interpolate=True,
     zout = deramp[:, None] * z
 
     # Exclude RFI samples from being used as interpolation sources.
-    mask_valid_clean = mask_valid & ~mask_replace
+    mask_valid_clean = valid_rows[:, None] & ~mask_replace
 
     for i in range(m):
         # copy for modification
@@ -249,6 +249,7 @@ def remove_loud_tones(
     zout=None,
     interpolate=True,
     fill_value="noise",
+    max_gap_fraction=0.5,
 ):
     """
     Detect and optionally mitigate narrowband RFI using spectral rank method.
@@ -295,6 +296,10 @@ def remove_loud_tones(
         Fallback value when interpolation fails or is disabled.
         "noise": use random Gaussian noise (default)
         "zero": use zero
+    max_gap_fraction : float, optional
+        Max portion of a row that can be masked by a TX gap before its
+        spectrum is considered invalid (0.0: any gap invalidates row,
+        1.0: ignore gap mask).
 
     Returns
     -------
@@ -406,10 +411,10 @@ def remove_loud_tones(
                 fd = doppler.eval(block_times[iblock], block_ranges[j])
                 cols, window = slices_windows[j]
                 nw = len(window)
-                mask_valid_blk = np.zeros(block_dims, bool)
-                mask_valid_blk[:, :nw] = mask_valid[:, cols]
+                valid_rows = ((~mask_valid[:, cols]).mean(axis=1)
+                    <= max_gap_fraction)
                 spectra[:, j, :] = fill_missing(spectra[:,j,:], fd, pulse_times,
-                    mask_replace, mask_valid_blk, noise, interpolate, fill_value)
+                    mask_replace, valid_rows, noise, interpolate, fill_value)
             hits[iblock, j, :] = fftshift(np.mean(mask_replace, axis=0))
             means[iblock, j] = 1 / λ if λ > 0.0 else 0.0
         # skip inverse FFTs and assignment if not required.

--- a/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/python/packages/isce3/signal/rfi_tone_rank.py
@@ -426,6 +426,44 @@ def remove_loud_tones(
 
 
 def write_tone_rank_results(group: h5py.Group, t, r, freq, means, isr, hits):
+    """
+    Write tone-rank RFI detection results to HDF5 group.
+
+    Creates datasets for time/range/frequency axes and detection results
+    (signal mean, interference-to-signal ratio, and hit counts) with
+    appropriate metadata attributes.
+
+    Parameters
+    ----------
+    group : h5py.Group
+        HDF5 group to write datasets into.
+    t : np.ndarray[float]
+        Azimuth times at center of each azimuth block in seconds since epoch,
+        length num_az_blocks. Written as "nativeDopplerTime" dataset.
+    r : np.ndarray[float]
+        Slant ranges at center of each range block in meters,
+        length num_range_blocks. Written as "slantRange" dataset.
+    freq : np.ndarray[float]
+        Frequency axis in Hz, length num_freq_bins.
+        Written as "frequency" dataset.
+    means : np.ndarray[float]
+        Estimated mean signal power per block from lifted exponential model,
+        shape (num_az_blocks, num_range_blocks). Written as "signalMean" dataset.
+    isr : np.ndarray[float]
+        Interference-to-signal ratio per block,
+        shape (num_az_blocks, num_range_blocks).
+        Written as "interferenceSignalRatio" dataset.
+    hits : np.ndarray[float]
+        Fraction of pulses with detected RFI at each frequency bin,
+        shape (num_az_blocks, num_range_blocks, num_freq_bins).
+        Written as "hitCount" dataset.
+
+    Notes
+    -----
+    All datasets are created with appropriate units and description attributes.
+    Time/range/frequency axes are stored as float64, while data arrays (means,
+    isr, hits) are stored as float32.
+    """
     m, n = means.shape
     if isr.shape != (m, n):
         raise ValueError(f"Expected isr.shape={(m,n)} but got {isr.shape}")
@@ -454,7 +492,8 @@ def write_tone_rank_results(group: h5py.Group, t, r, freq, means, isr, hits):
     ds_mean.attrs["description"] = np.bytes_("Estimated mean signal power per "
         "block from lifted exponential model.  Expressed in linear power units,"
         " e.g., DN^2")
-    ds_hits.attrs["description"] = np.bytes_("Interference-to-signal ratio.  "
+    ds_hits.attrs["description"] = np.bytes_("Fraction of pulses with detected "
+        "RFI at each frequency bin.  Values range from 0 (no RFI) to 1 (RFI in "
+        "all pulses)")
+    ds_isr.attrs["description"] = np.bytes_("Interference-to-signal ratio.  "
         "Expressed in linear power units, e.g., DN^2 / DN^2")
-    ds_isr.attrs["description"] = np.bytes_("Count of detected RFI samples at "
-        "each frequency bin")

--- a/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/python/packages/isce3/signal/rfi_tone_rank.py
@@ -122,7 +122,15 @@ def get_spectral_mask(
     too_loud = exp_from_quantile(q, λ, bandwidth)
     # Use threshold to generate mask.
     mask = power_spectra >= too_loud
-    isr = np.sum(power_spectra[mask]) / np.sum(power_spectra[~mask])
+    # Compute interference-to-signal ratio now that we've labeled the data.
+    # Since masked values are presumably the sum of signal and interference,
+    # we'll include an arithmetic correction using the stats model.
+    mean_power = 1 / λ
+    masked_sig_power = np.sum(mask) * mean_power
+    rfi_power = np.sum(power_spectra[mask]) - masked_sig_power
+    sig_power = np.sum(power_spectra[~mask]) + masked_sig_power
+    isr = rfi_power / sig_power
+    # Unflatten data.
     mask.shape = spectra.shape
     return mask, isr, λ
 

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1188,7 +1188,7 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray,
     elif opt.mitigation_algorithm.lower() == "tone-rank":
         if t is None or r is None or swaths is None or doppler is None:
             raise ValueError("tone-rank algorithm requires t, r, swaths, and doppler parameters")
-        isr, freq, hits = isce3.signal.rfi_tone_rank.remove_loud_tones(
+        means, isr, freq, hits = isce3.signal.rfi_tone_rank.remove_loud_tones(
             raw_data,
             t, r, swaths, doppler,
             detect_only=not opt.mitigation_enabled,

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -79,15 +79,17 @@ def load_config(yaml):
     return Struct(cfg)
 
 
+def struct2dict(s: Struct):
+    d = s.__dict__.copy()
+    for k in d:
+        if isinstance(d[k], Struct):
+            d[k] = struct2dict(d[k])
+        elif isinstance(d[k], list):
+            d[k] = [struct2dict(v) if isinstance(v, Struct) else v for v in d[k]]
+    return d
+
+
 def dump_config(cfg: Struct, stream):
-    def struct2dict(s: Struct):
-        d = s.__dict__.copy()
-        for k in d:
-            if isinstance(d[k], Struct):
-                d[k] = struct2dict(d[k])
-            elif isinstance(d[k], list):
-                d[k] = [struct2dict(v) if isinstance(v, Struct) else v for v in d[k]]
-        return d
     parser = YAML()
     parser.indent = 4
     d = struct2dict(cfg)
@@ -1145,7 +1147,7 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray,
             num_cpi_tb=opt_evd.num_cpi_per_threshold_block,
             mitigate_enable=opt.mitigation_enabled,
             raw_data_mitigated=raw_data_mitigated)
-    else:
+    elif opt.mitigation_algorithm == "FDNF":
         opt_fnf = opt.freq_notch_filter
         rfi_likelihood = isce3.signal.rfi_freq_null.run_freq_notch(
             raw_data,
@@ -1161,7 +1163,14 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray,
             wb_detect=opt_fnf.wb_detect,
             mitigate_enable=opt.mitigation_enabled,
             raw_data_mitigated=raw_data_mitigated)
-
+    elif opt.mitigation_algorithm.lower() == "tone-rank":
+        isr, freq, hits = isce3.signal.rfi_tone_rank.remove_loud_tones(
+            raw_data,
+            detect_only=not opt.mitigation_enabled,
+            zout=raw_data_mitigated,
+            **struct2dict(opt.tone_rank),
+        )
+        rfi_likelihood = np.sum(isr)
 
     log.info(f"RFI likelihood = {rfi_likelihood}")
     return raw_data_mitigated, rfi_likelihood

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1079,7 +1079,9 @@ def resample(raw: np.ndarray, t: np.ndarray,
     return regridded
 
 
-def process_rfi(cfg: Struct, raw_data: np.ndarray,
+def process_rfi(cfg: Struct, raw_data: np.ndarray, t: np.ndarray,
+                r: isce3.core.Linspace,
+                swaths: np.ndarray, doppler: LUT2d,
                 tmpfile: Callable = lambda name: open(name, "wb")):
     """
     Run radio frequency interference (RFI) detection and mitigation as
@@ -1091,6 +1093,16 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray,
         RSLC runconfig data
     raw_data : np.ndarray[np.complex64]
         Raw data layer.  May be modified in-place if mitigation is enabled.
+    t : np.ndarray [float64]
+        Pulse times (seconds since orbit/grid epoch).
+    r : isce3.core.Linspace
+        Range to each sample (meters).
+    swaths : np.ndarray [int]
+        Valid subswath samples, dims = (ns, nt, 2) where ns is the number of
+        sub-swaths, nt is the number of pulses, and the trailing dimension is
+        the [start, stop) indices of the sub-swath.
+    doppler : isce3.core.LUT2d [double]
+        Raw data Doppler look up table.  Must be valid over entire grid.
     tmpfile : Callable
         Function of a single string argument that returns an open file handle.
 
@@ -1164,6 +1176,7 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray,
     elif opt.mitigation_algorithm.lower() == "tone-rank":
         isr, freq, hits = isce3.signal.rfi_tone_rank.remove_loud_tones(
             raw_data,
+            t, r, swaths, doppler,
             detect_only=not opt.mitigation_enabled,
             zout=raw_data_mitigated,
             **struct2dict(opt.tone_rank),
@@ -1959,7 +1972,8 @@ def focus(runconfig, runconfig_path=""):
                         z[k] = wavelets.remove_tone(z[k])
                 raw_mm[block_out] = z
 
-            raw_clean, rfi_likelihood = process_rfi(cfg, raw_mm, temp)
+            raw_clean, rfi_likelihood = process_rfi(cfg, raw_mm, raw_times,
+                raw_grid.slant_ranges, swaths, dop[frequency], temp)
             rfi_results[(frequency, pol)].append(
                 (rfi_likelihood, raw_clean.shape[0]))
             del raw_mm, rawfd

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1112,8 +1112,6 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray,
             raise ValueError("Requested RFI mitigation but disabled detection.")
         log.info("Configured to skip RFI processing")
         return raw_data, np.nan
-    if opt.mitigation_algorithm != "ST-EVD" and opt.mitigation_algorithm != "FDNF":
-        raise NotImplementedError("Only ST-EVD and FDNF RFI algorithms are supported")
     msg = f"Running {opt.mitigation_algorithm} radio frequency interference (RFI) detection"
     if opt.mitigation_enabled:
         msg += " and mitigation"
@@ -1171,6 +1169,9 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray,
             **struct2dict(opt.tone_rank),
         )
         rfi_likelihood = np.sum(isr)
+    else:
+        raise NotImplementedError(f"{opt.mitigation_algorithm} RFI algorithm "
+            "is not supported")
 
     log.info(f"RFI likelihood = {rfi_likelihood}")
     return raw_data_mitigated, rfi_likelihood

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1084,7 +1084,10 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray,
                 r: Optional[isce3.core.Linspace] = None,
                 swaths: Optional[np.ndarray] = None,
                 doppler: Optional[LUT2d] = None,
-                tmpfile: Callable = lambda name: open(name, "wb")):
+                tmpfile: Callable = lambda name: open(name, "wb"),
+                h5group: h5py.Group = None,
+                fc: float = 0.0,
+                fs: float = 1.0):
     """
     Run radio frequency interference (RFI) detection and mitigation as
     configured by user input.
@@ -1110,6 +1113,12 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray,
         Required for tone-rank.
     tmpfile : Callable
         Function of a single string argument that returns an open file handle.
+    h5group : h5py.Group, optional
+        Group to write RFI information to (tone-rank only).
+    fc : float, optional
+        Center frequency, Hz (tone-rank only)
+    fs : float, optional
+        Sample rate, Hz (tone-rank only)
 
     Returns
     -------
@@ -1196,6 +1205,10 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray,
             **struct2dict(opt.tone_rank),
         )
         rfi_likelihood = np.max(isr)
+        if h5group is not None:
+            f = fc + fs * freq
+            isce3.signal.rfi_tone_rank.write_tone_rank_results(h5group,
+                block_times, block_ranges, f, means, isr, hits)
     else:
         raise NotImplementedError(f"{opt.mitigation_algorithm} RFI algorithm "
             "is not supported")
@@ -1938,6 +1951,8 @@ def focus(runconfig, runconfig_path=""):
 
 
     rfi_results = defaultdict(list)
+    rfi_opt = cfg.processing.radio_frequency_interference
+    using_tone_rank = rfi_opt.mitigation_algorithm.lower() == "tone-rank"
 
     # main processing loop
     for channel_out in common_mode:
@@ -1948,6 +1963,9 @@ def focus(runconfig, runconfig_path=""):
         deramp_ac = get_range_deramp(ogrid[frequency])
         writer = BackgroundWriter(scale * deramp_ac, acdata,
             cfg.output.data_type, mantissa_nbits=cfg.output.mantissa_nbits)
+
+        rfi_results_h5 = slc.root.require_group("metadata/RFI/"
+            f"frequency{frequency}/{pol}") if using_tone_rank else None
 
         # store noise powers and its azimuth times in containers
         # over all Raw files for a common band and pol.
@@ -2023,18 +2041,21 @@ def focus(runconfig, runconfig_path=""):
 
             uniform_pri = not raw.isDithered(channel_in.freq_id)
 
-            # Tone-rank always needs swaths; ST-EVD/FDNF only need it for dithered modes
-            algo = cfg.processing.radio_frequency_interference.mitigation_algorithm.upper()
-            swaths_arg = swaths if (algo == "TONE-RANK" or not uniform_pri) else None
-
             raw_clean, rfi_likelihood = process_rfi(
                 cfg,
                 raw_mm,
                 raw_times,
                 raw_grid.slant_ranges,
-                swaths_arg,
+                # Tone-rank always needs swaths, while ST-EVD/FDNF only need it
+                # for dithered modes
+                swaths if (using_tone_rank or not uniform_pri) else None,
                 dop[frequency],
-                temp
+                temp,
+                # Only write rich HDF5 for tone-rank
+                (rfi_results_h5.require_group(f"raw{raw_times[0]:05.0f}")
+                    if using_tone_rank else None),
+                raw.getCenterFrequency(frequency),
+                fs,
             )
             rfi_results[(frequency, pol)].append(
                 (rfi_likelihood, raw_clean.shape[0]))

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1195,7 +1195,7 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray,
             zout=raw_data_mitigated,
             **struct2dict(opt.tone_rank),
         )
-        rfi_likelihood = np.sum(isr)
+        rfi_likelihood = np.max(isr)
     else:
         raise NotImplementedError(f"{opt.mitigation_algorithm} RFI algorithm "
             "is not supported")

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1188,7 +1188,7 @@ def process_rfi(cfg: Struct, raw_data: np.ndarray,
     elif opt.mitigation_algorithm.lower() == "tone-rank":
         if t is None or r is None or swaths is None or doppler is None:
             raise ValueError("tone-rank algorithm requires t, r, swaths, and doppler parameters")
-        means, isr, freq, hits = isce3.signal.rfi_tone_rank.remove_loud_tones(
+        block_times, block_ranges, freq, means, isr, hits = isce3.signal.rfi_tone_rank.remove_loud_tones(
             raw_data,
             t, r, swaths, doppler,
             detect_only=not opt.mitigation_enabled,

--- a/share/nisar/defaults/focus.yaml
+++ b/share/nisar/defaults/focus.yaml
@@ -331,6 +331,10 @@ runconfig:
                     # signal level
                     # "zero": fill with zeros
                     fill_value: noise
+                    # Max portion of a row that can be masked by a TX gap before
+                    # its spectrum is considered invalid (0.0: any gap invalidates
+                    # row, 1.0: ignore gap mask).
+                    max_gap_fraction: 0.5
 
             # Range filter parameters for mixed-mode cases.
             range_common_band_filter:

--- a/share/nisar/defaults/focus.yaml
+++ b/share/nisar/defaults/focus.yaml
@@ -321,6 +321,16 @@ runconfig:
                     block_dims: [512, 1024]
                     nominal_false_positive_rate: 0.0005
                     reference_quantile: 0.5
+                    # Whether to attempt linear/nearest-neighbor interpolation
+                    # for RFI samples.  If False, RFI samples are replaced
+                    # directly with fill_value.
+                    interpolate: True
+                    # How to generate fallback values for RFI samples when
+                    # interpolation fails or is disabled.
+                    # "noise": use random Gaussian noise matched to estimated
+                    # signal level
+                    # "zero": fill with zeros
+                    fill_value: noise
 
             # Range filter parameters for mixed-mode cases.
             range_common_band_filter:

--- a/share/nisar/defaults/focus.yaml
+++ b/share/nisar/defaults/focus.yaml
@@ -305,6 +305,11 @@ runconfig:
                     # Defaults to True
                     wb_detect: True
 
+                tone_rank:
+                    block_dims: [512, 1024]
+                    nominal_false_positive_rate: 0.0005
+                    reference_quantile: 0.5
+
             # Range filter parameters for mixed-mode cases.
             range_common_band_filter:
                 # Stop-band attenuation in dB

--- a/share/nisar/defaults/focus.yaml
+++ b/share/nisar/defaults/focus.yaml
@@ -338,7 +338,7 @@ runconfig:
                     # "noise": use random Gaussian noise matched to estimated
                     # signal level
                     # "zero": fill with zeros
-                    fill_value: noise
+                    fill_value: zero
                     # Max portion of a row that can be masked by a TX gap before
                     # its spectrum is considered invalid (0.0: any gap invalidates
                     # row, 1.0: ignore gap mask).

--- a/share/nisar/defaults/focus.yaml
+++ b/share/nisar/defaults/focus.yaml
@@ -212,6 +212,8 @@ runconfig:
                 # RFI detection algorithm. Supported values include:
                 #   - 'ST-EVD': slow-time eigenvalue decomposition algorithm
                 #   - 'FDNF': frequency domain notch filtering algorithm
+                #   - 'tone-rank': detects RFI in the spectral domain using
+                #     a lifted exponential statistical model.
                 # Defaults to 'ST-EVD'.
                 mitigation_algorithm: ST-EVD
                 # Number of range samples per range block when data blocking
@@ -318,8 +320,14 @@ runconfig:
                     wb_detect: True
 
                 tone_rank:
+                    # Processing block size [azimuth, range] in samples.
                     block_dims: [512, 1024]
+                    # Target false positive rate for RFI detection, in (0, 1).
+                    # Lower values result in more conservative detection (fewer false
+                    # alarms but potentially missed RFI).
                     nominal_false_positive_rate: 0.0005
+                    # Quantile in [1-bandwidth, 1) used to estimate the rate parameter
+                    # of the lifted exponential distribution. Default is 0.5 (median).
                     reference_quantile: 0.5
                     # Whether to attempt linear/nearest-neighbor interpolation
                     # for RFI samples.  If False, RFI samples are replaced

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -510,6 +510,14 @@ tone_rank_options:
     block_dims: list(int(min=1), min=2, max=2, required=False)
     nominal_false_positive_rate: num(min=0.0, max=1.0, required=False)
     reference_quantile: num(min=0.0, max=1.0, required=False)
+    # Whether to attempt linear/nearest-neighbor interpolation for RFI samples.
+    # If False, RFI samples are replaced directly with fill_value.
+    interpolate: bool(required=False)
+    # How to generate fallback values for RFI samples when
+    # interpolation fails or is disabled.
+    # "noise": use random Gaussian noise matched to estimated signal level
+    # "zero": fill with zeros
+    fill_value: enum('noise', 'zero', required=False)
 
 qa_options:
   # For descriptions of all QA parameters, see template runconfig (in `defaults` directory)

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -404,6 +404,8 @@ rfi_options:
   # RFI detection algorithm. Supported values include:
   #   - 'ST-EVD': slow-time eigenvalue decomposition algorithm
   #   - 'FDNF': frequency domain notch filtering algorithm
+  #   - 'tone-rank': detects RFI in the spectral domain using
+  #     a lifted exponential statistical model.
   # Defaults to 'ST-EVD'.
   mitigation_algorithm: enum('ST-EVD', 'FDNF', "tone-rank", required=False)
   # Number of subdivisions in range.  Defaults to 1.
@@ -507,8 +509,14 @@ rfi_threshold_options:
     y: list(num(min=0), min=2, required=False)
 
 tone_rank_options:
+    # Processing block size [azimuth, range] in samples.
     block_dims: list(int(min=1), min=2, max=2, required=False)
+    # Target false positive rate for RFI detection, in (0, 1).
+    # Lower values result in more conservative detection (fewer false
+    # alarms but potentially missed RFI).
     nominal_false_positive_rate: num(min=0.0, max=1.0, required=False)
+    # Quantile in [1-bandwidth, 1) used to estimate the rate parameter
+    # of the lifted exponential distribution. Default is 0.5 (median).
     reference_quantile: num(min=0.0, max=1.0, required=False)
     # Whether to attempt linear/nearest-neighbor interpolation for RFI samples.
     # If False, RFI samples are replaced directly with fill_value.

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -518,6 +518,10 @@ tone_rank_options:
     # "noise": use random Gaussian noise matched to estimated signal level
     # "zero": fill with zeros
     fill_value: enum('noise', 'zero', required=False)
+    # Max portion of a row that can be masked by a TX gap before
+    # its spectrum is considered invalid (0.0: any gap invalidates row,
+    # 1.0: ignore gap mask).
+    max_gap_fraction: num(min=0.0, max=1.0, required=False)
 
 qa_options:
   # For descriptions of all QA parameters, see template runconfig (in `defaults` directory)

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -405,10 +405,11 @@ rfi_options:
   #   - 'ST-EVD': slow-time eigenvalue decomposition algorithm
   #   - 'FDNF': frequency domain notch filtering algorithm
   # Defaults to 'ST-EVD'.
-  mitigation_algorithm: enum('ST-EVD', 'FDNF', required=False)
+  mitigation_algorithm: enum('ST-EVD', 'FDNF', "tone-rank", required=False)
   # Number of subdivisions in range.  Defaults to 1.
   slow_time_evd: include('slow_time_evd_options', required=False)
   freq_notch_filter: include('freq_notch_filter_options', required=False)
+  tone_rank: include('tone_rank_options', required=False)
   # Number of range samples per range block when data blocking
   # is applied in range direction for sample covariance matrix
   # estimation. It is recommended that this parameter is at least
@@ -492,6 +493,11 @@ rfi_threshold_options:
     # final threshold. The values of x outside of the defined range of y are
     # extrapolated.
     y: list(num(min=0), min=2, required=False)
+
+tone_rank_options:
+    block_dims: list(int(min=1), min=2, max=2, required=False)
+    nominal_false_positive_rate: num(min=0.0, max=1.0, required=False)
+    reference_quantile: num(min=0.0, max=1.0, required=False)
 
 qa_options:
   # For descriptions of all QA parameters, see template runconfig (in `defaults` directory)

--- a/tests/python/packages/CMakeLists.txt
+++ b/tests/python/packages/CMakeLists.txt
@@ -30,6 +30,7 @@ isce3/signal/doppler_est_func.py
 isce3/signal/fir_filter_func.py
 isce3/signal/rfi_freq_null.py
 isce3/signal/rfi_process_evd.py
+isce3/signal/rfi_tone_rank.py
 isce3/solid_earth_tides/solid_earth_tides.py
 nisar/antenna/beamformer.py
 nisar/antenna/pattern.py

--- a/tests/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/tests/python/packages/isce3/signal/rfi_tone_rank.py
@@ -1,0 +1,44 @@
+import numpy as np
+import numpy.testing as npt
+
+from isce3.signal.rfi_tone_rank import remove_loud_tones, abs2
+
+
+def test_tone_rank():
+    # repeatable tests, https://www.youtube.com/watch?v=a6iW-8xPw3k
+    np.random.seed(12345)
+
+    m, n = 521, 5557  # primes
+    normal = lambda: np.random.normal(size=m * n)
+    signal = normal() + 1j * normal()
+    signal.shape = (m, n)
+
+    f = 97 / 313  # ratio of different primes
+    tone = np.exp(1j * 2 * np.pi * f * np.arange(n))
+    phases = np.random.uniform(0, 2 * np.pi, size=m)
+    interference = tone[None, :] * np.exp(1j * phases[:, None])
+
+    isr = np.sum(abs2(interference)) / np.sum(abs2(signal))
+    isr_desired = 10.0
+    z = signal + interference * isr_desired / isr
+
+    block_dims = (256, 512)
+    fpr = 0.0005
+    block_isr, freq, block_hits = remove_loud_tones(
+        z, block_dims, nominal_false_positive_rate=fpr, bandwidth=1
+    )
+
+    # Check basic bookkeeping.
+    assert len(freq) == block_dims[1]
+    assert len(freq) == block_hits.shape[2]
+
+    # Make sure we mostly suppressed the correct tone.
+    i, j = 0, 10
+    many_hits = block_hits[i, j, :] > 10
+    suppressed_freqs = freq[many_hits]
+    npt.assert_allclose(suppressed_freqs, f, atol=0.01)
+
+    # If the above passes, then the remaining hits are all false positives.
+    # Make sure there aren't a lot more than expected.
+    num_false_positives = np.sum(block_hits[i, j, ~many_hits])
+    assert num_false_positives / np.prod(block_dims) <= fpr

--- a/tests/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/tests/python/packages/isce3/signal/rfi_tone_rank.py
@@ -3,7 +3,8 @@ import numpy.testing as npt
 import pytest
 
 from isce3.core import LUT2d
-from isce3.signal.rfi_tone_rank import remove_loud_tones, abs2
+from isce3.signal.rfi_tone_rank import (remove_loud_tones, abs2,
+    exp_from_quantile)
 
 
 @pytest.mark.parametrize("m", [513, 521])
@@ -56,3 +57,29 @@ def test_tone_rank(m):
     # Make sure there aren't a lot more than expected.
     num_false_positives = np.sum(block_hits[i, j, ~many_hits])
     assert num_false_positives / np.prod(block_dims) <= fpr
+
+
+def rng_lifted_exp(n, λ, bw, rng=None):
+    if rng is None:
+        rng = np.random.default_rng()
+    # First figure out which component of the mixture each sample draws from.
+    component = rng.random(n) <= bw
+    # Generate n samples from each (a little wasteful).
+    zero = np.zeros(n)
+    exp = rng.exponential(1 / λ, n)
+    # Mix samples in correct proportion.
+    return np.where(component, exp, zero)
+
+def pow2db(x):
+    return 10 * np.log10(x)
+
+@pytest.mark.parametrize("λ", [0.01, 100.0])
+def test_exp_from_quantile(λ):
+    rng = np.random.default_rng(12345)  # seed for repeatability
+    n = 100_000
+    bw = 1 / 1.2
+    data = rng_lifted_exp(n, λ, bw, rng)
+
+    median = np.median(data)
+    λ_est = exp_from_quantile(0.5, median, bw)
+    npt.assert_allclose(pow2db(λ), pow2db(λ_est), atol=1)

--- a/tests/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/tests/python/packages/isce3/signal/rfi_tone_rank.py
@@ -1,6 +1,7 @@
 import numpy as np
 import numpy.testing as npt
 
+from isce3.core import LUT2d
 from isce3.signal.rfi_tone_rank import remove_loud_tones, abs2
 
 
@@ -22,10 +23,20 @@ def test_tone_rank():
     isr_desired = 10.0
     z = signal + interference * isr_desired / isr
 
+    # Fake Doppler and axes. Data are already baseband.
+    t = np.linspace(0, 1, m)
+    r = np.linspace(1, 2, n)
+    doppler = LUT2d(0.0)
+
+    # Don't bother with dithering stuff--say all samples are valid.
+    swaths = np.empty((1, m, 2), int)
+    swaths[...] = (0, n)
+
     block_dims = (256, 512)
     fpr = 0.0005
-    block_isr, freq, block_hits = remove_loud_tones(
-        z, block_dims, nominal_false_positive_rate=fpr, bandwidth=1
+    _, _, freq, _, _, block_hits = remove_loud_tones(
+        z, t, r, swaths, doppler, block_dims,
+        nominal_false_positive_rate=fpr, bandwidth=1
     )
 
     # Check basic bookkeeping.

--- a/tests/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/tests/python/packages/isce3/signal/rfi_tone_rank.py
@@ -1,15 +1,17 @@
 import numpy as np
 import numpy.testing as npt
+import pytest
 
 from isce3.core import LUT2d
 from isce3.signal.rfi_tone_rank import remove_loud_tones, abs2
 
 
-def test_tone_rank():
+@pytest.mark.parametrize("m", [513, 521])
+def test_tone_rank(m):
     # repeatable tests, https://www.youtube.com/watch?v=a6iW-8xPw3k
     np.random.seed(12345)
 
-    m, n = 521, 5557  # primes
+    n = 5557  # prime
     normal = lambda: np.random.normal(size=m * n)
     signal = normal() + 1j * normal()
     signal.shape = (m, n)

--- a/tests/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/tests/python/packages/isce3/signal/rfi_tone_rank.py
@@ -45,8 +45,9 @@ def test_tone_rank():
 
     # Make sure we mostly suppressed the correct tone.
     i, j = 0, 10
-    many_hits = block_hits[i, j, :] > 10
+    many_hits = block_hits[i, j, :] > (10 / m)
     suppressed_freqs = freq[many_hits]
+    assert len(suppressed_freqs) > 0
     npt.assert_allclose(suppressed_freqs, f, atol=0.01)
 
     # If the above passes, then the remaining hits are all false positives.

--- a/tests/python/packages/isce3/signal/rfi_tone_rank.py
+++ b/tests/python/packages/isce3/signal/rfi_tone_rank.py
@@ -23,7 +23,7 @@ def test_tone_rank(m):
 
     isr = np.sum(abs2(interference)) / np.sum(abs2(signal))
     isr_desired = 10.0
-    z = signal + interference * isr_desired / isr
+    z = signal + interference * np.sqrt(isr_desired / isr)
 
     # Fake Doppler and axes. Data are already baseband.
     t = np.linspace(0, 1, m)


### PR DESCRIPTION
## Summary                                                                                                                                                     

This PR implements the "tone-rank" algorithm for narrowband RFI detection and mitigation in raw SAR data, with configurable replacement strategies and diagnostic output. The main difference between the existing FDNF algorithm is the complete lack of averaging, either in slow-time or range-frequency. This probably reduces detection performance of persistent tones but allows us to mitigate intermittent noise with fewer artifacts.
                                                                                                                                                                 
  ## Key Features 

  **RFI Detection and Mitigation**                                                                                                                               
  - Spectral-domain detection using lifted exponential statistical model estimated from rank statistic.
  - STFT-based processing with COLA windowing                                                                                                                    
  - Temporal interpolation for mitigation with configurable fallback strategies                                                                                  
                                                                                                                                                                 
  **User Configuration**                                                                                                                                         
  - `interpolate` (bool): Enable/disable temporal interpolation                                                                                                  
  - `fill_value` ("noise" | "zero"): Fallback replacement strategy                                                                                               
  - Configurable detection parameters (block size, false positive rate, quantile)                                                                                
                                                                                                                                                                 
  **Diagnostic Output**                                                                                                                                          
  - HDF5 metadata with per-block statistics (ISR, mean signal power, hit rates)                                                                                  
  - Time/range/frequency axes for analysis                                                                                                                       
  - Written to `metadata/RFI/` group in RSLC product                                                                                                             
                                                                                                                                                                 
  **Integration**                                                                                                                                                
  - Integrated into focus.py workflow                                                                                                                            
  - Supports both detection-only and mitigation modes
  - Compatible with dithered and non-dithered acquisition modes                                                                                                  
                                                                                                                                                                 
  ## Files Changed                                                                                                                                               
                                                                                                                                                                 
  - `python/packages/isce3/signal/rfi_tone_rank.py`: Core algorithm implementation                                                                               
  - `python/packages/nisar/workflows/focus.py`: Workflow integration
  - `share/nisar/schemas/focus.yaml`: Schema validation                                                                                                          
  - `share/nisar/defaults/focus.yaml`: Default configuration                                                                                                     

<img width="956" height="456" alt="tone_rank_compare" src="https://github.com/user-attachments/assets/5ef081c6-325b-449e-9b69-50c14cbffe52" />
