### PR TITLE
Remove per-pixel atomics and dynamic scheduling from RTC _normalizeRtcArea (#341)

### DIFF
--- a/cxx/isce3/geometry/RTC.cpp
+++ b/cxx/isce3/geometry/RTC.cpp
@@ -270,18 +270,16 @@ void _normalizeRtcArea(isce3::core::Matrix<float>& numerator_array,
         pyre::journal::info_t& info)
 {
     info << "normalizing gamma-naught area..." << pyre::journal::endl;
-    _Pragma("omp parallel for schedule(dynamic) collapse(2)") 
-        for (int i = 0; i < numerator_array.length(); ++i) 
+    // Each (i, j) is read and written by exactly one iteration, so no
+    // atomics are required. Row-wise static scheduling avoids per-pixel
+    // dynamic dispatch overhead.
+    _Pragma("omp parallel for")
+        for (int i = 0; i < numerator_array.length(); ++i)
             for (int j = 0; j < numerator_array.width(); ++j) {
                 const float denominator_value = denominator_array(i, j);
-                if (denominator_value == 0) {
-                    _Pragma("omp atomic write")
-                        numerator_array(i, j) =
-                            std::numeric_limits<float>::quiet_NaN();
-                    continue;
-                }
-                _Pragma("omp atomic update") 
-                    numerator_array(i, j) /= denominator_value;
+                numerator_array(i, j) = denominator_value == 0
+                        ? std::numeric_limits<float>::quiet_NaN()
+                        : numerator_array(i, j) / denominator_value;
             }
 }
 


### PR DESCRIPTION
## Summary

Fixes #341.

`_normalizeRtcArea` in `cxx/isce3/geometry/RTC.cpp` ran its gamma-naught normalization loop with `omp parallel for schedule(dynamic) collapse(2)` (no chunk size, i.e. one iteration per dispatch) and a per-pixel `omp atomic` write/update. Each `(i, j)` is read and written by exactly one iteration, so the loop is race-free without the atomics — they were pure overhead — and the pixel-granularity dynamic scheduling turned a memory-bound pass over two `float` arrays into ~1.2e9 contended acquisitions of the shared iteration counter per call pair at NISAR frequency-A scale.

This PR replaces the loop body with a plain row-wise `omp parallel for` and a conditional expression (one function, +8/−10). Iteration-to-pixel mapping and per-pixel arithmetic are unchanged, so the output is bit-identical by construction as well as by measurement.

## Measured effect

On a real NISAR L1 RSLC (frequency A, 29240 × 21232 radar grid) processed through the GCOV workflow on a 16-core host (full methodology, run matrix, logs and raw profiles in #341):

| journal timer | current (median) | patched (median) | delta |
|---|---|---|---|
| `RTC-AP` | 966.2 s | 806.5 s | **−16.5%** |
| `GEO-AP` (~89% of workflow wall) | 1506.1 s | 1338.8 s | **−11.1%** |

All four GTiff output products (`HHHH`, `HVHV`, `numberOfLooks`, `rtcGammaToSigmaFactor`) are bit-identical across all 9 measurement runs (single md5 per product).

An isolated microbenchmark of the loop alone (same grid, 16 threads, bit-identity asserted against the current loop) gives 34.1 s → 0.127 s per call; the fixed loop runs at the measured parallel-memcpy ceiling of the host, i.e. the pass is memory-bandwidth-bound, as expected. Details, plus a comparison against Eigen `select()` variants, in [this comment](https://github.com/isce-framework/isce3/issues/341#issuecomment-5104911173).

## Notes for review

- Whole-run `perf` profiles attribute 10.9% (`gomp_iter_dynamic_next`) + 9.9% (the `_normalizeRtcArea` omp region) of user CPU to the removed overhead before the patch; both symbols drop below 0.5% after. Absolute thread-seconds of unrelated symbols (e.g. `Orbit::interpolate`) are unchanged within noise.
- The patched loop still compiles to scalar code with GCC 13 at -O2/-O3 (the NaN guard defeats if-conversion), so the measured gain is attributable entirely to removing the dynamic dispatch and the atomics, not to SIMD.
- `_applyRtcMinValueDb` (RTC.cpp:255) uses the identical `schedule(dynamic) collapse(2)` + atomic-write pattern and would take the same fix; it is left out of scope because it did not execute in the measured configuration. I can file a separate follow-up PR for it if desired.
- The sigma-naught-ellipsoid loop near RTC.cpp:1032 is deliberately untouched: its per-iteration work is heavy and variable (orbit interpolation + Newton iterations), so dynamic scheduling is plausibly justified there, and the atomics in the adjacent area accumulation are a genuine scatter-add that must stay.
- No new test is added: the change is behavior-preserving by construction (same iteration-to-pixel ownership, same per-pixel arithmetic), covered by the existing RTC tests plus the product-level bit-identity evidence above.

---

*Disclosure: this investigation and the patch were developed with assistance from AI coding tools (Claude, Codex, and Gemini). All measurements were executed on real hardware, and the evidence linked above (profiles, logs, and the bitwise verification) was generated and reviewed by the author.*
