### PR TITLE
Security: Integer Overflow in Chirp Size Calculation

### DIFF
--- a/cxx/isce3/focus/Chirp.cpp
+++ b/cxx/isce3/focus/Chirp.cpp
@@ -28,8 +28,7 @@ formLinearChirp(double chirprate,
 
     // check for possible overflow before double -> int conversion
     double d_size = samplerate * duration + 1;
-    double d_maxsize = std::numeric_limits<int>::max();
-    if (d_size > d_maxsize) {
+    if (d_size > std::numeric_limits<int>::max() || d_size < std::numeric_limits<int>::min()) {
         throw isce3::except::OverflowError(ISCE_SRCINFO(), "chirp size exceeds max int value");
     }
 


### PR DESCRIPTION
## Summary

Security: Integer Overflow in Chirp Size Calculation

## Problem

**Severity**: `Medium` | **File**: `cxx/isce3/focus/Chirp.cpp:L28`

In Chirp.cpp, the code checks if d_size > d_maxsize before converting to int, but uses std::floor(d_size) which returns a double. The check d_size > d_maxsize where d_maxsize = numeric_limits<int>::max() is not sufficient to prevent all overflow cases due to floating-point precision issues. A very large double value near INT_MAX could pass the check but still overflow when converted to int.

## Solution

Use a more robust overflow check. Instead of comparing doubles values, check if d_size > static_cast<double>(std::numeric_limits<int>::max()) or use std::numeric_limits<int>::max() directly as the threshold. Consider using size_t for the size variable instead of int to avoid the overflow entirely.

## Changes

- `cxx/isce3/focus/Chirp.cpp` (modified)