### PR TITLE
Fix RSLC mask in mixed mode cases

### DIFF
--- a/python/packages/nisar/products/readers/Raw/Raw.py
+++ b/python/packages/nisar/products/readers/Raw/Raw.py
@@ -925,17 +925,6 @@ class RawBase(Base, family='nisar.productreader.raw'):
         is_dithered = self.isDithered(frequency, tx=tx, num_ignore=num_ignore)
         rd, wd, wl = self.getRdWdWl(frequency, polarization)
 
-        # In order to have a shared edge between seamless observation we want
-        # the bbox to end one past the last pulse.  However, for dithered it's
-        # difficult to know exactly what the final PRI is, so just use the
-        # penultimate one.  The code that calculates the valid swath mask
-        # will still have to join edges within some tolerance, but this should
-        # help.
-        if len(times) < 2:
-            raise ValueError("Need at least two pulses for bbox")
-        final_pri = times[-2] - times[-1]
-        times = np.hstack((times, [times[-1] + final_pri]))
-
         # Replace enormous fill values with number of samples.
         subswaths = np.where(subswaths > nr, nr, subswaths)
 
@@ -973,9 +962,8 @@ class RawBase(Base, family='nisar.productreader.raw'):
 
         changes = get_dwp_change_indices(rd, wd, wl)
 
-        # Append first pulse and one-past last pulse to generate pairs of
-        # constant DWP.
-        breaks = np.hstack(([0], changes, [grid.shape[0]]))
+        # Append first and last pulses to generate pairs of constant DWP.
+        breaks = np.hstack(([0], changes, [grid.shape[0] - 1]))
         bbox_lists = []
         for ibreak in range(len(breaks) - 1):
             ipulse0, ipulse1 = breaks[ibreak], breaks[ibreak + 1]

--- a/python/packages/nisar/products/readers/Raw/Raw.py
+++ b/python/packages/nisar/products/readers/Raw/Raw.py
@@ -925,6 +925,17 @@ class RawBase(Base, family='nisar.productreader.raw'):
         is_dithered = self.isDithered(frequency, tx=tx, num_ignore=num_ignore)
         rd, wd, wl = self.getRdWdWl(frequency, polarization)
 
+        # In order to have a shared edge between seamless observation we want
+        # the bbox to end one past the last pulse.  However, for dithered it's
+        # difficult to know exactly what the final PRI is, so just use the
+        # penultimate one.  The code that calculates the valid swath mask
+        # will still have to join edges within some tolerance, but this should
+        # help.
+        if len(times) < 2:
+            raise ValueError("Need at least two pulses for bbox")
+        final_pri = times[-2] - times[-1]
+        times = np.hstack((times, [times[-1] + final_pri]))
+
         # Replace enormous fill values with number of samples.
         subswaths = np.where(subswaths > nr, nr, subswaths)
 
@@ -962,8 +973,9 @@ class RawBase(Base, family='nisar.productreader.raw'):
 
         changes = get_dwp_change_indices(rd, wd, wl)
 
