### PR TITLE
Support multiple preprocessing mask types for unwrap

### DIFF
--- a/share/nisar/defaults/insar.yaml
+++ b/share/nisar/defaults/insar.yaml
@@ -677,7 +677,7 @@ runconfig:
                         # 1) median_filter: compute mask with median absolute deviation thresholding
                         # 2) coherence: compute mask with normalized InSAR coherence thresholding
                         # 3) water: extract water areas from water mask file in dynamic ancillary data
-                        mask_type: coherence
+                        mask_type: ['subswath_mask']
                         # buffer from the land. Unit is [km]. Buffer should be integer.
                         ocean_water_buffer: 1
                         inland_water_buffer: 1

--- a/share/nisar/schemas/insar.yaml
+++ b/share/nisar/schemas/insar.yaml
@@ -244,7 +244,7 @@ preprocess_wrapped_phase_options:
     distance_interpolator: include('distance_interp_options', required=False)
 
 unwrap_mask_options:
-    mask_type: enum('median_filter', 'coherence', 'water', 'subswath_mask', required=False)
+    mask_type: list(enum('median_filter', 'coherence', 'water', 'subswath_mask'), required=False)
     mask_path: str(required=False)
     ocean_water_buffer: int(min=0, max=100, required=False)
     inland_water_buffer: int(min=0, max=100, required=False)


### PR DESCRIPTION
This PR updates `mask_type` to support multiple mask options for unwrap preprocessing. The parameter now accepts a list of selected mask types, such as:

mask_type: ['water', 'coherence']

This allows users to combine multiple filter masks, including water, median_filter, coherence, and subswath_mask, instead of selecting only a single mask type.