### PR TITLE
Handle case where no samples in a rangline are valid

### DIFF
--- a/python/packages/isce3/focus/__init__.py
+++ b/python/packages/isce3/focus/__init__.py
@@ -3,6 +3,6 @@ from .caltone import ToneRemover
 from .sar_duration import (get_sar_duration, get_radar_velocities,
 	predict_azimuth_envelope)
 from .valid_regions import (RadarPoint, RadarBoundingBox,
-	get_focused_sub_swaths, fill_gaps)
+	get_focused_sub_swaths, fill_gaps, find_bad_rangline_slices)
 from .calibration_luts import make_los_luts, make_cal_luts
 from .notch import Notch, FrequencyDomain

--- a/python/packages/isce3/focus/valid_regions.py
+++ b/python/packages/isce3/focus/valid_regions.py
@@ -597,7 +597,7 @@ def false_runs(arr: np.ndarray) -> list[slice]:
     padded = np.concatenate(([True], arr, [True]))
 
     # Find where transitions occur
-    diff = np.diff(padded.view(np.uint8))
+    diff = np.diff(padded.view(np.int8))
 
     # A False run starts where True→False (diff == -1), ends where False→True (diff == 1)
     starts = np.where(diff == -1)[0]  # index in original array

--- a/python/packages/isce3/focus/valid_regions.py
+++ b/python/packages/isce3/focus/valid_regions.py
@@ -549,6 +549,10 @@ def fill_gaps(data, swaths, value=np.complex64(0)):
         pulse_swaths = np.asarray(
             [swath for swath in pulse_swaths if swath[1] > swath[0]]
         )
+        # If there's no valid data then the whole rangeline is a "gap".
+        if len(pulse_swaths == 0):
+            yield slice(None)
+            return
         num_swaths = pulse_swaths.shape[0]
         # Gap leading up to first swath.
         yield slice(None, pulse_swaths[0, 0])

--- a/python/packages/isce3/focus/valid_regions.py
+++ b/python/packages/isce3/focus/valid_regions.py
@@ -574,3 +574,56 @@ def fill_gaps(data, swaths, value=np.complex64(0)):
     for ipulse in range(num_pulses):
         for gap in get_gap_slices(swaths[:, ipulse, :]):
             data[..., ipulse, gap] = value
+
+
+def false_runs(arr: np.ndarray) -> list[slice]:
+    """
+    Return a list of slices selecting continuous runs of False values.
+
+    Parameters
+    ----------
+    arr : np.ndarray
+        A 1D boolean NumPy array.
+
+    Returns
+    -------
+    list[slice]
+        A list of slice objects, each selecting a contiguous run of False values.
+    """
+    if arr.ndim != 1:
+        raise ValueError("Array must be 1D")
+
+    # Pad with True on both ends so edges are detected as transitions
+    padded = np.concatenate(([True], arr, [True]))
+
+    # Find where transitions occur
+    diff = np.diff(padded.view(np.uint8))
+
+    # A False run starts where True→False (diff == -1), ends where False→True (diff == 1)
+    starts = np.where(diff == -1)[0]  # index in original array
+    ends   = np.where(diff ==  1)[0]  # exclusive end in original array
+
+    return [slice(s, e) for s, e in zip(starts, ends)]
+
+
+def find_bad_rangline_slices(swaths):
+    """
+    Get slices corresponding to completely invalid rangelines.
+
+    Parameters
+    ----------
+    swaths : numpy.ndarray[int]
+        Array of [start, stop) valid data regions, shape = (nswath, npulse, 2)
+        where nswath is the number of valid sub-swaths and npulse is the length
+        of the raw image grid.
+
+    Returns
+    -------
+    num_invalid : int
+        Number of completely invalid ranglines.
+    slices : list[slice]
+        Azimuth index slices where all samples in the rangelines are invalid.
+    """
+    has_some_valid_data = np.any(swaths[..., 0] < swaths[..., 1], axis=0)
+    num_invalid = swaths.shape[1] - np.sum(has_some_valid_data)
+    return num_invalid, false_runs(has_some_valid_data)

--- a/python/packages/isce3/focus/valid_regions.py
+++ b/python/packages/isce3/focus/valid_regions.py
@@ -550,7 +550,7 @@ def fill_gaps(data, swaths, value=np.complex64(0)):
             [swath for swath in pulse_swaths if swath[1] > swath[0]]
         )
         # If there's no valid data then the whole rangeline is a "gap".
-        if len(pulse_swaths == 0):
+        if len(pulse_swaths) == 0:
             yield slice(None)
             return
         num_swaths = pulse_swaths.shape[0]

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -33,7 +33,8 @@ import nisar
 import numpy as np
 import isce3
 from isce3.core import DateTime, TimeDelta, LUT2d, Attitude, Orbit
-from isce3.focus import make_los_luts, fill_gaps, make_cal_luts, Notch
+from isce3.focus import (make_los_luts, fill_gaps, make_cal_luts, Notch,
+    find_bad_rangline_slices)
 from isce3.geometry import los2doppler
 from isce3.io.gdal import Raster, GDT_CFloat32
 from isce3.product import (RadarGridParameters,
@@ -1750,6 +1751,16 @@ def get_caltone_algorithm(cfg, fc, fs, n, is_dithered):
 
     return algorithm, wavelets
 
+
+def log_bad_pulses(swaths, max_slices=10):
+    n_bad_pulses, bad_slices = find_bad_rangline_slices(swaths)
+    log.info(f"Number of pulses with no valid samples = {n_bad_pulses}")
+    if n_bad_pulses > 0:
+        log.warning(f"Bad pulses appear in {len(bad_slices)} unique blocks")
+        for s in bad_slices[:max_slices]:
+            log.warning(f"Bad ranglines in pulse {s}")
+
+
 def focus(runconfig, runconfig_path=""):
     # Strip off two leading namespaces.
     cfg = runconfig.runconfig.groups
@@ -2050,6 +2061,7 @@ def focus(runconfig, runconfig_path=""):
             swaths = raw.getSubSwaths(channel_in.freq_id, tx=pol[0])
             swaths = swaths[:, pulse_begin:pulse_end, :]
             log.info(f"Number of sub-swaths = {swaths.shape[0]}")
+            log_bad_pulses(swaths)
 
             rawfd = temp(f"_{frequency}{pol}_raw.c8")
             log.info(f"Decoding raw data to memory map {rawfd.name}.")


### PR DESCRIPTION
This patch allows RSLC processing to continue when there are pulses in the L0B with no samples marked as valid. Without these changes one will get an error message like
```
  File "/opt/conda/lib/python3.12/site-packages/isce3/focus/valid_regions.py", line 554, in get_gap_slices
    yield slice(None, pulse_swaths[0, 0])
                      ~~~~~~~~~~~~^^^^^^
IndexError: too many indices for array: array is 1-dimensional, but 2 were indexed
```
While this limitation has been around for a while, it gains new relevance with the recent L0B processor update that marks the first 500 pulses of a datatake as invalid during the HPA warm-up period.

The heart of this patch is the four lines added to `isce3.focus.fill_gaps`. The rest of the changes are just to generate some concise log messages to help debugging cases with missing data down the line.