### PR TITLE
add ionosphere mask to InSAR mask

### DIFF
--- a/python/packages/nisar/products/insar/GOFF_writer.py
+++ b/python/packages/nisar/products/insar/GOFF_writer.py
@@ -132,9 +132,7 @@ class GOFFWriter(ROFFWriter, L2InSARWriter):
                  " bits 16–23 represent bitwise anomaly flags for the reference RSLC,"
                  " with each bit corresponding to a specific anomaly condition."
                  " A value of 0 in the anomaly bits indicates that no anomaly is detected in the corresponding RSLC."
-                 " Bit 24 indicates a bit mask for ionospheric phase mask used during filtering of ionospheric phase."
-                 " This ionospheric phase mask indicates pixels which were masked out and filled with interpolated data."
-                 " Bits 25–31 are reserved for future use"),
+                 " Bits 24–31 are reserved for future use"),
                 grid_mapping=grids_val,
                 xds=xds,
                 yds=yds,

--- a/python/packages/nisar/products/insar/GOFF_writer.py
+++ b/python/packages/nisar/products/insar/GOFF_writer.py
@@ -132,7 +132,9 @@ class GOFFWriter(ROFFWriter, L2InSARWriter):
                  " bits 16–23 represent bitwise anomaly flags for the reference RSLC,"
                  " with each bit corresponding to a specific anomaly condition."
                  " A value of 0 in the anomaly bits indicates that no anomaly is detected in the corresponding RSLC."
-                 " Bits 24–31 are reserved for future use"),
+                 " Bit 24 indicates a bit mask for ionospheric phase mask used during filtering of ionospheric phase."
+                 " This ionospheric phase mask indicates pixels which were masked out and filled with interpolated data."
+                 " Bits 25–31 are reserved for future use"),
                 grid_mapping=grids_val,
                 xds=xds,
                 yds=yds,

--- a/python/packages/nisar/products/insar/GUNW_writer.py
+++ b/python/packages/nisar/products/insar/GUNW_writer.py
@@ -305,7 +305,9 @@ class GUNWWriter(RUNWWriter, RIFGWriter, L2InSARWriter):
                      " bits 16–23 represent bitwise anomaly flags for the reference RSLC,"
                      " with each bit corresponding to a specific anomaly condition."
                      " A value of 0 in the anomaly bits indicates that no anomaly is detected in the corresponding RSLC."
-                     " Bits 24–31 are reserved for future use"),
+                     " Bit 24 indicates a bit mask for ionospheric phase mask used during filtering of ionospheric phase."
+                     " This ionospheric phase mask indicates pixels which were masked out and filled with interpolated data."
+                     " Bits 25–31 are reserved for future use"),
                     grid_mapping=grids_val,
                     xds=xds,
                     yds=yds,

--- a/python/packages/nisar/products/insar/GUNW_writer.py
+++ b/python/packages/nisar/products/insar/GUNW_writer.py
@@ -229,6 +229,31 @@ class GUNWWriter(RUNWWriter, RIFGWriter, L2InSARWriter):
 
         grids_val = "projection"
 
+        mask_description_common = (
+            "Combination of a water mask, a mask of subswaths of valid samples, and data anomalies"
+            " in the reference RSLC and the geometrically coregistered secondary RSLC."
+            " Each pixel value is encoded as a 32-bit unsigned integer."
+            " Bits 0–7 represent subswath encoding, where the most significant digit represents"
+            " the water flag of that pixel in the reference RSLC, where 1 is water"
+            " and 0 is non-water; the second most significant digit corresponds to"
+            " the subswath number of the reference RSLC, and the least significant digit"
+            " corresponds to the subswath number of the secondary RSLC;"
+            " a value of 0 in either digit indicates an invalid sample in the corresponding RSLC."
+            " Bits 8–15 represent bitwise anomaly flags for the secondary RSLC, and"
+            " bits 16–23 represent bitwise anomaly flags for the reference RSLC,"
+            " with each bit corresponding to a specific anomaly condition."
+            " A value of 0 in the anomaly bits indicates that no anomaly is detected in the corresponding RSLC."
+        )
+
+        mask_description_iono = (
+            " Bit 24 indicates a bit mask for ionospheric phase mask used during filtering of ionospheric phase."
+            " This ionospheric phase mask indicates pixels which were masked out and filled with interpolated data."
+            " Bits 25–31 are reserved for future use"
+        )
+
+        mask_description_no_iono = (
+            " Bits 24–31 are reserved for future use"
+        )
         # Only add the common fields such as list of polarizations, pixel offsets, and center frequency
         for freq, pol_list, _ in get_cfg_freq_pols(self.cfg):
             # Create the swath group
