### PR TITLE
Bugfix: STATIC Layover Shadow Mask geocoding fill not set to `255`

### DIFF
--- a/python/packages/nisar/static/layover_shadow_mask.py
+++ b/python/packages/nisar/static/layover_shadow_mask.py
@@ -195,19 +195,49 @@ def geocode_layover_shadow_mask(
     if geo2rdr_params is None:
         geo2rdr_params = {}
 
-    geocoded_layover_shadow_mask = make_scratch_gtiff(
-        shape=(geo_grid.length, geo_grid.width),
-        dtype=np.uint8,
+    # XXX: There's currently no way to create a "Geocode" object that operates directly
+    # on uint8 data with Fill value 255. Instead, the way this is done in the
+    # InSAR geocoding workflow is to create a `GeocodeFloat32` object, resulting
+    # in conversion of the input mask values to float32 during geocoding (and
+    # then conversion back to uint8 when they're written to the output raster).
+    # For STATIC, this shouldn't cause any loss of fidelity since the mask values
+    # are small and we're using nearest neighbor interpolation.
+
+    # However, when geocoding uint8 data with `GeocodeFloat32`, the C++ `GeocodeCov`
+    # implementation initializes the output buffer with `nan_t_out`. Then,
+    # 0 * NaN evaluates to NaN for float dtypes (correct), but for integer
+    # dtypes it evaluates to 0 (since uint8 cannot represent NaN). This leads to
+    # areas outside the radar grid extent retaining this 0 fill value instead
+    # of the correct 255.
+
+    # Workaround:
+    # 1. Convert the uint8 mask to float32, replacing 255 with NaN
+    # 2. Geocode the float32 raster (NaN values are preserved)
+    # 3. Convert back to uint8, replacing NaN with 255
+
+    layover_shadow_mask_float32 = make_scratch_gtiff(
+        shape=(radar_grid.length, radar_grid.width),
+        dtype=np.float32,
         dir_=scratch_dir,
-        prefix="geocoded-layover-shadow-mask_",
+        prefix="layover-shadow-mask-float32_",
     )
 
-    # XXX: There's currently no way to create a "Geocode" object that operates directly
-    # on uint8 data. Instead, the way this is done in the InSAR geocoding workflow is to
-    # create a `GeocodeFloat32` object, resulting in conversion of the input mask values
-    # to float32 during geocoding (and then conversion back to uint8 when they're
-    # written to the output raster). This shouldn't cause any loss of fidelity since the
-    # mask values are small and we're using nearest neighbor interpolation.
+    # Convert uint8 mask to float32, replacing fill value 255 with NaN
+    radar_data_uint8 = np.empty((radar_grid.length, radar_grid.width), dtype=np.uint8)
+    layover_shadow_mask.read_all(radar_data_uint8)
+    radar_data_float32 = radar_data_uint8.astype(np.float32)
+    radar_data_float32[radar_data_uint8 == 255] = np.nan
+    layover_shadow_mask_float32.write_all(radar_data_float32)
+
+    # Create output float32 raster for geocoded result
+    geocoded_layover_shadow_mask_float32 = make_scratch_gtiff(
+        shape=(geo_grid.length, geo_grid.width),
+        dtype=np.float32,
+        dir_=scratch_dir,
+        prefix="geocoded-layover-shadow-mask-float32_",
+    )
+
+    # Geocode the float32 mask
     geocode = isce3.geocode.GeocodeFloat32()
     geocode.orbit = orbit
     geocode.ellipsoid = get_reference_ellipsoid(dem_raster)
@@ -230,8 +260,8 @@ def geocode_layover_shadow_mask(
 
     geocode.geocode(
         radar_grid=radar_grid,
-        input_raster=layover_shadow_mask,
-        output_raster=geocoded_layover_shadow_mask,
+        input_raster=layover_shadow_mask_float32,
+        output_raster=geocoded_layover_shadow_mask_float32,
         dem_raster=dem_raster,
         output_mode=GeocodeOutputMode.INTERP,
         memory_mode=normalize_geocode_memory_mode(memory_mode),
@@ -239,6 +269,18 @@ def geocode_layover_shadow_mask(
         max_block_size=max_block_size,
         dem_interp_method=normalize_data_interp_method(dem_interp_method),
     )
+
+    # Convert geocoded float32 result back to uint8, replacing NaN with 255
+    geocoded_layover_shadow_mask = make_scratch_gtiff(
+        shape=(geo_grid.length, geo_grid.width),
+        dtype=np.uint8,
+        dir_=scratch_dir,
+        prefix="geocoded-layover-shadow-mask_",
+    )
+    geo_data_float32 = np.empty((geo_grid.length, geo_grid.width), dtype=np.float32)
+    geocoded_layover_shadow_mask_float32.read_all(geo_data_float32)
+    geo_data_uint8 = np.where(np.isnan(geo_data_float32), 255, geo_data_float32).astype(np.uint8)
+    geocoded_layover_shadow_mask.write_all(geo_data_uint8)
 
     return geocoded_layover_shadow_mask
 

--- a/python/packages/nisar/static/layover_shadow_mask.py
+++ b/python/packages/nisar/static/layover_shadow_mask.py
@@ -196,48 +196,42 @@ def geocode_layover_shadow_mask(
         geo2rdr_params = {}
 
     # XXX: There's currently no way to create a "Geocode" object that operates directly
-    # on uint8 data with Fill value 255. Instead, the way this is done in the
-    # InSAR geocoding workflow is to create a `GeocodeFloat32` object, resulting
-    # in conversion of the input mask values to float32 during geocoding (and
-    # then conversion back to uint8 when they're written to the output raster).
-    # For STATIC, this shouldn't cause any loss of fidelity since the mask values
-    # are small and we're using nearest neighbor interpolation.
+    # on uint8 data. Instead, the way this is done in the InSAR geocoding workflow is to
+    # create a `GeocodeFloat32` object, resulting in conversion of the input mask values
+    # to float32 during geocoding (and then conversion back to uint8 when they're
+    # written to the output uint8 raster). For the layover/shadow mask, this shouldn't
+    # cause any loss of fidelity since the mask values are small and we're using
+    # nearest neighbor interpolation.
 
-    # However, when geocoding uint8 data with `GeocodeFloat32`, the C++ `GeocodeCov`
-    # implementation initializes the output buffer with `nan_t_out`. Then,
-    # 0 * NaN evaluates to NaN for float dtypes (correct), but for integer
-    # dtypes it evaluates to 0 (since uint8 cannot represent NaN). This leads to
-    # areas outside the radar grid extent retaining this 0 fill value instead
-    # of the correct 255.
+    # However, when geocoding a `GeocodeFloat32`, the C++ `GeocodeCov` internally
+    # uses NaN as a fill value for the area outside the radar grid extent.
+    # uint8 cannot represent NaN, which leads to the geocoding fill area
+    # incorrectly getting the value 0. Because 0 is a valid value in the layover
+    # shadow mask, this is unacceptable; the geocoding fill pixels must be 255
+    # per the spec.
 
-    # Workaround:
-    # 1. Convert the uint8 mask to float32, replacing 255 with NaN
-    # 2. Geocode the float32 raster (NaN values are preserved)
-    # 3. Convert back to uint8, replacing NaN with 255
+    # So, we'll use geocode's `out_mask` parameter, where out_mask==255 indicates
+    # pixels outside radar grid extent.
+    # We'll use this coverage information to mask the final geocoded layover
+    # shadow mask, setting its geocoding fill pixels' value to 255.
 
-    layover_shadow_mask_float32 = make_scratch_gtiff(
-        shape=(radar_grid.length, radar_grid.width),
-        dtype=np.float32,
-        dir_=scratch_dir,
-        prefix="layover-shadow-mask-float32_",
-    )
-
-    # Convert uint8 mask to float32, replacing fill value 255 with NaN
-    radar_data_uint8 = np.empty((radar_grid.length, radar_grid.width), dtype=np.uint8)
-    layover_shadow_mask.read_all(radar_data_uint8)
-    radar_data_float32 = radar_data_uint8.astype(np.float32)
-    radar_data_float32[radar_data_uint8 == 255] = np.nan
-    layover_shadow_mask_float32.write_all(radar_data_float32)
-
-    # Create output float32 raster for geocoded result
-    geocoded_layover_shadow_mask_float32 = make_scratch_gtiff(
+    # Construct the output uint8 Geotiff raster
+    geocoded_layover_shadow_mask = make_scratch_gtiff(
         shape=(geo_grid.length, geo_grid.width),
-        dtype=np.float32,
+        dtype=np.uint8,
         dir_=scratch_dir,
-        prefix="geocoded-layover-shadow-mask-float32_",
+        prefix="geocoded-layover-shadow-mask_",
     )
 
-    # Geocode the float32 mask
+    # Create output mask to indicate which geocoded pixels are outside radar grid extent
+    out_mask = make_scratch_gtiff(
+        shape=(geo_grid.length, geo_grid.width),
+        dtype=np.uint8,
+        dir_=scratch_dir,
+        prefix="geocode-coverage-mask_",
+    )
+
+    # Setup the `GeocodeFloat32` object
     geocode = isce3.geocode.GeocodeFloat32()
     geocode.orbit = orbit
     geocode.ellipsoid = get_reference_ellipsoid(dem_raster)
@@ -258,29 +252,25 @@ def geocode_layover_shadow_mask(
     if "maxiter" in geo2rdr_params:
         geocode.numiter_geo2rdr = geo2rdr_params["maxiter"]
 
+    # Geocode uint8 layover shadow mask, with the out_mask
     geocode.geocode(
         radar_grid=radar_grid,
-        input_raster=layover_shadow_mask_float32,
-        output_raster=geocoded_layover_shadow_mask_float32,
+        input_raster=layover_shadow_mask,
+        output_raster=geocoded_layover_shadow_mask,
         dem_raster=dem_raster,
         output_mode=GeocodeOutputMode.INTERP,
+        out_mask=out_mask,
         memory_mode=normalize_geocode_memory_mode(memory_mode),
         min_block_size=min_block_size,
         max_block_size=max_block_size,
         dem_interp_method=normalize_data_interp_method(dem_interp_method),
     )
 
-    # Convert geocoded float32 result back to uint8, replacing NaN with 255
-    geocoded_layover_shadow_mask = make_scratch_gtiff(
-        shape=(geo_grid.length, geo_grid.width),
-        dtype=np.uint8,
-        dir_=scratch_dir,
-        prefix="geocoded-layover-shadow-mask_",
-    )
-    geo_data_float32 = np.empty((geo_grid.length, geo_grid.width), dtype=np.float32)
-    geocoded_layover_shadow_mask_float32.read_all(geo_data_float32)
-    geo_data_uint8 = np.where(np.isnan(geo_data_float32), 255, geo_data_float32).astype(np.uint8)
-    geocoded_layover_shadow_mask.write_all(geo_data_uint8)
+    # Set geocoding fill values to 255
+    mask_data = geocoded_layover_shadow_mask.get_block((slice(None), slice(None)))
+    out_mask_data = out_mask.get_block((slice(None), slice(None)))
+    mask_data[out_mask_data == 255] = 255
+    geocoded_layover_shadow_mask.set_block((slice(None), slice(None)), mask_data)
 
     return geocoded_layover_shadow_mask
 


### PR DESCRIPTION
WIP - unit tests are in-progress. Code is ready for review/discussion.

# Summary

When the STATIC workflow was first implemented in #144 , each raster layer provided complete coverage of the given track frame's extent; there was never any geocoding fill.

Then, #178 and #205 introduced the option into the STATIC workflow to only compute the science values for a smaller swath within that track frame, to e.g. reduce memory usage. This meant that several STATIC layer rasters would now include geocoding fill regions around the corners/edges of the rasters.

For raster layers that are float-valued, the geocoding fill pixels was correctly set to `NaN`.

However, for the layover shadow mask, the geocoding fill pixels were incorrectly set to `0`. This bug is due to a limitation of `GeocodeCov` not being able to natively handle geocoding `uint8` layers (Full details noted in the in-line code comments).

This PR resolves that issue so that the layover shadow mask layer has the geocoding fill correctly set to `255`.

# Technical Design

## Considerations

Related Ideas to keep in mind when selecting the correct implementation design:

1) This issue also impacts GUNW's Connected Components layer, and potentially others.
* For example, if `nisarqa`decides to generate PNGs for connected components, it would need to implement a similar fix.
* **Whatever approach is decided here will need to be adopted by other workflows.**

2) Choice of Design Pattern
* Design Option 1 - use `out_mask`
    - Currently, this PR implements a fix by having the calling function setup an `out_mask` parameter, which `GeocodeCov` then populates with the geocoding fill area. The calling function is then responsible for applying that mask to set the geocoding fill pixel values correctly to 255.
        * Pros: reduces number of rasters required to be in memory
        * Cons: requires an extra scratch Geotiff file
* Design Option 2 - convert to `float32`
    * A different approach could be to 1) Convert the uint8 mask to float32, replacing 255 with NaN, then 2) Geocode the float32 raster (NaN values are preserved), then 3) Convert back to uint8, replacing NaN with 255.
        * Cons: requires add'l copies of the raster to be in memory
* Design Option 3 - wrap `uint8` values
    * A trick with `uint8` is that if you add `255`, then instead of overflow, it will wrap values back around to e.g. `0`. This works with `numpy`, would need more research re: robustness in other situations.
    * Pseudo code: 1) Take the `uint8` mask layer and add `1` to all values. 2) Geocode; the fill values will be set to `0`. 3) Add `255` to the geocoded mask. This will set geocoding fill to `255` (correct), and all other values will get wrapped back to their original correct values.
