### PR TITLE
Fix BCAL normalization of first block

### DIFF
--- a/python/packages/nisar/antenna/beamformer.py
+++ b/python/packages/nisar/antenna/beamformer.py
@@ -815,6 +815,11 @@ def compute_transmit_pattern_weights(tx_trm_info, norm=False):
         if np.isclose(abs(tx_weights[bcal_lines_idx]).min(), 0):
             raise RuntimeError('Zero-value BCAL data is encountered!')
 
+        # handle case where first line isn't BCAL
+        bcal_rel = (tx_weights[bcal_lines_idx[0]] /
+                    tx_weights[bcal_lines_idx[0], 0])
+        tx_weights[:bcal_lines_idx[0]] /= bcal_rel
+
         for line_start, line_stop in zip(bcal_lines_idx[:-1],
                                          bcal_lines_idx[1:]):
             # normalize BCAL wrt to the first TX channel to get relative
@@ -827,12 +832,6 @@ def compute_transmit_pattern_weights(tx_trm_info, norm=False):
         bcal_rel = (tx_weights[bcal_lines_idx[-1]] /
                     tx_weights[bcal_lines_idx[-1], 0])
         tx_weights[bcal_lines_idx[-1]:] /= bcal_rel
-
-        # handle case where first line isn't BCAL
-        bcal_rel = (tx_weights[bcal_lines_idx[0]] /
-                    tx_weights[bcal_lines_idx[0], 0])
-        tx_weights[:bcal_lines_idx[0]] /= bcal_rel
-
 
     # Now fill in noise-only range lines with nearest neighbor values
     # from HCAL ones

--- a/python/packages/nisar/antenna/beamformer.py
+++ b/python/packages/nisar/antenna/beamformer.py
@@ -828,6 +828,12 @@ def compute_transmit_pattern_weights(tx_trm_info, norm=False):
                     tx_weights[bcal_lines_idx[-1], 0])
         tx_weights[bcal_lines_idx[-1]:] /= bcal_rel
 
+        # handle case where first line isn't BCAL
+        bcal_rel = (tx_weights[bcal_lines_idx[0]] /
+                    tx_weights[bcal_lines_idx[0], 0])
+        tx_weights[:bcal_lines_idx[0]] /= bcal_rel
+
+
     # Now fill in noise-only range lines with nearest neighbor values
     # from HCAL ones
     func_nearest = interp1d(hcal_lines_idx, tx_weights[hcal_lines_idx],


### PR DESCRIPTION
In the elevation antenna pattern code, the transmit path is characterized by the ratio of high-power amplifier calibration loop (HCAL) and bypass calibration loop (BCAL) measurements (normalized by the BCAL of the first channel). The HCAL and BCAL measurements are interleaved in time, so some logic is needed to associate the correct pairs of HCAL and BCAL measurements.

The existing code assumes that the first pulse is a BCAL measurement, which is typically true for the first observation in a data take. However, subsequent observations may not start with a BCAL. In those cases, a block of HCAL weights does not get properly normalized and the resulting antenna pattern is wrong. This PR handles the case by using the first BCAL to normalized the first set of HCAL pulses, even if that BCAL happens later in time.