### PR TITLE
Fix recently-introduced mixed-mode bug

### DIFF
--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -2092,7 +2092,7 @@ def focus(runconfig, runconfig_path=""):
                 # Only write rich HDF5 for tone-rank
                 (rfi_results_h5.require_group(f"raw{raw_times[0]:05.0f}")
                     if using_tone_rank else None),
-                raw.getCenterFrequency(frequency),
+                raw.getCenterFrequency(channel_in.freq_id),
                 fs,
             )
             rfi_results[(frequency, pol)].append(


### PR DESCRIPTION
I should know better by now, but when adding the tone-rank RFI suppression feature I messed up the bookkeeping of the subband frequency ID. This causes problems in mixed-mode processing, particularly when mixing 77 MHz with any dual-frequency mode. In that case we downsample the 77 MHz data twice, so there's one iteration where the output RSLC data will be labeled "B" but we're using L0B data from "A".

This PR changes the code to use the correct label for querying the source L0B.