-        # Append first and last pulses to generate pairs of constant DWP.
-        breaks = np.hstack(([0], changes, [grid.shape[0] - 1]))
+        # Append first pulse and one-past last pulse to generate pairs of
+        # constant DWP.
+        breaks = np.hstack(([0], changes, [grid.shape[0]]))
         bbox_lists = []
         for ibreak in range(len(breaks) - 1):
             ipulse0, ipulse1 = breaks[ibreak], breaks[ibreak + 1]

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1619,8 +1619,9 @@ def get_focused_sub_swaths(rawlist, out_chan, grid, orbit, doppler, dem, azres,
         T = raw.getChirpParameters(freq, txpol)[3]
         chirp_durations.extend(len(bbox_lists) * [T])
 
-    # Force azimuth continuity since Raw.getSubSwathBboxes only guesses about
-    # last PRI.
+    # Force azimuth continuity since Raw.getSubSwathBboxes doesn't know final
+    # PRI so there's a 1-pulse gap between observations.  Note that there
+    # should be no gap between 10-second DWP updates.
     for i in range(len(raw_bbox_lists) - 1):
         # Each subswath should have the same start/end time, just different
         # ranges.
@@ -1630,7 +1631,7 @@ def get_focused_sub_swaths(rawlist, out_chan, grid, orbit, doppler, dem, azres,
         if dt <= max_observation_gap:
             log.info(f"Merging observations separated by {dt * 1e6:.2f} us "
                 f"at {orbit.reference_epoch + TimeDelta(t_cur)}")
-            if dt <= 0.0:
+            if dt < 0.0:
                 # The time difference should always be positive since there's at
                 # least one PRI between the end of one observation and the start
                 # of the next one.  However, as of 2026-05-04, L0B time stamps

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1645,7 +1645,7 @@ def get_focused_sub_swaths(rawlist, out_chan, grid, orbit, doppler, dem, azres,
                 log.warning("Time decremented between observations.  "
                     "Assuming seamless transition.")
             for bbox in raw_bbox_lists[i]:
-                bbox.last.time = t_next
+                bbox.last.time = max(t_next, t_cur)
         else:
             log.warning(f"Gap between observations {dt:7f} s exceeds threshold "
                 f"for seamless observations ({max_observation_gap} s).")

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1546,7 +1546,7 @@ def get_output_range_spacings(rawlist: list[Raw], common_mode: PolChannelSet):
 def get_focused_sub_swaths(rawlist, out_chan, grid, orbit, doppler, dem, azres,
                            rdr2geo_params=dict(), geo2rdr_params=dict(),
                            ignore_failure=False, polygon_segment_length=50.0,
-                           num_ignore=25):
+                           num_ignore=25, max_observation_gap=800e-6):
     """
     Determine fully-focused regions of the image in a format suitable for
     populating the validSamplesSubSwathX RSLC datasets.
@@ -1589,6 +1589,11 @@ def get_focused_sub_swaths(rawlist, out_chan, grid, orbit, doppler, dem, azres,
         observation is immediately followed by a dithered observation, as the
         dithered pulses in the air will overlap the last few receive windows of
         the fixed-PRF one.
+    max_observation_gap : float, optional
+        Max allowed time (in seconds) between the last pulse of one observation
+        and the first pulse of the following observation for the two to be
+        considered seamless.  Larger raw data gaps may result in a synthetic
+        aperture being marked invalid in the RSLC.
 
     Returns
     -------
@@ -1610,6 +1615,22 @@ def get_focused_sub_swaths(rawlist, out_chan, grid, orbit, doppler, dem, azres,
         txpol = raw_chan.pol[0]
         T = raw.getChirpParameters(freq, txpol)[3]
         chirp_durations.extend(len(bbox_lists) * [T])
+
+    # Force azimuth continuity since Raw.getSubSwathBboxes only guesses about
+    # last PRI.
+    for i in range(len(raw_bbox_lists) - 1):
+        # Each subswath should have the same start/end time, just different
+        # ranges.
+        t_cur = raw_bbox_lists[i][0].last.time
+        t_next = raw_bbox_lists[i + 1][0].first.time
+        # abs() since difference could be negative if Raw.getSubSwathBboxes
+        # guess for the final PRI is larger than the actual final PRI.
+        dt = abs(t_next - t_cur)
+        if dt <= max_observation_gap:
+            log.info(f"Merging observations separated by {dt * 1e6:.3f} us "
+                f"at {orbit.reference_epoch + TimeDelta(t_cur)}")
+            for bbox in raw_bbox_lists[i]:
+                bbox.last.time = t_next
 
     try:
         swaths = isce3.focus.get_focused_sub_swaths(raw_bbox_lists,

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1629,9 +1629,10 @@ def get_focused_sub_swaths(rawlist, out_chan, grid, orbit, doppler, dem, azres,
         t_next = raw_bbox_lists[i + 1][0].first.time
         dt = t_next - t_cur
         if dt <= max_observation_gap:
-            log.info(f"Merging observations separated by {dt * 1e6:.2f} us "
-                f"at {orbit.reference_epoch + TimeDelta(t_cur)}")
-            if dt < 0.0:
+            if dt > 0.0:
+                log.info(f"Merging observations separated by {dt * 1e6:.2f} us "
+                    f"at {orbit.reference_epoch + TimeDelta(t_cur)}")
+            elif dt < 0.0:
                 # The time difference should always be positive since there's at
                 # least one PRI between the end of one observation and the start
                 # of the next one.  However, as of 2026-05-04, L0B time stamps

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1602,6 +1602,9 @@ def get_focused_sub_swaths(rawlist, out_chan, grid, orbit, doppler, dem, azres,
         where nswath is the number of valid sub-swaths and npulse is the length
         of the focused image grid.
     """
+    # Need raw files sorted in time so we can reason about gaps between them.
+    rawlist = sorted(rawlist, key=lambda raw: raw.identification.zdStartTime)
+
     raw_bbox_lists = []
     chirp_durations = []
     for raw in rawlist:
@@ -1623,16 +1626,26 @@ def get_focused_sub_swaths(rawlist, out_chan, grid, orbit, doppler, dem, azres,
         # ranges.
         t_cur = raw_bbox_lists[i][0].last.time
         t_next = raw_bbox_lists[i + 1][0].first.time
-        # abs() since difference could be negative if Raw.getSubSwathBboxes
-        # guess for the final PRI is larger than the actual final PRI.
-        dt = abs(t_next - t_cur)
-        if 0 < dt <= max_observation_gap:
+        dt = t_next - t_cur
+        if dt <= max_observation_gap:
             log.info(f"Merging observations separated by {dt * 1e6:.2f} us "
                 f"at {orbit.reference_epoch + TimeDelta(t_cur)}")
+            if dt <= 0.0:
+                # The time difference should always be positive since there's at
+                # least one PRI between the end of one observation and the start
+                # of the next one.  However, as of 2026-05-04, L0B time stamps
+                # are derived from LRCLK counts using a model that's updated
+                # every downlink pass.  If the observations were downlinked on
+                # separate passes, it's conceivable that time could go backwards
+                # (though this would violate requirements).  If that happens it
+                # seems safe to assume that's a seamless transition, so just log
+                # it and proceed.
+                log.warning("Time decremented between observations.  "
+                    "Assuming seamless transition.")
             for bbox in raw_bbox_lists[i]:
                 bbox.last.time = t_next
-        elif dt > 0:
-            log.info(f"Gap between observations {dt:7f} s exceeds threshold "
+        else:
+            log.warning(f"Gap between observations {dt:7f} s exceeds threshold "
                 f"for seamless observations ({max_observation_gap} s).")
 
     try:

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1546,7 +1546,7 @@ def get_output_range_spacings(rawlist: list[Raw], common_mode: PolChannelSet):
 def get_focused_sub_swaths(rawlist, out_chan, grid, orbit, doppler, dem, azres,
                            rdr2geo_params=dict(), geo2rdr_params=dict(),
                            ignore_failure=False, polygon_segment_length=50.0,
-                           num_ignore=25, max_observation_gap=800e-6):
+                           num_ignore=25, max_observation_gap=0.002):
     """
     Determine fully-focused regions of the image in a format suitable for
     populating the validSamplesSubSwathX RSLC datasets.
@@ -1626,11 +1626,14 @@ def get_focused_sub_swaths(rawlist, out_chan, grid, orbit, doppler, dem, azres,
         # abs() since difference could be negative if Raw.getSubSwathBboxes
         # guess for the final PRI is larger than the actual final PRI.
         dt = abs(t_next - t_cur)
-        if dt <= max_observation_gap:
-            log.info(f"Merging observations separated by {dt * 1e6:.3f} us "
+        if 0 < dt <= max_observation_gap:
+            log.info(f"Merging observations separated by {dt * 1e6:.2f} us "
                 f"at {orbit.reference_epoch + TimeDelta(t_cur)}")
             for bbox in raw_bbox_lists[i]:
                 bbox.last.time = t_next
+        elif dt > 0:
+            log.info(f"Gap between observations {dt:7f} s exceeds threshold "
+                f"for seamless observations ({max_observation_gap} s).")
 
     try:
         swaths = isce3.focus.get_focused_sub_swaths(raw_bbox_lists,

--- a/share/nisar/defaults/focus.yaml
+++ b/share/nisar/defaults/focus.yaml
@@ -474,6 +474,13 @@ runconfig:
                 # one.
                 num_ignore: 25
 
+                # Max allowed time (in seconds) between the last pulse of one
+                # observation and the first pulse of the following observation
+                # for the two to be considered seamless.  Larger raw data gaps
+                # may result in a synthetic aperture being marked invalid in the
+                # RSLC.
+                max_observation_gap: 800e-6
+
             caltone:
                 # If "azimuth_mean", subtract the azimuth mean from the raw
                 # data, which is useful when the caltone is nearly constant in

--- a/share/nisar/defaults/focus.yaml
+++ b/share/nisar/defaults/focus.yaml
@@ -479,7 +479,7 @@ runconfig:
                 # for the two to be considered seamless.  Larger raw data gaps
                 # may result in a synthetic aperture being marked invalid in the
                 # RSLC.
-                max_observation_gap: 800e-6
+                max_observation_gap: 0.002
 
             caltone:
                 # If "azimuth_mean", subtract the azimuth mean from the raw

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -314,7 +314,7 @@ mask_options:
   # for the two to be considered seamless.  Larger raw data gaps
   # may result in a synthetic aperture being marked invalid in the
   # RSLC.
-  max_observation_gap: 800e-6
+  max_observation_gap: num(min=0, required=False)
 
 caltone_options:
   frequency: num(min=0, required=False)

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -309,6 +309,13 @@ mask_options:
   # one.
   num_ignore: num(min=0, required=False)
 
+  # Max allowed time (in seconds) between the last pulse of one
+  # observation and the first pulse of the following observation
+  # for the two to be considered seamless.  Larger raw data gaps
+  # may result in a synthetic aperture being marked invalid in the
+  # RSLC.
+  max_observation_gap: 800e-6
+
 caltone_options:
   frequency: num(min=0, required=False)
   algorithm: enum('wavelet', 'azimuth_mean', 'auto', 'disabled', required=False)


### PR DESCRIPTION
This PR addresses the problem observed in mixed-mode cases where a small sliver is marked invalid at the boundaries between observations. Here's an illustration of the valid (start, end) indices for the following granule

NISAR_L1_PR_RSLC_009_005_A_019_4005_DHDH_A_20251228T125147_20251228T125222_X05013_N_F_J_001

<img width="1193" height="862" alt="fig_bad_mask" src="https://github.com/user-attachments/assets/3e9333af-97b3-47f4-be09-c5138e8bcdf4" />

What happens is there's a small time interval between the last pulse of one observation and the first pulse of the next observation. I had considered this case and implemented the logic [here](https://github.com/isce-framework/isce3/blob/bfe0c1a99acc498ad661a46956b749460b5e7c26/python/packages/isce3/focus/valid_regions.py#L407) to deal with it. However, I guess I hadn't put a lot of thought into the tolerance for merging the polygons. The algorithm is looping over scanlines intersecting the polygons, so it uses a range threshold. The basic relationship relating a range gap Δr to an azimuth gap Δs is $\Delta r = \Delta s / \tan\theta_{sq}$. The necessary merge threshold to cover a one-pulse or so gap works out to up to 250 range samples depending on your degree of conservatism (in the granule above the range gap was 75 samples). That's longer than our shortest pulse, so it's not a reasonable way to solve the problem.

Instead, I added a step after getting the raw data bounding boxes that forces them to share an edge when they're separated by less than some user-provided threshold. I set the default to 2 ms. The example above had a gap of 1.116 ms, which is honestly a little bigger than I expected.

I also changed the `Raw.getSubSwathBboxes` method to report an upper time bound of one PRI past the last pulse, which is consistent with what it does in range and with the interior bboxes due to DWP updates. However, those changes are not really necessary given the fix in higher-level logic.

With these changes there's no longer any pinching of the valid data mask around the 2-second mid-frame observation.