### PR TITLE
Fix RSLC valid data mask when L0B starts with a block of invalid data (NSDS-5279)

### DIFF
--- a/python/packages/nisar/products/readers/Raw/Raw.py
+++ b/python/packages/nisar/products/readers/Raw/Raw.py
@@ -962,8 +962,14 @@ class RawBase(Base, family='nisar.productreader.raw'):
 
         changes = get_dwp_change_indices(rd, wd, wl)
 
+        # Skip any blocks of bad data at the beginning (e.g., first 12 pulses
+        # of SSAR).  Note that argmax returns the first occurence of the max
+        # value, in this case the first index where any subswath is not empty.
+        i0 = np.argmax(np.any(subswaths[..., 1] > subswaths[..., 0], axis=0))
+
         # Append first and last pulses to generate pairs of constant DWP.
-        breaks = np.hstack(([0], changes, [grid.shape[0] - 1]))
+        # Sort this in case i0 is after first change.
+        breaks = np.sort(np.hstack(([i0], changes, [grid.shape[0] - 1])))
         bbox_lists = []
         for ibreak in range(len(breaks) - 1):
             ipulse0, ipulse1 = breaks[ibreak], breaks[ibreak + 1]


### PR DESCRIPTION
# Problem

Recently the raw data products (L0B/RRSD) began using the the `validSamplesSubSwath` metadata to mark the first N pulses of a datatake as invalid in order to reflect the ramp-up behavior of the instrument. It also uses the `calType` metadata to mark the corresponding loopback cal data as invalid.

The RSLC processor (focus.py) propagates the valid data mask forward, accounting for reskew, filter delays, presumming, etc. The L0B valid data mask is complicated by PRF dithering, so currently RSLC looks at the range timing metadata (RD, WD, WL) to figure out when the swath bounds are expected to actually change. Typically those changes can occur no faster than once every 10 seconds. The L0B valid data mask is basically consulted at the start of each block of constant range timing.

When the pulses at the start of a block are marked completely invalid in the L0B, RSLC considers the entire block invalid and emits a log message like
```
2026-07-25 18:40:56.934, WARNING, RSLC, Raw, 999999, /opt/conda/lib/python3.12/site-packages/nisar/products/readers/Raw/Raw.py:997, "no valid subswath for time interval [7913.479294832, 7933.479124307)"
```
The first consequence is that the valid data mask of the RSLC will mark that entire block of data as invalid.

The bad behavior gets worse when the datatake is short enough that the range timing never changes. That happens whenever the first observation in a datatake is shorter than 10 seconds, and there's a chance that longer ones could be affected as well. In this case, RSLC doesn't find any valid data which leads to an unhandled exception like
```
2026-07-25 18:40:56.906, INFO, RSLC, focus, 999999, /opt/conda/lib/python3.12/site-packages/nisar/workflows/focus.py:1934, "computing valid swaths"
2026-07-25 18:40:56.934, WARNING, RSLC, Raw, 999999, /opt/conda/lib/python3.12/site-packages/nisar/products/readers/Raw/Raw.py:997, "no valid subswath for time interval [7913.479294832, 7933.479124307)"
journal: No reference epoch provided. Using first date time from XML file as orbit reference epoch.
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/opt/conda/lib/python3.12/site-packages/nisar/workflows/focus.py", line 2408, in <module>
    main(sys.argv[1:])
  File "/opt/conda/lib/python3.12/site-packages/nisar/workflows/focus.py", line 2404, in main
    focus(cfg, args.run_config_path)
  File "/opt/conda/lib/python3.12/site-packages/nisar/workflows/focus.py", line 1935, in focus
    valid_swaths = get_focused_sub_swaths(rawlist, chan, og, orbit,
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/site-packages/nisar/workflows/focus.py", line 1705, in get_focused_sub_swaths
    raise e
  File "/opt/conda/lib/python3.12/site-packages/nisar/workflows/focus.py", line 1694, in get_focused_sub_swaths
    swaths = isce3.focus.get_focused_sub_swaths(raw_bbox_lists,
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/site-packages/isce3/focus/valid_regions.py", line 499, in get_focused_sub_swaths
    raw_polygons = get_raw_sub_swath_polygons(raw_bbox_lists=raw_bbox_lists,
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/site-packages/isce3/focus/valid_regions.py", line 157, in get_raw_sub_swath_polygons
    for corners in raw_corners_lists[0]:
                   ~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```

# Solution

The RLSC needs to better account for fully masked data regions when generating its own mask. Currently this PR accommodates fully masked regions at the beginning of an observation, which probably covers most of the cases of interest. Note that this is also necessary for SSAR data processing.

A more complete solution would accommodate blocks of invalid data that occur anywhere within the observation.