### PR TITLE
Restore = nullptr defaults to CUDA Rdr2Geo.topo() optional rasters (#265)

### DIFF
--- a/python/extensions/pybind_isce3/cuda/geometry/rdr2geo.cpp
+++ b/python/extensions/pybind_isce3/cuda/geometry/rdr2geo.cpp
@@ -65,17 +65,17 @@ void addbinding(py::class_<Topo> & pyRdr2Geo)
                                       isce3::io::Raster*>
                             (&Topo::topo),
                     py::arg("dem_raster"),
-                    py::arg("x_raster"),
-                    py::arg("y_raster"),
-                    py::arg("height_raster"),
-                    py::arg("incidence_angle_raster"),
-                    py::arg("heading_angle_raster"),
-                    py::arg("local_incidence_angle_raster"),
-                    py::arg("local_Psi_raster"),
-                    py::arg("simulated_amplitude_raster"),
-                    py::arg("layover_shadow_raster"),
-                    py::arg("ground_to_sat_east_raster"),
-                    py::arg("ground_to_sat_north_raster"),
+                    py::arg("x_raster") = nullptr,
+                    py::arg("y_raster") = nullptr,
+                    py::arg("height_raster") = nullptr,
+                    py::arg("incidence_angle_raster") = nullptr,
+                    py::arg("heading_angle_raster") = nullptr,
+                    py::arg("local_incidence_angle_raster") = nullptr,
+                    py::arg("local_psi_raster") = nullptr,
+                    py::arg("simulated_amplitude_raster") = nullptr,
+                    py::arg("layover_shadow_raster") = nullptr,
+                    py::arg("ground_to_sat_east_raster") = nullptr,
+                    py::arg("ground_to_sat_north_raster") = nullptr,
                     R"(
         Run topo and output to user created topo rasters
 

--- a/tests/python/extensions/pybind/cuda/geometry/rdr2geo.py
+++ b/tests/python/extensions/pybind/cuda/geometry/rdr2geo.py
@@ -11,6 +11,16 @@ import iscetest
 import isce3
 from nisar.products.readers import SLC
 
+# CUDA-gated: skip the whole module on CPU-only isce3 builds. The tests below
+# all depend on isce3.cuda.geometry.Rdr2Geo, which only exists when isce3 was
+# configured with CUDA. Without this gate, collection on a CPU-only build
+# would surface as fixture errors rather than a clear skip with a reason.
+pytestmark = pytest.mark.skipif(
+    not hasattr(isce3, "cuda"),
+    reason="isce3 built without CUDA support; skipping isce3.cuda.geometry tests",
+)
+
+
 @pytest.fixture(scope="module")
 def unit_test_params():
     params = types.SimpleNamespace()
@@ -126,6 +136,47 @@ def test_run_raster_layers(unit_test_params):
             ground_to_sat_east_raster,
             ground_to_sat_north_raster,
         ],
+    )
+
+
+def test_run_optional_layers(unit_test_params):
+    '''
+    Exercise the optional-raster path of topo() in the same call shape used
+    by COMPASS s1_rdr2geo.run: kwargs for a subset of output layers, with
+    explicit None for some and others omitted entirely. The C++ class
+    isce3::cuda::geometry::Topo::topo() documents an all-nullptr default
+    contract for the 11 output rasters, mirrored on the CPU sibling
+    binding. Without this test, the binding-layer regression that drops
+    the `= nullptr` defaults is invisible to CI because the existing
+    test_run_raster_layers passes every kwarg explicitly.
+    '''
+    radargrid = unit_test_params.radargrid
+    length, width = radargrid.shape
+
+    # Subset matching COMPASS's typical call: x/y/height + layoverShadow,
+    # plus a few explicit Nones (exercising pybind11's None-to-nullptr
+    # conversion) and the remaining four output rasters omitted entirely
+    # (exercising the kwarg defaults).
+    fnames_dtypes = [
+        ("opt_x", gdal.GDT_Float64),
+        ("opt_y", gdal.GDT_Float64),
+        ("opt_z", gdal.GDT_Float64),
+        ("opt_layoverShadow", gdal.GDT_Byte),
+    ]
+    x_raster, y_raster, height_raster, layover_shadow_raster = [
+        isce3.io.Raster(f"{fname}.rdr", width, length, 1, dtype, "ENVI")
+        for fname, dtype in fnames_dtypes
+    ]
+
+    unit_test_params.rdr2geo_obj.topo(
+        unit_test_params.dem_raster,
+        x_raster=x_raster,
+        y_raster=y_raster,
+        height_raster=height_raster,
+        local_incidence_angle_raster=None,
+        layover_shadow_raster=layover_shadow_raster,
+        ground_to_sat_east_raster=None,
+        ground_to_sat_north_raster=None,
     )
 
 


