### PR TITLE
Fix bug with repeated calls to form_pattern

### DIFF
--- a/python/packages/nisar/antenna/pattern.py
+++ b/python/packages/nisar/antenna/pattern.py
@@ -399,7 +399,7 @@ class AntennaPattern:
             channel_adj_fact_rx = (
                 self.rx_imb[self.freq_band, txrx_pol].lna_caltone_ratio)
             if self.channel_adj_fact_rx[rxp] is not None:
-                channel_adj_fact_rx *= np.asarray(
+                channel_adj_fact_rx = channel_adj_fact_rx * np.asarray(
                     self.channel_adj_fact_rx[rxp])
 
             # Split up provided timespan into groups with the same range timing


### PR DESCRIPTION
I was trying to optimize the antenna pattern weights and thought I was going crazy because I'd get different patterns every time I called `AntennaPattern.form_pattern`. It turns out #231 introduced a bug where the receive pattern weights mutate the stored LNA/caltone ratio on every call.

In focus.py we only call `form_pattern` twice on each instance, once for the science data and then again for the noise data. So in production the image is fine but the noise equivalent backscatter is calculating the wrong RX pattern whenever the weights aren't unity.