### PR TITLE
Scale RSLC mixed-mode filter by bandwidth ratio

### DIFF
--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1347,6 +1347,10 @@ def prep_rangecomp(cfg, raw, raw_grid, channel_in, channel_out, cal=None,
     log.info("Normalizing chirp to unit white noise gain.")
     chirp *= 1.0 / np.linalg.norm(chirp)
 
+    if channel_in.band != channel_out.band:
+        log.info("Re-scaling by mixed-mode filter bandwidth ratio")
+        chirp *= np.sqrt(channel_out.band.width / channel_in.band.width)
+
     # Careful to use effective TBP after mixed-mode filtering.
     time_bw_product = channel_out.band.width**2 / abs(K)
 


### PR DESCRIPTION
The range reference function is normalized by its white noise gain, which helps keep the calibration constant when we change the window parameter. However, in the mixed-mode case that normalization also increases the pass-band gain in proportion to the bandwidth reduction. The latter effect is not desirable since it causes a radiometric offset.

To test this change, I found a case near the south pole where we mix 77 MHz (half-swath) with 40+5 MHz (full-swath) data. Looking at the 77 & 5 MHz mix is most obvious, since the change is almost 12 dB in that case. With the change, we get a nice continuous backscatter image.

<img width="960" height="540" alt="mixed_mode_normalization" src="https://github.com/user-attachments/assets/960bc515-dcd5-439b-9c01-b605e739920a" />

Note 1: I just used the browse QA images for the above figure, so they have independent color maps. You can see from the histogram and profile that it's actually the 77 MHz getting darker to match the 5 MHz part.

Note 2: This test case also requires #268 