### PR TITLE
Modify QP Logic in Parsing CalType and ChirpCorrelator

### DIFF
--- a/python/packages/nisar/noise/noise_estimation_from_raw.py
+++ b/python/packages/nisar/noise/noise_estimation_from_raw.py
@@ -19,8 +19,7 @@ from isce3.core import DateTime, TimeDelta
 from nisar.products.readers.Raw import (
     chirpcorrelator_caltype_from_raw,
     is_raw_quad_pol,
-    first_tx_pol_for_quad,
-    opposite_linear_pol
+    first_tx_pol_for_quad
 )
 
 # Global Noise-related Constants
@@ -588,12 +587,12 @@ def est_noise_power_from_raw(
                 # calculate approximate ENBW for relatively white noise!
                 enbw = enbw_from_raw(raw, freq_band, txrx_pol[0])
                 logger.info(f'Approximate ENBW in (MHz) -> {enbw * 1e-6}')
-                # check if quad pol per telemetry then use the opposite
-                # TX pol for noise range lines if that pol is not the
-                # first TX pol.
+                # check if quad pol and the first TX pol is "H".
+                # Then use the opposite TX pol, "V", w/ the same RX pol
+                # for noise-only (sniffer) range lines!
                 txrx_p = txrx_pol
-                if is_quad_pol and txrx_pol[0] != first_tx_pol:
-                    txrx_p = opposite_linear_pol(txrx_pol[0]) + txrx_pol[1]
+                if is_quad_pol and txrx_pol[0] == 'H':
+                    txrx_p = 'V' + txrx_pol[1]
                     logger.warning(f'Use noise-only range lines from {txrx_p} '
                                    f'for {txrx_pol}!')
                 # parse one noise dataset

--- a/python/packages/nisar/noise/noise_estimation_from_raw.py
+++ b/python/packages/nisar/noise/noise_estimation_from_raw.py
@@ -506,6 +506,7 @@ def est_noise_power_from_raw(
                 # loop over several AZ blocks of noise-only range lines
                 noise_power_azblk = []
                 az_dt_utc = []
+                ns_prod = None
                 for (dset_noise1, idx_rgl_ns), (dset_noise2, _) in zip(
                     extract_noise_only_lines(
                         raw, freq_band, txrx_pols[0], max_lines),
@@ -567,7 +568,8 @@ def est_noise_power_from_raw(
                         ns_prod.freq_band,
                         ns_prod.method
                     )
-                noise_prods.append(ns_prod)
+                if ns_prod is not None:
+                    noise_prods.append(ns_prod)
 
         else:  # no polarimetric diff!
             # For qaud pol, use noise range lines of the
@@ -599,6 +601,7 @@ def est_noise_power_from_raw(
                 # loop over several AZ blocks of noise-only range lines
                 noise_power_azblk = []
                 az_dt_utc = []
+                ns_prod = None
                 for (dset_noise, idx_rgl_ns) in extract_noise_only_lines(
                         raw, freq_band, txrx_p, max_lines):
                     if exclude_first_last:
@@ -650,7 +653,8 @@ def est_noise_power_from_raw(
                         ns_prod.freq_band,
                         ns_prod.method
                     )
-                noise_prods.append(ns_prod)
+                if ns_prod is not None:
+                    noise_prods.append(ns_prod)
 
     return noise_prods
 

--- a/python/packages/nisar/products/readers/Raw/Raw.py
+++ b/python/packages/nisar/products/readers/Raw/Raw.py
@@ -1385,7 +1385,12 @@ def chirpcorrelator_caltype_from_raw(
         chp_cor = raw.getChirpCorrelator(freq_band, txrx_pol[0])
         cal_type = raw.getCalType(freq_band, txrx_pol[0])
         return chp_cor, cal_type
-    # Linear Quad pol case
+    # Linear Quad Pol (QP) case:
+    # TX Cal path type under HRT/QFSP is the same for all
+    # polarizations "txrx_pol". That is, no difference between
+    # H and V!
+    # Both cal type and chirp correlators under HRT/QFSP are
+    # provided over all TX pulses at fastest PRF clock!
     if is_raw_quad_pol(raw):
         tx_pol_first = first_tx_pol_for_quad(raw)
         # check input TX pol against first TX pol in

--- a/python/packages/nisar/products/readers/Raw/Raw.py
+++ b/python/packages/nisar/products/readers/Raw/Raw.py
@@ -1385,30 +1385,35 @@ def chirpcorrelator_caltype_from_raw(
         chp_cor = raw.getChirpCorrelator(freq_band, txrx_pol[0])
         cal_type = raw.getCalType(freq_band, txrx_pol[0])
         return chp_cor, cal_type
-    # Quad pol case
+    # Linear Quad pol case
     if is_raw_quad_pol(raw):
         tx_pol_first = first_tx_pol_for_quad(raw)
-        if txrx_pol[0] == tx_pol_first:
-            chp_cor = chp_cor[::2]
-            cal_type = cal_type[::2]
-        else:  # the second TX pol
-            # get data from the opposite TX pol
-            x_pol = opposite_linear_pol(txrx_pol[0]) + txrx_pol[1]
-            chp_cor_x, cal_type_x = chirpcorrelator_caltype_from_raw(
-                raw, txrx_pol=x_pol)
-            # if co-pol get HPA value from same TX but
-            # fill in LNA/BYP from opposite TX
-            if txrx_pol[0] == txrx_pol[1]:
-                chp_cor = chp_cor[1::2]
-                cal_type = cal_type[1::2]
-                _, idx_byp, idx_lna, _ = get_calib_range_line_idx(cal_type_x)
-                chp_cor[idx_byp] = chp_cor_x[idx_byp]
-                chp_cor[idx_lna] = chp_cor_x[idx_lna]
-                cal_type[idx_byp] = CalPath.BYPASS
-                cal_type[idx_lna] = CalPath.LNA
-            else:  # x-pol product
-                chp_cor = chp_cor_x
-                cal_type = cal_type_x
+        # check input TX pol against first TX pol in
+        # linear QP to get proper indexing in HRT.
+        if tx_pol_first == txrx_pol[0]:
+            first_slice = np.s_[::2]
+            second_slice = np.s_[1::2]
+        else:  # the opposite pol
+            first_slice = np.s_[1::2]
+            second_slice = np.s_[::2]
+        # Now check if the input TX pol is H or V.
+        if txrx_pol[0] == 'V':
+            # TX pol = V. No special treatment.
+            chp_cor = chp_cor[first_slice]
+            cal_type = cal_type[first_slice]
+        else:
+            # TX = H pol that requires special
+            # treatment for sniffer pulses (LNA/BYPASS)!
+            # get sniffer pulses from the opposite TX but same receive!
+            cal_type_x = cal_type[second_slice]
+            chp_cor_x = chp_cor[second_slice]
+            _, idx_byp, idx_lna, _ = get_calib_range_line_idx(cal_type_x)
+            chp_cor = chp_cor[first_slice]
+            cal_type = cal_type[first_slice]
+            chp_cor[idx_byp] = chp_cor_x[idx_byp]
+            chp_cor[idx_lna] = chp_cor_x[idx_lna]
+            cal_type[idx_byp] = CalPath.BYPASS
+            cal_type[idx_lna] = CalPath.LNA
     # set x-pol HPA to INVALID given they are the mix of
     # LNA from co-pol and HPA from x-pol!
     if txrx_pol in ('HV', 'VH'):

--- a/python/packages/nisar/products/readers/Raw/Raw.py
+++ b/python/packages/nisar/products/readers/Raw/Raw.py
@@ -1373,6 +1373,14 @@ def chirpcorrelator_caltype_from_raw(
     np.ndarray(uint8)
         1-D array of cal type w/ values HPA=0, LNA=1, BYPASS=2, and INVALID=255
 
+    Notes
+    -----
+    Assumptions for NISAR L-band products in regards
+    to sniffer (BYPASS/LNA) pulses:
+    - The first TX pulse in any datatake is sniffer pulse (BYPASS).
+    - The period of sniffer pulse is always an even number!
+    - The tx=V on odd TX pulses while tx=H on even ones in Quad pol.
+
     """
     try:
         chp_cor = raw._parse_chirpcorrelator_from_hrt_qfsp(txrx_pol=txrx_pol)
@@ -1394,7 +1402,8 @@ def chirpcorrelator_caltype_from_raw(
     if is_raw_quad_pol(raw):
         tx_pol_first = first_tx_pol_for_quad(raw)
         # check input TX pol against first TX pol in
-        # linear QP to get proper indexing in HRT.
+        # linear QP to get proper single-pol indexing (slow PRF)
+        # from fast indexing (fast PRF) of HRT.
         if tx_pol_first == txrx_pol[0]:
             first_slice = np.s_[::2]
             second_slice = np.s_[1::2]
@@ -1409,10 +1418,14 @@ def chirpcorrelator_caltype_from_raw(
         else:
             # TX = H pol that requires special
             # treatment for sniffer pulses (LNA/BYPASS)!
-            # get sniffer pulses from the opposite TX but same receive!
+            # get sniffer pulses from the opposite TX
+            # (other pulse indices) but same receive
+            # to update chirp correlator and cal type.
             cal_type_x = cal_type[second_slice]
             chp_cor_x = chp_cor[second_slice]
             _, idx_byp, idx_lna, _ = get_calib_range_line_idx(cal_type_x)
+            # Parse and update the chirp correlator and cal
+            # type for BYPASS/LNA (sniffer pulses)
             chp_cor = chp_cor[first_slice]
             cal_type = cal_type[first_slice]
             chp_cor[idx_byp] = chp_cor_x[idx_byp]

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -21,8 +21,7 @@ from nisar.products.readers.Raw import (
     open_rrsd,
     chirpcorrelator_caltype_from_raw,
     is_raw_quad_pol,
-    first_tx_pol_for_quad,
-    opposite_linear_pol
+    first_tx_pol_for_quad
 )
 from nisar.products.readers.rslc_cal import (RslcCalibration,
     parse_rslc_calibration, get_scale_and_delay, check_cal_validity_dates)
@@ -2086,7 +2085,7 @@ def focus(runconfig, runconfig_path=""):
                     'interval. Skip noise estimation and set noise equivalent '
                     'backscatter to zero.')
                 pow_noise = np.zeros_like(sr_noise, dtype='f4')
-            else: # there is at least one noise-only range line
+            else:  # there is at least one noise-only range line
                 nrgl_noise = idx_noise.size
                 log.info(f'Number of noise-only range lines is {nrgl_noise}')
                 # create a dedicated memory map for noise data and processing.
@@ -2095,17 +2094,17 @@ def focus(runconfig, runconfig_path=""):
                 data_noise = np.memmap(
                     fid_noise, mode='w+', shape=(nrgl_noise, rc.output_size),
                     dtype=np.complex64)
-                # Check if raw is quad pol and the TX pol is not the
-                # first TX pol. Then extract noise only range line
-                # from the opposite TX pol w/ the same RX pol.
+                # Check if raw is quad pol and the TX pol is "H".
+                # Then extract noise-only (sniffer) range lines
+                # from the opposite TX pol, "V", w/ the same RX pol.
                 # XXX No RFI/caltone clean up of noise-only range lines
                 # for second TX pol products of quad pol!
                 raw_ns = np.copy(raw_clean[idx_noise])
                 if is_raw_quad_pol(raw):
                     first_tx_pol = first_tx_pol_for_quad(raw)
                     log.info(f'Quad pol w/ first {first_tx_pol} pol!')
-                    if pol[0] != first_tx_pol:
-                        pol_ns = opposite_linear_pol(pol[0]) + pol[1]
+                    if pol[0] == 'H':
+                        pol_ns = 'V' + pol[1]
                         log.warning('Get noise-only range lines from '
                                     f'{pol_ns} for {pol} of quad pol!')
                         ds_ns = raw.getRawDataset(channel_in.freq_id, pol_ns)


### PR DESCRIPTION
This quick PR slightly modifies the logic used in extracting chirp calibration path types and chirp correlators from L0B high-rate telemetry for simply linear Quad-Pol (QP). 
This fixes the issue with radiometric calibration (*EAP=ON*) and noise estimation (*NEB*) in RSLC L1 product for QP case where the first TX pol is **H**. 
Besides, it fixes the issue with missing sniffer pulses in noise estimator workflow from raw L0B products for QP.
This PR has been successfully tested by generating RSLC w/ EAP=ON and estimating noise power from L0B over two different Fixed-PRF QP modes supporting both H and V as the first TX polarization.

Here is the example of 3-second QP RSLC browse images toggling between EAP=OFF/ON:

- *A & HH/HV/VH/VV*
<img width="2013" height="165" alt="EAP_OFF2ON" src="https://github.com/user-attachments/assets/b9e06ee1-4782-43af-9ea6-de307523e416" />

- *B & HH*  
<img width="1636" height="136" alt="EAP_OFF2ON_B_HH" src="https://github.com/user-attachments/assets/fc90a985-ad26-485c-ae01-62b2859ccef8" />