@@ -285,6 +310,13 @@ class GUNWWriter(RUNWWriter, RIFGWriter, L2InSARWriter):
                     ds_group_name,
                     ds_geogrid,
                 )
+                mask_description_suffix = (
+                    mask_description_no_iono
+                    if ds_group_name == pixeloffsets_group_name
+                    else mask_description_iono
+                )
+
+                mask_description = mask_description_common + mask_description_suffix
 
                 self._create_2d_dataset(
                     ds_group,
@@ -292,30 +324,15 @@ class GUNWWriter(RUNWWriter, RIFGWriter, L2InSARWriter):
                     (ds_geogrid.length,
                      ds_geogrid.width),
                     np.uint32,
-                    ("Combination of a water mask, a mask of subswaths of valid samples, and data anomalies"
-                     " in the reference RSLC and the geometrically coregistered secondary RSLC."
-                     " Each pixel value is encoded as a 32-bit unsigned integer."
-                     " Bits 0–7 represent subswath encoding, where the most significant digit represents"
-                     " the water flag of that pixel in the reference RSLC, where 1 is water"
-                     " and 0 is non-water; the second most significant digit corresponds to"
-                     " the subswath number of the reference RSLC, and the least significant digit"
-                     " corresponds to the subswath number of the secondary RSLC;"
-                     " a value of 0 in either digit indicates an invalid sample in the corresponding RSLC."
-                     " Bits 8–15 represent bitwise anomaly flags for the secondary RSLC, and"
-                     " bits 16–23 represent bitwise anomaly flags for the reference RSLC,"
-                     " with each bit corresponding to a specific anomaly condition."
-                     " A value of 0 in the anomaly bits indicates that no anomaly is detected in the corresponding RSLC."
-                     " Bit 24 indicates a bit mask for ionospheric phase mask used during filtering of ionospheric phase."
-                     " This ionospheric phase mask indicates pixels which were masked out and filled with interpolated data."
-                     " Bits 25–31 are reserved for future use"),
+                    mask_description,
                     grid_mapping=grids_val,
                     xds=xds,
                     yds=yds,
                     fill_value=255,
                 )
-            ds_group['mask'].attrs['valid_min'] = 0
-            ds_group['mask'].attrs['percentage_water'] = 0.0
-            ds_group['mask'].attrs['disclaimer'] = to_bytes(self.water_mask_source)
+                ds_group['mask'].attrs['valid_min'] = 0
+                ds_group['mask'].attrs['percentage_water'] = 0.0
+                ds_group['mask'].attrs['disclaimer'] = to_bytes(self.water_mask_source)
 
             for pol in pol_list:
                 unwrapped_pol_name = f"{unwrapped_group_name}/{pol}"
@@ -327,8 +344,8 @@ class GUNWWriter(RUNWWriter, RIFGWriter, L2InSARWriter):
                     unwrapped_geogrids,
                 )
 
-                #unwrapped dataset parameters as tuples in the following
-                #order: dataset name, data type, description, and units
+                # unwrapped dataset parameters as tuples in the following
+                # order: dataset name, data type, description, and units
                 unwrapped_ds_params = [
                     ("coherenceMagnitude", np.float32,
                      f"Coherence magnitude between {pol} layers",

--- a/python/packages/nisar/products/insar/InSAR_L1_writer.py
+++ b/python/packages/nisar/products/insar/InSAR_L1_writer.py
@@ -505,7 +505,9 @@ class L1InSARWriter(InSARBaseWriter):
                                                  " and bits 16–23 represent bitwise anomaly flags for the reference RSLC,"
                                                  " with each bit corresponding to a specific anomaly condition."
                                                  " A value of 0 in the anomaly bits indicates that no anomaly is detected in the corresponding RSLC."
-                                                 " Bits 24–31 are reserved for future use"),
+                                                 " Bit 24 indicates a bit mask for ionospheric phase mask used during filtering of ionospheric phase."
+                                                 " This ionospheric phase mask indicates pixels which were masked out and filled with interpolated data."
+                                                 " Bits 25–31 are reserved for future use"),
                                     fill_value=255)
             offset_group['mask'].attrs['long_name'] = to_bytes("Valid samples subswath and data anomaly mask")
             offset_group['mask'].attrs['valid_min'] = 0
