### PR TITLE
Improve error message related to missing telemetry (NSDS-5235)

### DIFF
--- a/python/packages/nisar/antenna/pattern.py
+++ b/python/packages/nisar/antenna/pattern.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from isce3.core import Orbit, Attitude, Linspace
 from isce3.geometry import DEMInterpolator
 import logging
+from pathlib import Path
 from nisar.products.readers.antenna import AntennaParser
 from nisar.products.readers.instrument import InstrumentParser
 from nisar.products.readers.Raw import (
@@ -119,8 +120,16 @@ def build_tx_trm(raw: Raw, pulse_times: np.ndarray, freq_band: str,
     # Parse Tx-related Cal stuff used for Tx BMF
     tx_chanl = raw.getListOfTxTRMs(freq_band, tx_pol)
     # get chirp correlator and cal type for co-pol product
+    copol = 2 * tx_pol
+    if copol not in raw.polarizations[freq_band]:
+        name = Path(raw.filename).name
+        raise ValueError(f"Require co-pol ({copol}) telemetry to build "
+            "transmit antenna pattern but these data are missing from "
+            f"raw data file ({name}).  Consider disabling elevation "
+            "antenna pattern correction by setting processing.is_enabled.eap "
+            "to False in the run configuration file.")
     chp_corr, cal_type = chirpcorrelator_caltype_from_raw(
-        raw, txrx_pol=2 * tx_pol)
+        raw, txrx_pol=copol)
     corr_tap2 = chp_corr[..., 1]
     # build TxTRM  from Tx Cal stuff w/o optional "tx_phase"
     return TxTrmInfo(pulse_times, tx_chanl, corr_tap2,

--- a/python/packages/nisar/products/readers/Raw/Raw.py
+++ b/python/packages/nisar/products/readers/Raw/Raw.py
@@ -1388,8 +1388,11 @@ def chirpcorrelator_caltype_from_raw(
     except KeyError:
         # XXX if the respective field does not exist then use co-pol under
         # swath in L0B for the sake of backward compatibility
-        freq_band = [f for f in raw.frequencies if
-                     txrx_pol in raw.polarizations[f]][0]
+        freq_bands = [f for f in raw.frequencies if
+                     txrx_pol in raw.polarizations[f]]
+        if len(freq_bands) == 0:
+            raise  # No band contains the desired pol, can't fall back.
+        freq_band = sorted(freq_bands)[0]
         chp_cor = raw.getChirpCorrelator(freq_band, txrx_pol[0])
         cal_type = raw.getCalType(freq_band, txrx_pol[0])
         return chp_cor, cal_type


### PR DESCRIPTION
SDS has reported several errors related to missing telemetry. The interpretation of the log message isn't so obvious, especially since the logic in an error handling block itself contains an error, so one gets two exception tracebacks. This PR fixes the problem in the low-level error handling and adds a more informative error message in the higher-level code.

The actual problem at hand is that data were collected in a dual-pol mode (HH and HV), but presumably something went awry with the downlink such that only HV made it into the L0B file. The processor is configured with elevation antenna pattern (EAP) correction enabled, and the loopback calibration telemetry is required to compute the patterns. However, there's no such thing as crosspol loopback cal; the transmit-H pattern must be formed using analysis of the HH loopback cal. Since that isn't available in the file, the EAP processing cannot proceed.