### PR TITLE
(InSAR) Replace en dash (U+2013) with ASCII hyphen in HDF5 descriptions

### DIFF
--- a/python/packages/isce3/signal/rfi_freq_null.py
+++ b/python/packages/isce3/signal/rfi_freq_null.py
@@ -140,7 +140,7 @@ def run_freq_notch(
     __________
     ..[1]  F. Meyer, J. Nicoll, and A. Doulgeris, “Correction and Characterization 
     of Radio Frequency Interference Signatures in L-Band Synthetic Aperture Radar 
-    Data”, IEEE Trans. Geosci. Remote Sens., vol. 51, no. 10, pp. 4961–4972, Oct. 2013.
+    Data”, IEEE Trans. Geosci. Remote Sens., vol. 51, no. 10, pp. 4961-4972, Oct. 2013.
     """
 
     # Modify raw_data in-place

--- a/python/packages/nisar/products/insar/GOFF_writer.py
+++ b/python/packages/nisar/products/insar/GOFF_writer.py
@@ -122,17 +122,17 @@ class GOFFWriter(ROFFWriter, L2InSARWriter):
                 ("Combination of a water mask, a mask of subswaths of valid samples, and data anomalies"
                  " in the reference RSLC and the geometrically coregistered secondary RSLC."
                  " Each pixel value is encoded as a 32-bit unsigned integer."
-                 " Bits 0–7 represent subswath encoding, where the most significant digit represents"
+                 " Bits 0-7 represent subswath encoding, where the most significant digit represents"
                  " the water flag of that pixel in the reference RSLC, where 1 is water"
                  " and 0 is non-water; the second most significant digit corresponds to"
                  " the subswath number of the reference RSLC, and the least significant digit"
                  " corresponds to the subswath number of the secondary RSLC;"
                  " a value of 0 in either digit indicates an invalid sample in the corresponding RSLC."
-                 " Bits 8–15 represent bitwise anomaly flags for the secondary RSLC, and"
-                 " bits 16–23 represent bitwise anomaly flags for the reference RSLC,"
+                 " Bits 8-15 represent bitwise anomaly flags for the secondary RSLC, and"
+                 " bits 16-23 represent bitwise anomaly flags for the reference RSLC,"
                  " with each bit corresponding to a specific anomaly condition."
                  " A value of 0 in the anomaly bits indicates that no anomaly is detected in the corresponding RSLC."
-                 " Bits 24–31 are reserved for future use"),
+                 " Bits 24-31 are reserved for future use"),
                 grid_mapping=grids_val,
                 xds=xds,
                 yds=yds,

--- a/python/packages/nisar/products/insar/GUNW_writer.py
+++ b/python/packages/nisar/products/insar/GUNW_writer.py
@@ -233,14 +233,14 @@ class GUNWWriter(RUNWWriter, RIFGWriter, L2InSARWriter):
             "Combination of a water mask, a mask of subswaths of valid samples, and data anomalies"
             " in the reference RSLC and the geometrically coregistered secondary RSLC."
             " Each pixel value is encoded as a 32-bit unsigned integer."
-            " Bits 0–7 represent subswath encoding, where the most significant digit represents"
+            " Bits 0-7 represent subswath encoding, where the most significant digit represents"
             " the water flag of that pixel in the reference RSLC, where 1 is water"
             " and 0 is non-water; the second most significant digit corresponds to"
             " the subswath number of the reference RSLC, and the least significant digit"
             " corresponds to the subswath number of the secondary RSLC;"
             " a value of 0 in either digit indicates an invalid sample in the corresponding RSLC."
-            " Bits 8–15 represent bitwise anomaly flags for the secondary RSLC, and"
-            " bits 16–23 represent bitwise anomaly flags for the reference RSLC,"
+            " Bits 8-15 represent bitwise anomaly flags for the secondary RSLC, and"
+            " bits 16-23 represent bitwise anomaly flags for the reference RSLC,"
             " with each bit corresponding to a specific anomaly condition."
             " A value of 0 in the anomaly bits indicates that no anomaly is detected in the corresponding RSLC."
         )
@@ -248,11 +248,11 @@ class GUNWWriter(RUNWWriter, RIFGWriter, L2InSARWriter):
         mask_description_iono = (
             " Bit 24 indicates a bit mask for ionospheric phase mask used during filtering of ionospheric phase."
             " This ionospheric phase mask indicates pixels which were masked out and filled with interpolated data."
-            " Bits 25–31 are reserved for future use"
+            " Bits 25-31 are reserved for future use"
         )
 
         mask_description_no_iono = (
-            " Bits 24–31 are reserved for future use"
+            " Bits 24-31 are reserved for future use"
         )
         # Only add the common fields such as list of polarizations, pixel offsets, and center frequency
         for freq, pol_list, _ in get_cfg_freq_pols(self.cfg):

--- a/python/packages/nisar/products/insar/InSAR_L1_writer.py
+++ b/python/packages/nisar/products/insar/InSAR_L1_writer.py
@@ -497,15 +497,15 @@ class L1InSARWriter(InSARBaseWriter):
                                     description=("Mask indicating the subswaths of valid samples and data anomalies"
                                                  " in the reference RSLC and the geometrically coregistered secondary RSLC."
                                                  " Each pixel value is encoded as a 32-bit unsigned integer."
-                                                 " Bits 0–7 represent subswath encoding,"
+                                                 " Bits 0-7 represent subswath encoding,"
                                                  " where the most significant digit corresponds to the subswath number of the reference RSLC"
                                                  " and the least significant digit corresponds to the subswath number of the secondary RSLC;"
                                                  " a value of 0 in either digit indicates an invalid sample in the corresponding RSLC."
-                                                 " Bits 8–15 represent bitwise anomaly flags for the secondary RSLC,"
-                                                 " and bits 16–23 represent bitwise anomaly flags for the reference RSLC,"
+                                                 " Bits 8-15 represent bitwise anomaly flags for the secondary RSLC,"
+                                                 " and bits 16-23 represent bitwise anomaly flags for the reference RSLC,"
                                                  " with each bit corresponding to a specific anomaly condition."
                                                  " A value of 0 in the anomaly bits indicates that no anomaly is detected in the corresponding RSLC."
-                                                 " Bits 24–31 are reserved for future use"),
+                                                 " Bits 24-31 are reserved for future use"),
                                     fill_value=255)
             offset_group['mask'].attrs['long_name'] = to_bytes("Valid samples subswath and data anomaly mask")
             offset_group['mask'].attrs['valid_min'] = 0
@@ -711,20 +711,20 @@ class L1InSARWriter(InSARBaseWriter):
                 "Mask indicating the subswaths of valid samples and data anomalies"
                 " in the reference RSLC and the geometrically coregistered secondary RSLC."
                 " Each pixel value is encoded as a 32-bit unsigned integer."
-                " Bits 0–7 represent subswath encoding,"
+                " Bits 0-7 represent subswath encoding,"
                 " where the most significant digit corresponds to the subswath number of the reference RSLC"
                 " and the least significant digit corresponds to the subswath number of the secondary RSLC;"
                 " a value of 0 in either digit indicates an invalid sample in the corresponding RSLC."
-                " Bits 8–15 represent bitwise anomaly flags for the secondary RSLC,"
-                " and bits 16–23 represent bitwise anomaly flags for the reference RSLC,"
+                " Bits 8-15 represent bitwise anomaly flags for the secondary RSLC,"
+                " and bits 16-23 represent bitwise anomaly flags for the reference RSLC,"
                 " with each bit corresponding to a specific anomaly condition."
                 " A value of 0 in the anomaly bits indicates that no anomaly is detected in the corresponding RSLC."
             )
-            mask_description_no_iono =  " Bits 24–31 are reserved for future use"
+            mask_description_no_iono =  " Bits 24-31 are reserved for future use"
             mask_description_iono = (
                 " Bit 24 indicates a bit mask for ionospheric phase mask used during filtering of ionospheric phase."
                 " This ionospheric phase mask indicates pixels which were masked out and filled with interpolated data."
-                " Bits 25–31 are reserved for future use")
+                " Bits 25-31 are reserved for future use")
 
             mask_description = (
                 mask_description_common + mask_description_iono


### PR DESCRIPTION
Replaced Unicode en dash character (U+2013 "–") with standard ASCII hyphen (U+002d "-") in 19 locations across 4 Python files. The en dash was causing display issues in some programs, appearing as "â€"" instead of "–".

This issue is not readily visible to the human eye in all programs; for example, the en dash renders nicely in HDFView.

However, the issue does appear in e.g. H5Web extension for VSCode:

<img width="1103" height="521" alt="Screenshot 2026-06-15 at 2 15 09 PM" src="https://github.com/user-attachments/assets/10a57382-9ef2-4074-b78d-fb012e0fdd97" />


This fix ensures HDF5 attribute descriptions display correctly across all programs and avoids confusion with special Unicode characters in source code.

**NOTE: If this PR is approved, this change will need to be reflected in the PIX Product Specs as well. Currently, the product specs also use a Unicode en dash.**

cc: @hfattahi 