@@ -723,7 +725,9 @@ class L1InSARWriter(InSARBaseWriter):
                                                  " and bits 16–23 represent bitwise anomaly flags for the reference RSLC,"
                                                  " with each bit corresponding to a specific anomaly condition."
                                                  " A value of 0 in the anomaly bits indicates that no anomaly is detected in the corresponding RSLC."
-                                                 " Bits 24–31 are reserved for future use"),
+                                                 " Bit 24 indicates a bit mask for ionospheric phase mask used during filtering of ionospheric phase."
+                                                 " This ionospheric phase mask indicates pixels which were masked out and filled with interpolated data."
+                                                 " Bits 25–31 are reserved for future use"),
                                     fill_value=255)
             igram_group['mask'].attrs['valid_min'] = 0
             igram_group['mask'].attrs['long_name'] = to_bytes("Valid samples subswath and data anomaly mask")

--- a/python/packages/nisar/products/insar/InSAR_L1_writer.py
+++ b/python/packages/nisar/products/insar/InSAR_L1_writer.py
@@ -505,9 +505,7 @@ class L1InSARWriter(InSARBaseWriter):
                                                  " and bits 16–23 represent bitwise anomaly flags for the reference RSLC,"
                                                  " with each bit corresponding to a specific anomaly condition."
                                                  " A value of 0 in the anomaly bits indicates that no anomaly is detected in the corresponding RSLC."
-                                                 " Bit 24 indicates a bit mask for ionospheric phase mask used during filtering of ionospheric phase."
-                                                 " This ionospheric phase mask indicates pixels which were masked out and filled with interpolated data."
-                                                 " Bits 25–31 are reserved for future use"),
+                                                 " Bits 24–31 are reserved for future use"),
                                     fill_value=255)
             offset_group['mask'].attrs['long_name'] = to_bytes("Valid samples subswath and data anomaly mask")
             offset_group['mask'].attrs['valid_min'] = 0

--- a/python/packages/nisar/workflows/ionosphere.py
+++ b/python/packages/nisar/workflows/ionosphere.py
@@ -1950,7 +1950,7 @@ def run(cfg: dict, runw_hdf5: str):
                     existing_range = None
                     new_range = None
 