* Design Option 4 - Choose 1, 2, or 3, but implement in a light wrapper around `GeocodeCov`
    * Require 1-line change to all calling functions
    * Pros:
        * Does not touch `GeocodeCov`, which can be finnicky
        * Reasonable to maintain long-term
    * Users with `uint8` datasets will need to remember to call the wrapper function
* Design Option 5 - Choose 1, 2, or 3, but implement internal to `GeocodeCov`
    * Should automatically resolve the issue across all products with minimal changes to their implementation
        * Pros: Reduces technical debt. Will improve user experience in the future.
        * Cons: Potentially messier refactor, which touches a core part of the ISCE3 code.

## Design Implemented

This PR implements Design Option 1 for only the STATIC Layers workflow.

Open to discussion about whether a different design would be preferred.

# Test Results

Tested locally. Once the design pattern is approved, @jplzhan could you please test this branch in the production pipeline?

## Before this PR

<img width="706" height="580" alt="Screenshot 2026-07-15 at 3 35 29 PM" src="https://github.com/user-attachments/assets/4f63ba08-d3b8-4b18-b451-07ac854b7d61" />


## After this PR

(Fill Value of 255 is a lighter grey; it is not noted in the colorbar. I'll update the plot if/when there's time)

<img width="498" height="419" alt="Screenshot 2026-07-15 at 3 30 46 PM" src="https://github.com/user-attachments/assets/ee978423-7849-4db4-a719-08217b83166c" />

PDF illustrating all layers, and how the radar grid varies between layers:
[NISAR_L2_STATIC_023_D_067_0800_0800_19991231T235959_A10000_J_001_report.pdf](https://github.com/user-attachments/files/30067715/NISAR_L2_STATIC_023_D_067_0800_0800_19991231T235959_A10000_J_001_report.pdf)


cc: @hfattahi 