### PR TITLE
Fix CI hanging

### DIFF
--- a/.github/workflows/build-and-run-gpu.yml
+++ b/.github/workflows/build-and-run-gpu.yml
@@ -61,6 +61,7 @@ jobs:
       - name: Setup Environment
         uses: mamba-org/setup-micromamba@v2
         with:
+          micromamba-version: '1.5.10-0'
           environment-file: ${{ matrix.deps.env-file }}
           environment-name: isce3
           create-args: >-

--- a/.github/workflows/build-and-run.yml
+++ b/.github/workflows/build-and-run.yml
@@ -81,6 +81,7 @@ jobs:
       - name: Setup Environment
         uses: mamba-org/setup-micromamba@v2
         with:
+          micromamba-version: '1.5.10-0'
           environment-file: ${{ env.env-file }}
           environment-name: isce3
           create-args: >-


### PR DESCRIPTION
Our CI is failing because the jobs time out while micromamba solves the environment. I tried reproducing on the on-demand system, but it solved okay there. Digging a bit, there seems to be some kind of solver performance regression between versions 1.5 and 2.x ([link](https://github.com/mamba-org/mamba/issues/3822)). I have mamba 1.5.12 on the ods, so here I'm going to try pinning to an older version of micromamba to see if that helps the github CI.