-                with HDF5OptimizedReader(name=iono_output, mode='a',
+                with HDF5OptimizedReader(name=runw_path_insar, mode='a',
                                          libver='latest') as dst_h5:
                     update_hdf5_mask_bit24_block(
                         dst_h5,

--- a/python/packages/nisar/workflows/ionosphere.py
+++ b/python/packages/nisar/workflows/ionosphere.py
@@ -237,6 +237,67 @@ def decimate_freq_a_offset(iono_insar_cfg, original_dict):
                             file_type='ENVI')
 
 
+def add_binary_mask_to_bit24(existing_mask,
+                             new_binary_mask,
+                             existing_range_array=None,
+                             new_range_array=None):
+    """
+    Encode a boolean mask into bit 24 of an existing 32-bit integer mask.
+    If shapes differ, resample new_binary_mask to existing_mask grid.
+    """
+    existing_mask = np.asarray(existing_mask, dtype=np.uint32)
+    new_binary_mask = np.asarray(new_binary_mask, dtype=bool)
+
+    if existing_mask.shape != new_binary_mask.shape:
+        if existing_range_array is None or new_range_array is None:
+            raise ValueError(
+                "existing_range_array and new_range_array are required "
+                "when shapes differ."
+            )
+        new_binary_mask = interpolate_freq_b_array(
+            existing_range_array,
+            new_range_array,
+            new_binary_mask
+        ).astype(bool)
+
+    if existing_mask.shape != new_binary_mask.shape:
+        raise ValueError(
+            f"Shape mismatch after interpolation: "
+            f"existing_mask={existing_mask.shape}, "
+            f"new_binary_mask={new_binary_mask.shape}"
+        )
+
+    cleared_mask = existing_mask & np.uint32(0xFEFFFFFF)
+    shifted_new_bits = new_binary_mask.astype(np.uint32) << 24
+
+    return cleared_mask | shifted_new_bits
+
+
+def update_hdf5_mask_bit24_block(
+        h5_file,
+        mask_dataset_path,
+        new_binary_mask,
+        row_start,
+        existing_range_array=None,
+        new_range_array=None):
+
+    dst_mask = h5_file[mask_dataset_path]
+
+    block_rows = new_binary_mask.shape[0]
+
+    existing_mask = dst_mask[
+        row_start:row_start + block_rows, :
+    ]
+
+    updated_mask = add_binary_mask_to_bit24(
+        existing_mask=existing_mask,
+        new_binary_mask=new_binary_mask,
+        existing_range_array=existing_range_array,
+        new_range_array=new_range_array)
+
+    dst_mask[row_start:row_start + block_rows, :] = updated_mask
+
+
 def copy_iono_datasets(iono_insar_cfg,
                        input_runw,
                        output_runw,
@@ -1121,7 +1182,7 @@ def run(cfg: dict, runw_hdf5: str):
 
     # Run InSAR for sub-band SLCs (split-main-bands) or
     # for main and side bands for iono_freq_pols (main-side-bands)
-    insar_ionosphere_pair(iono_insar_cfg, runw_hdf5)
+    # insar_ionosphere_pair(iono_insar_cfg, runw_hdf5)
 
     t_all = time.time()
     # Define methods to use subband or sideband
@@ -1868,6 +1929,7 @@ def run(cfg: dict, runw_hdf5: str):
                     slant_main=main_slant,
                     slant_side=side_slant,
                     invalid_value=0)
+                final_iono_mask = mask_array & valid_area & valid_area_coh
 
                 mask_path = os.path.join(
                     iono_path, iono_method, pol_comb_str, 'mask_array')
@@ -1875,10 +1937,28 @@ def run(cfg: dict, runw_hdf5: str):
                 # ENVI format files
                 write_array(
                     mask_path,
-                    mask_array & valid_area & valid_area_coh,
+                    final_iono_mask,
                     data_type=gdal.GDT_Float32,
                     block_row=row_start,
                     data_shape=[rows_output, cols_output])
+
+                if iono_method in iono_method_sideband:
+                    existing_range = main_slant
+                    new_range = side_slant
+
+                else:
+                    existing_range = None
+                    new_range = None
+
+                with HDF5OptimizedReader(name=iono_output_runw, mode='a',
+                                         libver='latest') as dst_h5:
+                    update_hdf5_mask_bit24_block(
+                        dst_h5,
+                        subswath_mask_freq_a_path,
+                        final_iono_mask,
+                        row_start=row_start,
+                        existing_range_array=existing_range,
+                        new_range_array=new_range)
 
         if filter_bool:
             # if unwrapping correction technique is not requested,

--- a/python/packages/nisar/workflows/ionosphere.py
+++ b/python/packages/nisar/workflows/ionosphere.py
@@ -1182,7 +1182,7 @@ def run(cfg: dict, runw_hdf5: str):
 
     # Run InSAR for sub-band SLCs (split-main-bands) or
     # for main and side bands for iono_freq_pols (main-side-bands)
-    # insar_ionosphere_pair(iono_insar_cfg, runw_hdf5)
+    insar_ionosphere_pair(iono_insar_cfg, runw_hdf5)
 
     t_all = time.time()
     # Define methods to use subband or sideband
@@ -1950,7 +1950,7 @@ def run(cfg: dict, runw_hdf5: str):
                     existing_range = None
                     new_range = None
 
-                with HDF5OptimizedReader(name=iono_output_runw, mode='a',
+                with HDF5OptimizedReader(name=iono_output, mode='a',
                                          libver='latest') as dst_h5:
                     update_hdf5_mask_bit24_block(
                         dst_h5,


### PR DESCRIPTION
This PR adds support for writing the ionosphere filter mask into bit 24 of the InSAR HDF5 mask dataset.

- Encodes the final ionosphere mask into bit 24 of the existing HDF5 mask.
- Preserves all existing mask bits by clearing and updating only bit 24.
- Supports cases where the generated mask and target HDF5 mask have different range dimensions for different ionosphere estimation method.
- Resamples the generated mask to the target HDF5 mask grid when needed, especially for side-band-based ionosphere methods.
