### PR TITLE
(RSLC) Inconsistent description text between XML and HDF5

### DIFF
--- a/python/packages/nisar/products/writers/SLC.py
+++ b/python/packages/nisar/products/writers/SLC.py
@@ -84,9 +84,9 @@ def add_cal_layer(group: h5py.Group, lut: LUT2d, name: str,
         # C++ API doesn't add descriptions...
         group[xname].attrs["description"] = np.bytes_("Slant range "
             "dimension corresponding to processing information records")
-        group[yname].attrs["description"] = np.bytes_("Zero Doppler time "
-            "since UTC epoch dimension corresponding to processing information "
-            "records")
+        group[yname].attrs["description"] = np.bytes_("Vector of zero Doppler "
+            "azimuth times, measured relative to a UTC epoch, corresponding to "
+            "processing information records")
         group[name].attrs["description"] = np.bytes_(description)
     else:
         raise IOError(f"Found only one of {xname} or {yname}."


### PR DESCRIPTION
**Location**:
- `/science/LSAR/RSLC/metadata/processingInformation/parameters/frequencyA/zeroDopplerTime`
- `/science/LSAR/RSLC/metadata/processingInformation/parameters/frequencyB/zeroDopplerTime`

**Description**: The `description` attribute text differs slightly between XML spec and HDF5 file.

**Changes Made**:
- **Before**: "Zero Doppler time since UTC epoch dimension corresponding to processing information records"
- **After**: "Vector of zero Doppler azimuth times, measured relative to a UTC epoch, corresponding to processing information records"

Link to internal PIX specs: https://github-fn.jpl.nasa.gov/NISAR-ADT/NISAR_PIX/blob/b6c9409e59f85cf1bc18dd6e363a838c2534f0f7/XML/L1/nisar_L1_RSLC.xml#L1741