### PR DESCRIPTION
Closes #265.

## Summary

The CUDA pybind binding for `isce3::cuda::geometry::Topo::topo()`
declared all 11 output-raster kwargs as required, while the underlying
C++ class accepts `nullptr` per its documented contract and the CPU
sibling binding marks the same kwargs `= nullptr`. Calling the CUDA
overload with a subset of layers (kwargs only, others omitted) raised
`TypeError` on argument matching:

```python
import isce3.cuda.geometry as g
rdr2geo = g.Rdr2Geo(radar_grid, orbit, ellipsoid, doppler)
rdr2geo.topo(dem_raster, x_raster=x, y_raster=y, height_raster=z)
# TypeError: topo(): incompatible function arguments
```

The CPU sibling accepts the same call and produces the requested
layers. Full evidence — including pybind11 docstring inspection and a
self-contained repro that imports only `isce3` — is in #265.

## What's in this PR

Two commits:

1. **Restore `= nullptr` defaults to CUDA `Rdr2Geo.topo()` optional rasters**
   — adds `= nullptr` to the 11 output-raster kwargs in
   `python/extensions/pybind_isce3/cuda/geometry/rdr2geo.cpp` to mirror
   the CPU sibling and the C++ class signature
   (`cxx/isce3/cuda/geometry/Topo.h:43-54`). Also renames
   `local_Psi_raster` → `local_psi_raster` for parity with the CPU
   binding (the lowercase form was already used by the CPU sibling and
   by the shared docstring; the capital-P was a leftover from the same
   rewrite that dropped the defaults).
2. **Add CUDA `Rdr2Geo.topo()` optional-rasters regression test** —
   `test_run_optional_layers` in
   `tests/python/extensions/pybind/cuda/geometry/rdr2geo.py` exercises
   the kwarg-subset call shape (subset of layers requested, others
   passed as `None` or omitted) so future binding-layer regressions on
   the optional path get caught. Also gates the whole module with
   `pytestmark = pytest.mark.skipif` on `isce3.cuda` availability so
   CPU-only builds skip cleanly with a reason rather than failing
   fixture collection.

Net diff: ~15 lines of binding code (11 `= nullptr` + the rename) plus a
regression test. No kernel changes, no C++ class changes — purely a
binding-layer restoration.

## Why this is regression-shaped, not a feature

The defaults existed historically. The "Regression history" section in
#265 traces this: commit `a19944c0` (2022, "Optional topo layers") added
`= nullptr` to **both** the CPU and CUDA bindings symmetrically. The
later commit `362813e7` (2023, "ground-to-sat East/North components")
rewrote the CUDA binding block in a different formatting style and
silently dropped every `= nullptr` along the way, while the CPU sibling
was edited in place and kept its defaults. This PR restores the
pre-`362813e7` contract for the CUDA side.

## Why existing CI didn't catch it

`tests/python/extensions/pybind/cuda/geometry/rdr2geo.py::test_run_raster_layers`
exercises the multi-raster overload but always passes **every** raster
kwarg explicitly. No test ever exercised the optional path on the CUDA
side, so CI was green through `362813e7`. The new
`test_run_optional_layers` covers the gap.

Internal NISAR callers (`nisar/workflows/{rdr2geo,geocode_corrections}.py`)
pass all 12 raster args positionally with the unwanted ones as `None`.
pybind11 converts `None → nullptr` for `Raster*` arguments regardless of
whether the binding declares a default, so those callers are insensitive
to the missing defaults. Only kwarg-subset callers hit it.

## Tests

`pytest tests/python/extensions/pybind/cuda/geometry/rdr2geo.py -v` —
5/5 PASS (existing 4 + the new `test_run_optional_layers`) on a
CUDA-enabled build. On a CPU-only build the whole module reports a
clean skip via `pytestmark`.

The standalone `isce3`-only repro in #265 ("Reproducing" section) goes
from `CPU defaults=11/PASS, CUDA defaults=0/TypeError` (BEFORE) to
`CPU defaults=11/PASS, CUDA defaults=11/PASS` (AFTER) on this branch.

## Notes

- `#868` and `#1393` referenced by `a19944c0` and `362813e7` commit
  messages are JPL-internal MCR numbers (GitLab), not GitHub PRs.
- The C++ class signature is unchanged; this is purely binding-layer.
- Rebased onto current `develop` HEAD `2919e1c97` (no conflicts —
  upstream files touched by intervening commits #205, #268, #269 are
  disjoint from the two files in this PR).
