### PR TITLE
Update STATIC workflow for new water mask spec

### DIFF
--- a/python/packages/nisar/static/water_mask.py
+++ b/python/packages/nisar/static/water_mask.py
@@ -19,8 +19,8 @@ def binarize_nisar_water_mask(water_distance: ArrayLike) -> np.ndarray:
     ----------
     water_distance : array_like
         The input water distance map, in the format specified by the NISAR Water Mask
-        Product Specification\ [1]_. A value of 0 indicates a water pixel. A value of
-        255 represents a no-data (invalid) pixel. Values in 1-200 represent non-water
+        Product Specification\ [1]_. A value of 0 indicates a not-water pixel. A value
+        of 255 represents a no-data (invalid) pixel. Values in 1-200 represent water
         pixels.
 
     Returns
@@ -37,7 +37,7 @@ def binarize_nisar_water_mask(water_distance: ArrayLike) -> np.ndarray:
 
     # Compute a binary mask where the value 1 represents (ocean or inland) water pixels
     # and the value 0 represents non-water pixels.
-    water = water_distance == 0
+    water = (water_distance >= 1) & (water_distance <= 200)
 
     # Get a binary mask of invalid pixels (i.e. pixels whose value is equal to the fill
     # value of 255).
@@ -102,8 +102,8 @@ def binarize_and_reproject_water_mask(
     water_distance_raster_file : path-like
         The file path or name of the input water distance map file. It must be a
         GDAL-compatible raster file in the format specified by the NISAR Water Mask
-        Product Specification\ [1]_. A value of 0 indicates a water pixel. A value of
-        255 represents a no-data (invalid) pixel. Values in 1-200 represent non-water
+        Product Specification\ [1]_. A value of 0 indicates a not-water pixel. A value
+        of 255 represents a no-data (invalid) pixel. Values in 1-200 represent water
         pixels.
     geo_grid : isce3.product.GeoGridParameters
         The output geocoded coordinate grid to re-project the water mask onto.

--- a/share/nisar/defaults/static.yaml
+++ b/share/nisar/defaults/static.yaml
@@ -12,7 +12,9 @@ runconfig:
       # [REQUIRED] File path or URL of the input water mask raster file.
       # Must be an existing file in a GDAL-compatible raster format that spans the
       # region of interest and conforms to the NISAR Water Mask Product Specification
-      # (JPL D-107710).
+      # (JPL D-107710), where a value of 0 indicates a not-water pixel, a value
+      # of 255 represents a no-data (invalid) pixel, and values in 1-200 represent
+      # water pixels.
       water_mask_raster_file:
       # [REQUIRED] Path to the input orbit ephemeris XML file.
       # Must be an existing XML file conforming to the NISAR Orbit Ephemeris Product

--- a/tests/python/packages/nisar/static/water_mask.py
+++ b/tests/python/packages/nisar/static/water_mask.py
@@ -9,14 +9,14 @@ import isce3
 
 
 def test_binarize_nisar_water_mask():
-    # Create three arrays of water pixels (filled with zeros), non-water pixels (filled
+    # Create three arrays of non-water pixels (filled with zeros), water pixels (filled
     # with values in range [1, 200]), and invalid pixels (filled with 255).
-    water = np.zeros((20, 10), dtype=np.uint8)
-    nonwater = np.arange(1, 201, dtype=np.uint8).reshape(20, 10)
+    nonwater = np.zeros((20, 10), dtype=np.uint8)
+    water = np.arange(1, 201, dtype=np.uint8).reshape(20, 10)
     invalid = np.full((20, 10), fill_value=255, dtype=np.uint8)
 
     # Concatenate the three arrays into a single 20x30 array.
-    water_distance = np.concatenate([water, nonwater, invalid], axis=1)
+    water_distance = np.concatenate([nonwater, water, invalid], axis=1)
 
     # Convert the water distance map into a binary water mask
     water_mask = binarize_nisar_water_mask(water_distance)
@@ -25,8 +25,8 @@ def test_binarize_nisar_water_mask():
     assert water_mask.dtype == np.uint8
 
     # Check the mask values.
-    np.testing.assert_equal(water_mask[:, :10], 1)
-    np.testing.assert_equal(water_mask[:, 10:20], 0)
+    np.testing.assert_equal(water_mask[:, :10], 0)
+    np.testing.assert_equal(water_mask[:, 10:20], 1)
     np.testing.assert_equal(water_mask[:, 20:], 255)
 
 


### PR DESCRIPTION
This PR updates to the STATIC Workflow to reflect the current specification for the NISAR Water Mask, which uses the classifications (Per JPL D-107710):

```
Layer classes:
0: Not water – an area with valid data that is not open water (class 1), high-backscattering water (class 2), low-backscattering
non-water (class 3), landcover masked (class 4), height above nearest drainage masked (class 5), layover/shadow masked
(class 6), or ocean masked (class 254). Masking can result in “not water” (class 0) where land cover masking is applied.
1 -100: Ocean distance – distance from the coastline (unit: km)
101 -200: Inland water distance – distance from the boundary between inland water and land (unit: km)
255: Fill value (no data)
```

### Background

When the Static Workflow was originally implemented in #144 , the classification used by the NISAR water mask at that time was:

https://github.com/isce-framework/isce3/blob/bdf1f6fb9175ffe9e53b61839c797e69947dd268/python/packages/nisar/static/water_mask.py#L21-L24

However, for the current water mask TIFF files being used in mission operations, 0 designates not-water, and 1-200 designates water. Here is a screenshot of `NISAR_water_mask_N33_N34_W119_W118_30m_v0.5.0.tif`, provided by M Zahn: 

<img width="1199" height="1012" alt="Screenshot 2026-07-08 at 5 06 38 PM" src="https://github.com/user-attachments/assets/d03c1840-8911-48dd-a567-213c69433d3b" />

Due to this discrepancy, the static layers workflow was generating `waterMask` layers with the binary values 0 and 1 inverted. This PR resolves the issue.