### PR TITLE
Update to PIX 1.5.0 product specification

### DIFF
--- a/python/packages/nisar/products/XML/L2/nisar_L2_GCOV.xml
+++ b/python/packages/nisar/products/XML/L2/nisar_L2_GCOV.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!-- product specification version is 1.4.0 -->
+<!-- product specification version is 1.5.0 -->
 <algorithm name="L2_GeocodedCovariance"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <product template="L2_GCOV_template">

--- a/python/packages/nisar/products/XML/L2/nisar_L2_GSLC.xml
+++ b/python/packages/nisar/products/XML/L2/nisar_L2_GSLC.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!-- product specification version is 1.4.0 -->
+<!-- product specification version is 1.5.0 -->
 <algorithm name="L2_GeocodedSlc"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <product template="L2_GSLC_template">

--- a/python/packages/nisar/products/XML/L2/nisar_L2_STATIC.xml
+++ b/python/packages/nisar/products/XML/L2/nisar_L2_STATIC.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!-- product specification version is 1.4.0 -->
+<!-- product specification version is 1.5.0 -->
 <algorithm name="L2_StaticLayers"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <product template="L2_STATIC_template">

--- a/python/packages/nisar/products/insar/InSAR_products_info.py
+++ b/python/packages/nisar/products/insar/InSAR_products_info.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import isce3
 
 ISCE3_VERSION = isce3.__version__
-PRODUCT_SPECIFICATION_VERSION = "1.4.0"
+PRODUCT_SPECIFICATION_VERSION = "1.5.0"
 
 @dataclass
 class InSARProductsInfo:
@@ -15,7 +15,7 @@ class InSARProductsInfo:
     Attributes
     ----------
     ProductSpecificationVersion : str
-        Product specification version (default is '1.4.0')
+        Product specification version (default is '1.5.0')
     ProductType : str
         Product type, one of 'RIFG', 'ROFF', 'RUNW', 'GOFF', 'GUNW'
     ProductLevel : str

--- a/python/packages/nisar/products/writers/BaseWriterSingleInput.py
+++ b/python/packages/nisar/products/writers/BaseWriterSingleInput.py
@@ -623,7 +623,7 @@ class BaseWriterSingleInput():
 
         self.set_value(
             'identification/productSpecificationVersion',
-            '1.4.0')
+            '1.5.0')
 
         self.copy_from_input(
             'identification/lookDirection',

--- a/python/packages/nisar/products/writers/SLC.py
+++ b/python/packages/nisar/products/writers/SLC.py
@@ -702,7 +702,7 @@ class SLC(h5py.File):
                             has_input_data_exception: int = None,
                             is_urgent: Optional[bool] = None,
                             is_joint: Optional[bool] = None,
-                            product_spec_version: str = "1.4.0",
+                            product_spec_version: str = "1.5.0",
                             processing_center: str = "JPL",
                             granule_id: str = "None",
                             product_version: str = "0.1.0",

--- a/python/packages/nisar/workflows/h5_prep.py
+++ b/python/packages/nisar/workflows/h5_prep.py
@@ -258,7 +258,7 @@ def cp_geocode_meta(cfg, output_hdf5, dst):
 
         # Assign product specification version
         dst_h5[f'{ident_path}/productSpecificationVersion'] = \
-            np.bytes_('1.4.0')
+            np.bytes_('1.5.0')
 
         # Assign granule ID
         dst_h5[f'{ident_path}/granuleId'] = \


### PR DESCRIPTION
This PR updates the PIX Product Specification version to 1.5.0.

Notes:
While the output ISCE3 HDF5 files and the PIX product specs are getting closer to being in sync, they are still not perfectly in-sync.

Here are the known discrepancies as of 3 months ago. Several of these persist, some might have been resolved, and there could be additional new discrepancies:

* https://github.com/isce-framework/isce3/issues/202
* https://github.com/isce-framework/isce3/issues/203
* https://github.com/isce-framework/isce3/issues/204
