### PR TITLE
Solve CI failures

### DIFF
--- a/cxx/isce3/geometry/TopoLayers.cpp
+++ b/cxx/isce3/geometry/TopoLayers.cpp
@@ -110,9 +110,18 @@ TopoLayers::TopoLayers(const size_t linesPerBlock, isce3::io::Raster* xRaster,
 
 void TopoLayers::writeData(size_t xidx, size_t yidx)
 {
-    std::vector<std::variant<double*, float*, short*>> valarrays {&_x[0],
-            &_y[0], &_z[0], &_inc[0], &_hdg[0], &_localInc[0], &_localPsi[0],
-            &_sim[0], &_mask[0], &_groundToSatEast[0], &_groundToSatNorth[0]};
+    // Layers whose raster wasn't requested are left with size-0 valarrays
+    // (see setBlockSize), so indexing element 0 unconditionally would be
+    // out-of-bounds. Only take the address when the valarray is non-empty.
+    auto ptr = [](auto& valarray) {
+        using T = typename std::remove_reference_t<decltype(valarray)>::value_type;
+        return valarray.size() ? &valarray[0] : static_cast<T*>(nullptr);
+    };
+
+    std::vector<std::variant<double*, float*, short*>> valarrays {ptr(_x),
+            ptr(_y), ptr(_z), ptr(_inc), ptr(_hdg), ptr(_localInc),
+            ptr(_localPsi), ptr(_sim), ptr(_mask), ptr(_groundToSatEast),
+            ptr(_groundToSatNorth)};
 
     std::vector<isce3::io::Raster*> rasters {_xRaster, _yRaster, _zRaster,
             _incRaster, _hdgRaster, _localIncRaster, _localPsiRaster,

--- a/cxx/isce3/geometry/TopoLayers.cpp
+++ b/cxx/isce3/geometry/TopoLayers.cpp
@@ -113,15 +113,16 @@ void TopoLayers::writeData(size_t xidx, size_t yidx)
     // Layers whose raster wasn't requested are left with size-0 valarrays
     // (see setBlockSize), so indexing element 0 unconditionally would be
     // out-of-bounds. Only take the address when the valarray is non-empty.
-    auto ptr = [](auto& valarray) {
+    auto safe_deref = [](auto& valarray) {
         using T = typename std::remove_reference_t<decltype(valarray)>::value_type;
         return valarray.size() ? &valarray[0] : static_cast<T*>(nullptr);
     };
 
-    std::vector<std::variant<double*, float*, short*>> valarrays {ptr(_x),
-            ptr(_y), ptr(_z), ptr(_inc), ptr(_hdg), ptr(_localInc),
-            ptr(_localPsi), ptr(_sim), ptr(_mask), ptr(_groundToSatEast),
-            ptr(_groundToSatNorth)};
+    std::vector<std::variant<double*, float*, short*>> valarrays {
+            safe_deref(_x), safe_deref(_y), safe_deref(_z), safe_deref(_inc),
+            safe_deref(_hdg), safe_deref(_localInc), safe_deref(_localPsi),
+            safe_deref(_sim), safe_deref(_mask), safe_deref(_groundToSatEast),
+            safe_deref(_groundToSatNorth)};
 
     std::vector<isce3::io::Raster*> rasters {_xRaster, _yRaster, _zRaster,
             _incRaster, _hdgRaster, _localIncRaster, _localPsiRaster,

--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,7 @@ dependencies:
   - ninja
   - numpy>=1.20
   - pyaps3>=0.3
-  - pybind11>=2.5
+  - pybind11>=2.5,!=3.1.0
   - pyre>=1.12.5
   - pysolid>=0.2
   - pytest

--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,7 @@ dependencies:
   - ninja
   - numpy>=1.20
   - pyaps3>=0.3
-  - pybind11>=2.5,!=3.1.0
+  - pybind11>=2.5
   - pyre>=1.12.5
   - pysolid>=0.2
   - pytest

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -108,21 +108,17 @@ macro(getpackage_pybind11)
     # find same installation as modern FindPython
     set(PYTHON_EXECUTABLE "${Python_EXECUTABLE}")
     set(PYBIND11_PYTHON_VERSION "${Python_VERSION}")
-    # pybind11 3.x has a signature-generation bug that corrupts function
-    # registration for some Eigen-typed bindings (throws "Internal error
-    # while parsing type signature (2)" at import time). Cap below 3.0
-    # until this is fixed upstream.
     if(ISCE3_FETCH_PYBIND11)
-        find_package(pybind11 2.5...<3.0 CONFIG)
+        find_package(pybind11 2.5 CONFIG)
         if(NOT pybind11_FOUND)
             fetch_extern_repo(pybind11
                 GIT_REPOSITORY  https://github.com/pybind/pybind11
-                GIT_TAG         v2.13.6
+                GIT_TAG         v3.1.0
                 GIT_SHALLOW     TRUE
                 )
         endif()
     else()
-        find_package(pybind11 2.5...<3.0 CONFIG REQUIRED)
+        find_package(pybind11 2.5 CONFIG REQUIRED)
     endif()
 endmacro()
 

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -108,17 +108,21 @@ macro(getpackage_pybind11)
     # find same installation as modern FindPython
     set(PYTHON_EXECUTABLE "${Python_EXECUTABLE}")
     set(PYBIND11_PYTHON_VERSION "${Python_VERSION}")
+    # pybind11 3.x has a signature-generation bug that corrupts function
+    # registration for some Eigen-typed bindings (throws "Internal error
+    # while parsing type signature (2)" at import time). Cap below 3.0
+    # until this is fixed upstream.
     if(ISCE3_FETCH_PYBIND11)
-        find_package(pybind11 2.5 CONFIG)
+        find_package(pybind11 2.5...<3.0 CONFIG)
         if(NOT pybind11_FOUND)
             fetch_extern_repo(pybind11
                 GIT_REPOSITORY  https://github.com/pybind/pybind11
-                GIT_TAG         v2.5.0
+                GIT_TAG         v2.13.6
                 GIT_SHALLOW     TRUE
                 )
         endif()
     else()
-        find_package(pybind11 2.5 CONFIG REQUIRED)
+        find_package(pybind11 2.5...<3.0 CONFIG REQUIRED)
     endif()
 endmacro()
 

--- a/python/extensions/pybind_isce3/focus/DryTroposphereModel.cpp
+++ b/python/extensions/pybind_isce3/focus/DryTroposphereModel.cpp
@@ -1,5 +1,11 @@
 #include "DryTroposphereModel.h"
 
+// dryTropoDelayTSX() takes Eigen (Vec3) arguments; without this, pybind11
+// silently uses a different type_caster for Vec3 here than in other
+// translation units binding the same argument types, which is an ODR
+// violation that can crash pybind11 3.x at import time.
+#include <pybind11/eigen.h>
+
 using isce3::focus::DryTroposphereModel;
 
 namespace py = pybind11;

--- a/tests/cxx/isce3/antenna/frame.cpp
+++ b/tests/cxx/isce3/antenna/frame.cpp
@@ -20,10 +20,10 @@ struct FrameTest : public ::testing::Test {
         std::for_each(
                 az_deg.begin(), az_deg.end(), [=](double& ang) { ang *= d2r; });
         // fill out a vector of expected XYZ values for each (EL,AZ) pair
-        est_xyz_eaz.reserve(el_deg.size());
-        est_xyz_eoa.reserve(el_deg.size());
-        est_xyz_aoe.reserve(el_deg.size());
-        est_xyz_tp.reserve(el_deg.size());
+        est_xyz_eaz.resize(el_deg.size());
+        est_xyz_eoa.resize(el_deg.size());
+        est_xyz_aoe.resize(el_deg.size());
+        est_xyz_tp.resize(el_deg.size());
 
         est_xyz_eaz[0] << -0.121864326797, -0.015668270588, 0.992423090799;
         est_xyz_eaz[1] << -0.034899213187, -0.006979842637, 0.999366462673;

--- a/tests/cxx/isce3/geometry/geometry/geometry.cpp
+++ b/tests/cxx/isce3/geometry/geometry/geometry.cpp
@@ -138,7 +138,7 @@ TEST_F(GeometryTest, GeoToRdr)
     // undefined.  It also needs to fall within the domain of the Doppler
     // LUT2d, or the LUT2d must be configured to allow extrapolation.
     // In this case, orbit.midTime() satisfies both constraints.
-    double aztime = orbit.midTime(), slantRange;
+    double aztime = orbit.midTime(), slantRange = 0.0;
     int stat = isce3::geometry::geo2rdr(llh, ellipsoid, orbit, doppler, aztime,
             slantRange, swath.processedWavelength(), lookSide, 1.0e-10, 50,
             10.0);

--- a/tests/cxx/isce3/geometry/geometry/geometry.cpp
+++ b/tests/cxx/isce3/geometry/geometry/geometry.cpp
@@ -133,7 +133,12 @@ TEST_F(GeometryTest, GeoToRdr)
             -115.72466801139711 * radians, 34.65846532785868 * radians, 1772.0};
 
     // Run geo2rdr
-    double aztime, slantRange;
+    // aztime is used as the initial azimuth time guess, so it must be
+    // initialized to a value within the orbit's time span rather than left
+    // undefined.  It also needs to fall within the domain of the Doppler
+    // LUT2d, or the LUT2d must be configured to allow extrapolation.
+    // In this case, orbit.midTime() satisfies both constraints.
+    double aztime = orbit.midTime(), slantRange;
     int stat = isce3::geometry::geo2rdr(llh, ellipsoid, orbit, doppler, aztime,
             slantRange, swath.processedWavelength(), lookSide, 1.0e-10, 50,
             10.0);


### PR DESCRIPTION
CI is failing for every PR right now. I've narrowed the problem with `test.python.pybind.geometry.pntintersect` to the latest version of pybind11 (v3.1.0), while the previous version (3.0.4) seems to work okay. Claude thinks it has something to do with the new `call_impl` method, but I didn't go too deep down that rabbit hole. Changing the function signature in the Python binding of `slantrange_from_lookvec` to pass the ellipsoid by value instead of by `const&` seems to work around the issue, but that seems like a hack. ~For now I just blacklisted the latest pybind11 version in hopes it gets fixed upstream.~ Edit: As noted below, it's not actually necessary to blacklist the latest pybind11 version.

I think there may be some other CI failures as well and will use this branch to work on them.