### PR TITLE
Improvement for TEC correction

### DIFF
--- a/python/packages/isce3/atmosphere/tec_product.py
+++ b/python/packages/isce3/atmosphere/tec_product.py
@@ -2,6 +2,8 @@
 Package to compute TEC LUT from JSON file
 '''
 from datetime import datetime, timedelta
+from itertools import combinations
+from math import comb
 import json
 import os
 
@@ -56,7 +58,10 @@ def _compute_ionospheric_range_delay(utc_time: np.ma.MaskedArray,
         Ellipsoid with same EPSG as DEM interpolator
     total_tec_only: bool
         If True, use total TEC only without subtracting the topside TEC.
-        Otherwise use the suborbital TEC (total TEC minus topside TEC).
+        If False, the topside TEC is evaluated using the corresponding data flag
+        and if all data are valid covering the scenes are found then
+        the suborbital TEC (total TEC minus topside TEC).
+        If not then only total TEC is used.
     polyfit: bool
         If True, fit a polynomial of degree `polyfit_degree` to the suborbital
         TEC profile and use the fitted (smoothed) values. Otherwise use the
@@ -83,6 +88,117 @@ def _compute_ionospheric_range_delay(utc_time: np.ma.MaskedArray,
     delta_r = K * sub_orbital_tec * TECU / center_freq**2 / np.cos(incidence)
 
     return delta_r
+
+
+def _ransac_polyfit(x: np.ndarray, y: np.ndarray, degree: int,
+                    inlier_scale: float=3.0,
+                    max_combinations: int=1000) -> np.ndarray:
+    '''
+    Robustly fit a polynomial to a TEC profile by rejecting noisy samples using
+    an exhaustive RANSAC-style search.
+
+    A polynomial of the given degree is fit to every combination of the minimal
+    number of points (`degree` + 1). For each candidate fit, the consensus set
+    is all samples whose absolute residual falls within an inlier threshold
+    derived from a robust (MAD-based) estimate of the noise scale. The candidate
+    with the largest consensus set is selected (ties broken by smaller sum of
+    squared inlier residuals).
+
+    Because the initial noise scale comes from a full-data fit that the outliers
+    themselves corrupt, the threshold is then recomputed from the consensus set
+    and the search repeated until the consensus set stabilizes. A final
+    polynomial is fit to the resulting consensus set and evaluated at every `x`.
+
+    Parameters
+    ----------
+    x: np.ndarray
+        Sample x-axis (assumed distinct, e.g. sample indices).
+    y: np.ndarray
+        Sample values (the TEC profile) to fit.
+    degree: int
+        Degree of the polynomial to fit.
+    inlier_scale: float
+        Multiplier `k` on the robust noise scale that sets the inlier
+        threshold: `k * 1.4826 * MAD`. Default 3.0.
+    max_combinations: int
+        Upper bound on the number of minimal subsets to enumerate. If the
+        exhaustive search would exceed this, fall back to a plain polynomial
+        fit over all samples. Default 1000.
+
+    Returns
+    -------
+    np.ndarray
+        The fitted (smoothed) values evaluated at every `x`.
+    '''
+    warning_channel = journal.warning("tec_product._ransac_polyfit")
+    info_channel = journal.info("tec_product._ransac_polyfit")
+
+    n = len(y)
+    n_min = degree + 1
+
+    # Not enough points to separate inliers from outliers; plain fit.
+    if n <= n_min:
+        coeffs = np.polyfit(x, y, degree)
+        return np.polyval(coeffs, x)
+
+    # Guard against combinatorial blow-up for very long TEC profiles.
+    if comb(n, n_min) > max_combinations:
+        warning_channel.log(
+            f'Number of minimal subsets C({n}, {n_min}) exceeds '
+            f'max_combinations={max_combinations}; falling back to a plain '
+            'polynomial fit without outlier rejection.')
+        coeffs = np.polyfit(x, y, degree)
+        return np.polyval(coeffs, x)
+
+    def _robust_scale(inliers):
+        # k * 1.4826 * MAD of residuals about the fit over `inliers`.
+        coeffs = np.polyfit(x[inliers], y[inliers], degree)
+        resid = (y - np.polyval(coeffs, x))[inliers]
+        mad = np.median(np.abs(resid - np.median(resid)))
+        return inlier_scale * 1.4826 * mad
+
+    def _largest_consensus(threshold):
+        # Exhaustive search over minimal subsets for the largest consensus set.
+        best_inliers = None
+        best_count = -1
+        best_ssr = np.inf
+        for combo in combinations(range(n), n_min):
+            combo = list(combo)
+            coeffs = np.polyfit(x[combo], y[combo], degree)
+            resid = np.abs(y - np.polyval(coeffs, x))
+            inliers = resid <= threshold
+            count = int(np.count_nonzero(inliers))
+            ssr = float(np.sum(resid[inliers] ** 2))
+            if count > best_count or (count == best_count and ssr < best_ssr):
+                best_count = count
+                best_ssr = ssr
+                best_inliers = inliers
+        return best_inliers
+
+    # Initial noise scale from a full-data fit.
+    threshold = _robust_scale(np.ones(n, dtype=bool))
+
+    # Degenerate noise scale (near-perfect fit); nothing to reject.
+    if not np.isfinite(threshold) or threshold <= 0:
+        coeffs = np.polyfit(x, y, degree)
+        return np.polyval(coeffs, x)
+
+    # Iterate: the full-data threshold is inflated by the outliers, so recompute
+    # the scale from the (cleaner) consensus set and reselect until it settles.
+    inliers = _largest_consensus(threshold)
+    for _ in range(5):
+        new_threshold = _robust_scale(inliers)
+        if not np.isfinite(new_threshold) or new_threshold <= 0:
+            break
+        new_inliers = _largest_consensus(new_threshold)
+        if np.array_equal(new_inliers, inliers):
+            break
+        inliers = new_inliers
+
+    # Final fit on the largest consensus set.
+    coeffs = np.polyfit(x[inliers], y[inliers], degree)
+    info_channel.log('RANSAC outlier detection and polynimial fitting completed.')
+    return np.polyval(coeffs, x)
 
 
 def _get_suborbital_tec(tec_json_dict: dict,
@@ -130,10 +246,10 @@ def _get_suborbital_tec(tec_json_dict: dict,
     sub_orbital_tec = sub_orbital_tec[~tec_time_mask]
 
     if polyfit:
-        # Fit a polynomial over the TEC profile to smooth out noise.
+        # Fit a polynomial over the TEC profile to smooth out noise, rejecting
+        # noisy samples first via an exhaustive RANSAC-style search.
         x = np.arange(len(sub_orbital_tec))
-        coeffs = np.polyfit(x, sub_orbital_tec, polyfit_degree)
-        sub_orbital_tec = np.polyval(coeffs, x)
+        sub_orbital_tec = _ransac_polyfit(x, sub_orbital_tec, polyfit_degree)
 
     return sub_orbital_tec
 
@@ -422,6 +538,9 @@ def _get_tec_time(tec_json_dict: dict,
     _check_tec_grid_contains_radargrid(radar_grid, t_since_ref_epoch,
                                        staggered_tec_grid)
 
+    # check if the TEC time grids are equally spaced
+    _check_tec_grid_equally_spaced(t_since_ref_epoch)
+
     return t_since_ref_epoch
 
 
@@ -474,6 +593,37 @@ def _check_tec_grid_contains_radargrid(radar_grid: isce3.product.RadarGridParame
                f'Relative timing w.r.t. Sensing start:\ntec_start={tec_t[0] - radar_grid.sensing_start}, '
                f'tec_end={tec_t[-1] - radar_grid.sensing_start}\n'
                f'radargrid start={0}, radargrid_stop={radar_grid.sensing_stop - radar_grid.sensing_start}')
+
+    error_channel.log(err_msg)
+    raise ValueError(err_msg)
+
+
+def _check_tec_grid_equally_spaced(t_since_ref_epoch: np.ma.MaskedArray) -> None:
+    '''
+    Helper function to check if the valid TEC time grid is equally spaced.
+
+    Parameters
+    ----------
+    t_since_ref_epoch: np.ma.MaskedArray
+        Masked array of the TEC time grid in seconds since reference epoch.
+
+    Raises
+    ------
+    ValueError: When the valid TEC time grid is not equally spaced.
+    '''
+    tec_t = t_since_ref_epoch.compressed()
+
+    spacings = np.diff(tec_t)
+    mean_spacing = spacings.mean()
+
+    if np.allclose(spacings, mean_spacing):
+        return
+
+    error_channel = journal.error(
+        "tec_product._check_tec_grid_equally_spaced")
+    err_msg = ('TEC time grid is not equally spaced.\n'
+               f'mean spacing={mean_spacing}\n'
+               f'min spacing={spacings.min()}, max spacing={spacings.max()}')
 
     error_channel.log(err_msg)
     raise ValueError(err_msg)

--- a/python/packages/isce3/atmosphere/tec_product.py
+++ b/python/packages/isce3/atmosphere/tec_product.py
@@ -22,7 +22,8 @@ def _compute_ionospheric_range_delay(utc_time: np.ma.MaskedArray,
                                      doppler_lut: isce3.core.LUT2d,
                                      radar_grid: isce3.product.RadarGridParameters,
                                      dem_interp: isce3.geometry.DEMInterpolator,
-                                     ellipsoid: isce3.core.Ellipsoid) -> np.ndarray:
+                                     ellipsoid: isce3.core.Ellipsoid,
+                                     total_tec_only: bool=False) -> np.ndarray:
     '''
     Compute near or far TEC delta range
 
@@ -51,6 +52,9 @@ def _compute_ionospheric_range_delay(utc_time: np.ma.MaskedArray,
         Digital elevation model, m above ellipsoid. Defaults to h=0.
     ellipsoid: isce3.core.Ellipsoid
         Ellipsoid with same EPSG as DEM interpolator
+    total_tec_only: bool
+        If True, use total TEC only without subtracting the topside TEC.
+        Otherwise use the suborbital TEC (total TEC minus topside TEC).
 
     Returns
     -------
@@ -59,7 +63,8 @@ def _compute_ionospheric_range_delay(utc_time: np.ma.MaskedArray,
     '''
     # compute sub orbital TEC from total and top TEC in JSON
     sub_orbital_tec = _get_suborbital_tec(tec_json_dict, nr_fr,
-                                          utc_time.mask)
+                                          utc_time.mask,
+                                          total_tec_only=total_tec_only)
 
     incidence = [compute_incidence_angle(t, nr_fr_rg, orbit, doppler_lut,
                                          radar_grid, dem_interp, ellipsoid)
@@ -72,7 +77,10 @@ def _compute_ionospheric_range_delay(utc_time: np.ma.MaskedArray,
 
 def _get_suborbital_tec(tec_json_dict: dict,
                         nr_fr: str,
-                        tec_time_mask: np.ndarray) -> np.ndarray:
+                        tec_time_mask: np.ndarray,
+                        total_tec_only: bool=False,
+                        polyfit: bool=False,
+                        polyfit_degree: int=2) -> np.ndarray:
     '''
     Get the suborbital TEC from IMAGEN TEC product parsed as a dictionary by
     subtracting the total TEC by top (i.e. above the satellite) TEC
@@ -87,6 +95,15 @@ def _get_suborbital_tec(tec_json_dict: dict,
         Mask of TEC values that fall within radar grid or orbit time span. Mask
         follows NumPy masked array convention where True is masked and False is
         not.
+    total_tec_only: bool
+            If True, use total TEC only without subtracting the topside TEC.
+            Otherwise use the suborbital TEC (total TEC minus topside TEC).
+    polyfit: bool
+        If True, fit a polynomial of degree `polyfit_degree` to the suborbital
+        TEC profile and return the fitted (smoothed) values. Otherwise return
+        the suborbital TEC as is.
+    polyfit_degree: int
+        Degree of the polynomial fit applied when `polyfit` is True. Default 2.
 
     Returns
     -------
@@ -96,8 +113,17 @@ def _get_suborbital_tec(tec_json_dict: dict,
     # compute sub orbital TEC from total and top TEC in JSON
     tot_tec = np.array(tec_json_dict[f'totTec{nr_fr}'])
     top_tec = np.array(tec_json_dict[f'topTec{nr_fr}'])
-    sub_orbital_tec = tot_tec - top_tec
+    if total_tec_only:
+        sub_orbital_tec = tot_tec
+    else:
+        sub_orbital_tec = tot_tec - top_tec
     sub_orbital_tec = sub_orbital_tec[~tec_time_mask]
+
+    if polyfit:
+        # Fit a polynomial over the TEC profile to smooth out noise.
+        x = np.arange(len(sub_orbital_tec))
+        coeffs = np.polyfit(x, sub_orbital_tec, polyfit_degree)
+        sub_orbital_tec = np.polyval(coeffs, x)
 
     return sub_orbital_tec
 
@@ -106,7 +132,8 @@ def tec_lut2d_from_json_srg(json_path: str, center_freq: float,
                             orbit: isce3.core.Orbit,
                             radar_grid: isce3.product.RadarGridParameters,
                             doppler_lut: isce3.core.LUT2d, dem_path: str,
-                            margin: float=40.0) -> isce3.core.LUT2d:
+                            margin: float=40.0,
+                            total_tec_only: bool=False) -> isce3.core.LUT2d:
     '''
     Create a TEC LUT2d for slant range correction from a JSON source
 
@@ -127,6 +154,9 @@ def tec_lut2d_from_json_srg(json_path: str, center_freq: float,
     margin: float
         Margin (seconds) to pad to sensing start and stop times when extracting
         TEC data. Default 40 seconds.
+    total_tec_only: bool
+        If True, use total TEC only without subtracting the topside TEC.
+        Otherwise use the suborbital TEC (total TEC minus topside TEC).
 
     Returns
     -------
@@ -172,7 +202,8 @@ def tec_lut2d_from_json_srg(json_path: str, center_freq: float,
                                                           doppler_lut,
                                                           radar_grid,
                                                           dem_interp,
-                                                          ellipsoid)
+                                                          ellipsoid,
+                                                          total_tec_only)
                          for nr_fr, rg in zip(['Nr', 'Fr'], rg_vec)]).T
 
     return isce3.core.LUT2d(rg_vec, t_since_epoch_masked.compressed(), delta_r)
@@ -181,7 +212,10 @@ def tec_lut2d_from_json_srg(json_path: str, center_freq: float,
 def tec_lut2d_from_json_az(json_path: str, center_freq: float,
                            orbit: isce3.core.Orbit,
                            radar_grid: isce3.product.RadarGridParameters,
-                           margin: float=40.0) -> isce3.core.LUT2d:
+                           margin: float=40.0,
+                           total_tec_only: bool=False,
+                           polyfit: bool=False,
+                           polyfit_degree: int=2) -> isce3.core.LUT2d:
     '''
     Create a TEC LUT2d for azimuth time correction from a JSON source
 
@@ -198,6 +232,15 @@ def tec_lut2d_from_json_az(json_path: str, center_freq: float,
     margin: float
         Margin (seconds) to pad to sensing start and stop times when extracting
         TEC data. Default 40 seconds.
+    total_tec_only: bool
+        If True, use total TEC only without subtracting the topside TEC.
+        Otherwise use the suborbital TEC (total TEC minus topside TEC).
+    polyfit: bool
+        If True, fit a polynomial of degree `polyfit_degree` to the suborbital
+        TEC profile before computing the azimuth gradient. Otherwise use the
+        suborbital TEC as is.
+    polyfit_degree: int
+        Degree of the polynomial fit applied when `polyfit` is True. Default 2.
 
     Returns
     -------
@@ -229,7 +272,10 @@ def tec_lut2d_from_json_az(json_path: str, center_freq: float,
     # Transpose stacked output to get shape to be consistent with coordinates
     tec_suborbital = np.vstack([_get_suborbital_tec(tec_json_dict,
                                                     nr_fr,
-                                                    t_since_epoch_masked.mask)
+                                                    t_since_epoch_masked.mask,
+                                                    total_tec_only=total_tec_only,
+                                                    polyfit=polyfit,
+                                                    polyfit_degree=polyfit_degree)
                                 for nr_fr in ['Nr', 'Fr']]).T
 
     # set up up the LUT grids for az. iono. delay
@@ -299,7 +345,7 @@ def _get_tec_time(tec_json_dict: dict,
     # Get string UTC times from JSON as isce3.core.DateTime objects.
     json_utc_datetimes = [isce3.core.DateTime(iso_t_str)
                           for iso_t_str in tec_json_dict['utc']]
-    
+
     # Adjust the radar grid margin in case of the staggered grid.
     # The staggered grid needs at least half of the TEC spacing at each side.
     # When `margin` is not big enough, then increase it to half the spacing.
@@ -352,7 +398,7 @@ def _get_tec_time(tec_json_dict: dict,
 
     t_since_ref_epoch = np.ma.MaskedArray(data=t_since_ref_epoch,
                                           mask=np.logical_not(time_mask))
-    
+
     _check_tec_grid_contains_radargrid(radar_grid, t_since_ref_epoch,
                                        staggered_tec_grid)
 
@@ -390,7 +436,7 @@ def _check_tec_grid_contains_radargrid(radar_grid: isce3.product.RadarGridParame
 
     tec_grid_spacing = (tec_grid_end - tec_grid_start) / (len(tec_t) - 1)
 
-    # Adjust the radar grid start / stop time when staggered grid is used    
+    # Adjust the radar grid start / stop time when staggered grid is used
     if staggered:
         rdr_grid_start -= tec_grid_spacing / 2
         rdr_grid_stop += tec_grid_spacing / 2

--- a/python/packages/isce3/atmosphere/tec_product.py
+++ b/python/packages/isce3/atmosphere/tec_product.py
@@ -23,7 +23,9 @@ def _compute_ionospheric_range_delay(utc_time: np.ma.MaskedArray,
                                      radar_grid: isce3.product.RadarGridParameters,
                                      dem_interp: isce3.geometry.DEMInterpolator,
                                      ellipsoid: isce3.core.Ellipsoid,
-                                     total_tec_only: bool=False) -> np.ndarray:
+                                     total_tec_only: bool=False,
+                                     polyfit: bool=False,
+                                     polyfit_degree: int=2) -> np.ndarray:
     '''
     Compute near or far TEC delta range
 
@@ -55,6 +57,12 @@ def _compute_ionospheric_range_delay(utc_time: np.ma.MaskedArray,
     total_tec_only: bool
         If True, use total TEC only without subtracting the topside TEC.
         Otherwise use the suborbital TEC (total TEC minus topside TEC).
+    polyfit: bool
+        If True, fit a polynomial of degree `polyfit_degree` to the suborbital
+        TEC profile and use the fitted (smoothed) values. Otherwise use the
+        suborbital TEC as is.
+    polyfit_degree: int
+        Degree of the polynomial fit applied when `polyfit` is True. Default 2.
 
     Returns
     -------
@@ -64,7 +72,9 @@ def _compute_ionospheric_range_delay(utc_time: np.ma.MaskedArray,
     # compute sub orbital TEC from total and top TEC in JSON
     sub_orbital_tec = _get_suborbital_tec(tec_json_dict, nr_fr,
                                           utc_time.mask,
-                                          total_tec_only=total_tec_only)
+                                          total_tec_only=total_tec_only,
+                                          polyfit=polyfit,
+                                          polyfit_degree=polyfit_degree)
 
     incidence = [compute_incidence_angle(t, nr_fr_rg, orbit, doppler_lut,
                                          radar_grid, dem_interp, ellipsoid)
@@ -133,7 +143,9 @@ def tec_lut2d_from_json_srg(json_path: str, center_freq: float,
                             radar_grid: isce3.product.RadarGridParameters,
                             doppler_lut: isce3.core.LUT2d, dem_path: str,
                             margin: float=40.0,
-                            total_tec_only: bool=False) -> isce3.core.LUT2d:
+                            total_tec_only: bool=False,
+                            polyfit: bool=False,
+                            polyfit_degree: int=2) -> isce3.core.LUT2d:
     '''
     Create a TEC LUT2d for slant range correction from a JSON source
 
@@ -157,6 +169,12 @@ def tec_lut2d_from_json_srg(json_path: str, center_freq: float,
     total_tec_only: bool
         If True, use total TEC only without subtracting the topside TEC.
         Otherwise use the suborbital TEC (total TEC minus topside TEC).
+    polyfit: bool
+        If True, fit a polynomial of degree `polyfit_degree` to the suborbital
+        TEC profile and use the fitted (smoothed) values. Otherwise use the
+        suborbital TEC as is.
+    polyfit_degree: int
+        Degree of the polynomial fit applied when `polyfit` is True. Default 2.
 
     Returns
     -------
@@ -203,7 +221,9 @@ def tec_lut2d_from_json_srg(json_path: str, center_freq: float,
                                                           radar_grid,
                                                           dem_interp,
                                                           ellipsoid,
-                                                          total_tec_only)
+                                                          total_tec_only,
+                                                          polyfit,
+                                                          polyfit_degree)
                          for nr_fr, rg in zip(['Nr', 'Fr'], rg_vec)]).T
 
     return isce3.core.LUT2d(rg_vec, t_since_epoch_masked.compressed(), delta_r)

--- a/python/packages/nisar/workflows/gcov.py
+++ b/python/packages/nisar/workflows/gcov.py
@@ -19,6 +19,7 @@ from nisar.products.readers import SLC
 from nisar.workflows.h5_prep import add_radar_grid_cubes_to_hdf5
 from isce3.atmosphere.tec_product import (tec_lut2d_from_json_srg,
                                           tec_lut2d_from_json_az)
+from nisar.workflows.geocode_corrections import should_use_only_total_tec
 from nisar.workflows.yaml_argparse import YamlArgparse
 from nisar.workflows.gcov_runconfig import GCOVRunConfig
 import nisar.workflows.helpers as helpers
@@ -398,6 +399,10 @@ def _run(cfg, raster_scratch_dir):
     apply_azimuth_ionospheric_delay_correction = \
         geocode_dict['apply_azimuth_ionospheric_delay_correction']
 
+    # TEC correction options
+    polyfit_tec_profile = \
+        cfg['processing']['tec_correction']['polyfit_tec_profile']
+
     apply_valid_samples_sub_swath_masking = \
         geocode_dict['apply_valid_samples_sub_swath_masking']
     geogrid_upsampling = geocode_dict['geogrid_upsampling']
@@ -564,17 +569,30 @@ def _run(cfg, raster_scratch_dir):
         # get azimuth ionospheric delay LUTs (if applicable)
         center_freq = \
             slc.getSwathMetadata(frequency).processed_center_frequency
+
+        # Decide whether TEC correction should use total TEC only (i.e. without
+        # subtracting the topside TEC) based on the run config and TEC data.
+        if apply_azimuth_ionospheric_delay_correction or \
+                apply_range_ionospheric_delay_correction:
+            use_total_tec_only = should_use_only_total_tec(
+                cfg, radar_grid.ref_epoch,
+                radar_grid.sensing_start, radar_grid.sensing_stop)
+
         if apply_azimuth_ionospheric_delay_correction:
-            az_correction = tec_lut2d_from_json_az(tec_file, center_freq,
-                                                   orbit, radar_grid)
+            az_correction = tec_lut2d_from_json_az(
+                tec_file, center_freq, orbit, radar_grid,
+                total_tec_only=use_total_tec_only,
+                polyfit=polyfit_tec_profile)
             timing_corrections_dict['az_correction'][frequency] = az_correction
             optional_geo_kwargs['az_time_correction'] = az_correction
 
         # get slant-range ionospheric delay LUTs (if applicable)
         if apply_range_ionospheric_delay_correction:
-            rg_correction = tec_lut2d_from_json_srg(tec_file, center_freq,
-                                                    orbit, radar_grid,
-                                                    zero_doppler, dem_file)
+            rg_correction = tec_lut2d_from_json_srg(
+                tec_file, center_freq, orbit, radar_grid,
+                zero_doppler, dem_file,
+                total_tec_only=use_total_tec_only,
+                polyfit=polyfit_tec_profile)
             timing_corrections_dict['rg_correction'][frequency] = rg_correction
             optional_geo_kwargs['slant_range_correction'] = rg_correction
 

--- a/python/packages/nisar/workflows/geocode_corrections.py
+++ b/python/packages/nisar/workflows/geocode_corrections.py
@@ -255,7 +255,7 @@ def should_use_only_total_tec(cfg, ref_epoch, az_start, az_stop):
     Decide whether to use total TEC only or suborbital TEC.
     If `use_total_tec_only` is explicitly turned ON, processing will be forced
     to use total TEC only. If it's turned OFF, then the logic looks at the flag
-    `ignore_low_quality_topside_tec`. If turned on, this inspects the topside
+    `ignore_invalid_topside_tec`. If turned on, this inspects the topside
     TEC data flags within the radar grid and decides whether to use topside TEC.
 
     Parameters
@@ -275,7 +275,9 @@ def should_use_only_total_tec(cfg, ref_epoch, az_start, az_stop):
     bool
         True if total TEC only should be used, False otherwise.
     '''
+    info_channel = journal.info("geocode_corrections.should_use_only_total_tec")
     warning_channel = journal.warning("geocode_corrections.should_use_only_total_tec")
+    error_channel = journal.warning("geocode_corrections.should_use_only_total_tec")
 
     tec_path = cfg['dynamic_ancillary_file_group']['tec_file']
 
@@ -284,8 +286,8 @@ def should_use_only_total_tec(cfg, ref_epoch, az_start, az_stop):
         return False
 
     if not os.path.exists(tec_path):
-        warning_channel.log(f'TEC path provided does not exist: {tec_path}')
-        return False
+        error_channel.log(f'TEC path provided does not exist: {tec_path}')
+        raise FileNotFoundError
 
     if cfg['processing']['tec_correction']['use_total_tec_only'] is True:
         return True
@@ -301,7 +303,7 @@ def should_use_only_total_tec(cfg, ref_epoch, az_start, az_stop):
         return False
 
     # Start the investigation.
-    if cfg['processing']['tec_correction']['ignore_low_quality_topside_tec'] is True:
+    if cfg['processing']['tec_correction']['ignore_invalid_topside_tec']:
         # Convert the TEC UTC times to seconds since the radar grid reference
         # epoch so they share the same time base as the azimuth time span.
         tec_t_since_epoch = np.array(
@@ -319,11 +321,13 @@ def should_use_only_total_tec(cfg, ref_epoch, az_start, az_stop):
 
         # A flag value of 1 marks a low-quality topside TEC sample. If any
         # exist within the radar grid, fall back to total TEC only.
-        if np.any(top_tec_flags == 1):
+        if np.any(top_tec_flags):
             warning_channel.log(
                 'Low-quality topside TEC detected within the radar grid; '
                 'using total TEC only.')
             return True
+
+    info_channel.log('Data flag satisfactory. Using suborbital TEC')
 
     return False
 

--- a/python/packages/nisar/workflows/geocode_corrections.py
+++ b/python/packages/nisar/workflows/geocode_corrections.py
@@ -231,9 +231,13 @@ def _get_iono_srange_corrections(cfg, slc, frequency, orbit,
     # DEM file for DEM interpolator and EPSG for ellipsoid
     dem_file = cfg['dynamic_ancillary_file_group']['dem_file']
 
+    polyfit_tec_profile = \
+        cfg['processing']['tec_correction']['polyfit_tec_profile']
+
     tec_correction = tec_lut2d_from_json_srg(tec_file, center_freq, orbit,
                                              radar_grid, doppler, dem_file,
-                                             total_tec_only=use_totaltec_only)
+                                             total_tec_only=use_totaltec_only,
+                                             polyfit=polyfit_tec_profile)
 
     if cfg['processing']['tec_correction']['apply_slant_range_correction'] is False:
             # NOTE: Just returning an empty LUT2d() will disrupt the downstream procedure,
@@ -353,7 +357,7 @@ class AzSrgCorrections:
             tec_dict = json.load(fin)
         # For compatibility, skip the check if `topTecNrDataFlag` or `topTecFrDataFlag`
         # do not exist.
-        required_keys = {"topTecNrDataFlag", "topTecRrDataFlag"}
+        required_keys = {"topTecNrDataFlag", "topTecFrDataFlag"}
 
         if not required_keys.issubset(tec_dict):
             warning_channel.log(f'TopTEC Dataflag do not exist in IMAGEN TEC file: {tec_path}')

--- a/python/packages/nisar/workflows/geocode_corrections.py
+++ b/python/packages/nisar/workflows/geocode_corrections.py
@@ -3,6 +3,8 @@ Compute azimuth and slant range geocoding corrections as LUT2d
 '''
 import itertools
 import pathlib
+import os
+import json
 
 import numpy as np
 from osgeo import gdal
@@ -139,7 +141,8 @@ def _read_llh(scratch_path):
     return x, y, z
 
 
-def _get_iono_azimuth_corrections(cfg, slc, frequency, orbit):
+def _get_iono_azimuth_corrections(cfg, slc, frequency, orbit,
+                                  use_totaltec_only=False):
     '''
     Compute and return TEC geolocation corrections for azimuth as a LUT2d.
 
@@ -154,6 +157,9 @@ def _get_iono_azimuth_corrections(cfg, slc, frequency, orbit):
         Str identification for NISAR SLC frequencies
     orbit: isce3.core.Orbit
         Object containing orbit associated with SLC
+    use_totaltec_only: bool
+        If True, use total TEC only without subtracting the topside TEC.
+        Otherwise use the suborbital TEC (total TEC minus topside TEC).
 
     Returns
     -------
@@ -166,13 +172,27 @@ def _get_iono_azimuth_corrections(cfg, slc, frequency, orbit):
     center_freq = slc.getSwathMetadata(frequency).processed_center_frequency
     radar_grid = slc.getRadarGrid(frequency)
 
+    polyfit_tec_profile = \
+        cfg['processing']['tec_correction']['polyfit_tec_profile']
+
     tec_correction = tec_lut2d_from_json_az(tec_file, center_freq, orbit,
-                                            radar_grid)
+                                            radar_grid,
+                                            total_tec_only=use_totaltec_only,
+                                            polyfit=polyfit_tec_profile)
+
+    if cfg['processing']['tec_correction']['apply_azimuth_correction'] is False:
+        # NOTE: Just returning an empty LUT2d() will disrupt the downstream procedure,
+        # especially comparing the LUT's axis with the RSLC's radargrid
+        zero_arr = np.zeros(tec_correction.data.shape)
+        tec_correction = isce3.core.LUT2d(tec_correction.x_axis,
+                                          tec_correction.y_axis,
+                                          zero_arr)
 
     return tec_correction
 
 
-def _get_iono_srange_corrections(cfg, slc, frequency, orbit):
+def _get_iono_srange_corrections(cfg, slc, frequency, orbit,
+                                 use_totaltec_only=False):
     '''
     Compute and return TEC corrections for slant range as LUT2d.
 
@@ -190,6 +210,9 @@ def _get_iono_srange_corrections(cfg, slc, frequency, orbit):
         Str identification for NISAR SLC frequencies
     orbit: isce3.core.Orbit
         Object containing orbit associated with SLC
+    use_totaltec_only: bool
+        If True, use total TEC only without subtracting the topside TEC.
+        Otherwise use the suborbital TEC (total TEC minus topside TEC).
 
     Yields
     ------
@@ -209,7 +232,16 @@ def _get_iono_srange_corrections(cfg, slc, frequency, orbit):
     dem_file = cfg['dynamic_ancillary_file_group']['dem_file']
 
     tec_correction = tec_lut2d_from_json_srg(tec_file, center_freq, orbit,
-                                             radar_grid, doppler, dem_file)
+                                             radar_grid, doppler, dem_file,
+                                             total_tec_only=use_totaltec_only)
+
+    if cfg['processing']['tec_correction']['apply_slant_range_correction'] is False:
+            # NOTE: Just returning an empty LUT2d() will disrupt the downstream procedure,
+            # especially comparing the LUT's axis with the RSLC's radargrid
+            zero_arr = np.zeros(tec_correction.data.shape)
+            tec_correction = isce3.core.LUT2d(tec_correction.x_axis,
+                                              tec_correction.y_axis,
+                                              zero_arr)
 
     return tec_correction
 
@@ -256,6 +288,7 @@ class AzSrgCorrections:
         self.slc = slc
         self.frequency = frequency
         self.orbit = orbit
+        self.use_totaltec_only = False
 
         # Decimate radar grid to 5km resolution in azimuth and slant range
         radar_grid = self.slc.getRadarGrid(self.frequency)
@@ -271,6 +304,11 @@ class AzSrgCorrections:
         # Unpack flags and determine which corrections to generate
         self.correct_set = cfg['processing']['correction_luts']['solid_earth_tides_enabled']
         self.correct_tec = cfg["dynamic_ancillary_file_group"]['tec_file'] is not None
+
+        # Decide whether TEC correction should use total TEC only (i.e. without
+        # subtracting the topside TEC) based on the run config and TEC data.
+        self.use_totaltec_only = self._should_use_only_total_tec()
+
         if self.correct_set or self.correct_tec:
             self._compute_model_correction_luts()
 
@@ -282,6 +320,72 @@ class AzSrgCorrections:
 
         if self.apply_data_driven_correction:
             self._compute_offset_luts()
+
+
+    def _should_use_only_total_tec(self):
+        '''
+        Decide whether to use total TEC only or suborbital TEC.
+        If `use_total_tec_only` is explicitly turned ON,
+        processing will be forced to use total TEC only.
+        If it's turned OFF, then the logic will take a look at the flag
+        `ignore_low_quality_topside_tec` is turned on. If turned on,
+        this function will take a look at the data and decide whether or not to use topside TEC
+        '''
+
+        info_channel = journal.info("AzSrgCorrections._should_use_only_total_tec")
+        warning_channel = journal.warning("AzSrgCorrections._should_use_only_total_tec")
+        error_channel = journal.info("AzSrgCorrections._should_use_only_total_tec")
+
+        tec_path = self.cfg['dynamic_ancillary_file_group']['tec_file']
+
+        if tec_path is None:
+            warning_channel.log(f'TEC path was not provided: {tec_path}')
+            return False
+
+        if not os.path.exists(tec_path):
+            warning_channel.log(f'TEC path provided does not exist: {tec_path}')
+            return False
+
+        if self.cfg['processing']['tec_correction']['use_total_tec_only'] is True:
+            return True
+
+        with open(tec_path, 'r') as fin:
+            tec_dict = json.load(fin)
+        # For compatibility, skip the check if `topTecNrDataFlag` or `topTecFrDataFlag`
+        # do not exist.
+        required_keys = {"topTecNrDataFlag", "topTecRrDataFlag"}
+
+        if not required_keys.issubset(tec_dict):
+            warning_channel.log(f'TopTEC Dataflag do not exist in IMAGEN TEC file: {tec_path}')
+            return False
+
+        # Start the investigation.
+        if self.cfg['processing']['tec_correction']['ignore_low_quality_topside_tec'] is True:
+            # Convert the TEC UTC times to seconds since the radar grid
+            # reference epoch so they share the same time base as self.az_vec.
+            ref_epoch = self.radar_grid_scaled.ref_epoch
+            tec_t_since_epoch = np.array(
+                [(isce3.core.DateTime(t_str) - ref_epoch).total_seconds()
+                 for t_str in tec_dict['utc']])
+
+            # Crop the topside TEC data flags to the TEC samples that fall
+            # within the azimuth time span of the (decimated) radar grid.
+            within_radar_grid = ((tec_t_since_epoch >= self.az_vec[0]) &
+                                 (tec_t_since_epoch <= self.az_vec[-1]))
+
+            top_tec_flags = np.concatenate(
+                [np.array(tec_dict['topTecNrDataFlag'])[within_radar_grid],
+                 np.array(tec_dict['topTecFrDataFlag'])[within_radar_grid]])
+
+            # A flag value of 1 marks a low-quality topside TEC sample. If any
+            # exist within the radar grid, fall back to total TEC only.
+            if np.any(top_tec_flags == 1):
+                warning_channel.log(
+                    'Low-quality topside TEC detected within the radar grid; '
+                    'using total TEC only.')
+                return True
+
+        return False
 
 
     def _compute_offset_luts(self):
@@ -339,11 +443,13 @@ class AzSrgCorrections:
             low_res_tec_az = _get_iono_azimuth_corrections(self.cfg,
                                                            self.slc,
                                                            self.frequency,
-                                                           self.orbit)
+                                                           self.orbit,
+                                                           self.use_totaltec_only)
             low_res_tec_srange = _get_iono_srange_corrections(self.cfg,
                                                               self.slc,
                                                               self.frequency,
-                                                              self.orbit)
+                                                              self.orbit,
+                                                              self.use_totaltec_only)
 
             # If only TEC corrections generated, return existing TEC correction LUT2ds
             if not self.correct_set:

--- a/python/packages/nisar/workflows/geocode_corrections.py
+++ b/python/packages/nisar/workflows/geocode_corrections.py
@@ -312,8 +312,9 @@ def should_use_only_total_tec(cfg, ref_epoch, az_start, az_stop):
 
         # Crop the topside TEC data flags to the TEC samples that fall within
         # the azimuth time span of the (decimated) radar grid.
-        within_radar_grid = ((tec_t_since_epoch >= az_start) &
-                             (tec_t_since_epoch <= az_stop))
+        i_start = np.searchsorted(tec_t_since_epoch, az_start, side='left')
+        i_stop = np.searchsorted(tec_t_since_epoch, az_stop, side='right')
+        within_radar_grid = slice(i_start, i_stop)
 
         top_tec_flags = np.concatenate(
             [np.array(tec_dict['topTecNrDataFlag'])[within_radar_grid],

--- a/python/packages/nisar/workflows/geocode_corrections.py
+++ b/python/packages/nisar/workflows/geocode_corrections.py
@@ -240,14 +240,92 @@ def _get_iono_srange_corrections(cfg, slc, frequency, orbit,
                                              polyfit=polyfit_tec_profile)
 
     if cfg['processing']['tec_correction']['apply_slant_range_correction'] is False:
-            # NOTE: Just returning an empty LUT2d() will disrupt the downstream procedure,
-            # especially comparing the LUT's axis with the RSLC's radargrid
-            zero_arr = np.zeros(tec_correction.data.shape)
-            tec_correction = isce3.core.LUT2d(tec_correction.x_axis,
-                                              tec_correction.y_axis,
-                                              zero_arr)
+        # NOTE: Just returning an empty LUT2d() will disrupt the downstream procedure,
+        # especially comparing the LUT's axis with the RSLC's radargrid
+        zero_arr = np.zeros(tec_correction.data.shape)
+        tec_correction = isce3.core.LUT2d(tec_correction.x_axis,
+                                          tec_correction.y_axis,
+                                          zero_arr)
 
     return tec_correction
+
+
+def should_use_only_total_tec(cfg, ref_epoch, az_start, az_stop):
+    '''
+    Decide whether to use total TEC only or suborbital TEC.
+    If `use_total_tec_only` is explicitly turned ON, processing will be forced
+    to use total TEC only. If it's turned OFF, then the logic looks at the flag
+    `ignore_low_quality_topside_tec`. If turned on, this inspects the topside
+    TEC data flags within the radar grid and decides whether to use topside TEC.
+
+    Parameters
+    ----------
+    cfg: dict
+        Dict containing the runconfiguration parameters
+    ref_epoch: isce3.core.DateTime
+        Reference epoch of the radar grid used to convert TEC UTC times to
+        seconds relative to the same time base as `az_start` / `az_stop`.
+    az_start: float
+        Azimuth start time (seconds since `ref_epoch`) of the radar grid.
+    az_stop: float
+        Azimuth stop time (seconds since `ref_epoch`) of the radar grid.
+
+    Returns
+    -------
+    bool
+        True if total TEC only should be used, False otherwise.
+    '''
+    warning_channel = journal.warning("geocode_corrections.should_use_only_total_tec")
+
+    tec_path = cfg['dynamic_ancillary_file_group']['tec_file']
+
+    if tec_path is None:
+        warning_channel.log(f'TEC path was not provided: {tec_path}')
+        return False
+
+    if not os.path.exists(tec_path):
+        warning_channel.log(f'TEC path provided does not exist: {tec_path}')
+        return False
+
+    if cfg['processing']['tec_correction']['use_total_tec_only'] is True:
+        return True
+
+    with open(tec_path, 'r') as fin:
+        tec_dict = json.load(fin)
+    # For compatibility, skip the check if `topTecNrDataFlag` or `topTecFrDataFlag`
+    # do not exist.
+    required_keys = {"topTecNrDataFlag", "topTecFrDataFlag"}
+
+    if not required_keys.issubset(tec_dict):
+        warning_channel.log(f'TopTEC Dataflag do not exist in IMAGEN TEC file: {tec_path}')
+        return False
+
+    # Start the investigation.
+    if cfg['processing']['tec_correction']['ignore_low_quality_topside_tec'] is True:
+        # Convert the TEC UTC times to seconds since the radar grid reference
+        # epoch so they share the same time base as the azimuth time span.
+        tec_t_since_epoch = np.array(
+            [(isce3.core.DateTime(t_str) - ref_epoch).total_seconds()
+             for t_str in tec_dict['utc']])
+
+        # Crop the topside TEC data flags to the TEC samples that fall within
+        # the azimuth time span of the (decimated) radar grid.
+        within_radar_grid = ((tec_t_since_epoch >= az_start) &
+                             (tec_t_since_epoch <= az_stop))
+
+        top_tec_flags = np.concatenate(
+            [np.array(tec_dict['topTecNrDataFlag'])[within_radar_grid],
+             np.array(tec_dict['topTecFrDataFlag'])[within_radar_grid]])
+
+        # A flag value of 1 marks a low-quality topside TEC sample. If any
+        # exist within the radar grid, fall back to total TEC only.
+        if np.any(top_tec_flags == 1):
+            warning_channel.log(
+                'Low-quality topside TEC detected within the radar grid; '
+                'using total TEC only.')
+            return True
+
+    return False
 
 
 class AzSrgCorrections:
@@ -311,7 +389,9 @@ class AzSrgCorrections:
 
         # Decide whether TEC correction should use total TEC only (i.e. without
         # subtracting the topside TEC) based on the run config and TEC data.
-        self.use_totaltec_only = self._should_use_only_total_tec()
+        self.use_totaltec_only = should_use_only_total_tec(
+            self.cfg, self.radar_grid_scaled.ref_epoch,
+            self.az_vec[0], self.az_vec[-1])
 
         if self.correct_set or self.correct_tec:
             self._compute_model_correction_luts()
@@ -324,72 +404,6 @@ class AzSrgCorrections:
 
         if self.apply_data_driven_correction:
             self._compute_offset_luts()
-
-
-    def _should_use_only_total_tec(self):
-        '''
-        Decide whether to use total TEC only or suborbital TEC.
-        If `use_total_tec_only` is explicitly turned ON,
-        processing will be forced to use total TEC only.
-        If it's turned OFF, then the logic will take a look at the flag
-        `ignore_low_quality_topside_tec` is turned on. If turned on,
-        this function will take a look at the data and decide whether or not to use topside TEC
-        '''
-
-        info_channel = journal.info("AzSrgCorrections._should_use_only_total_tec")
-        warning_channel = journal.warning("AzSrgCorrections._should_use_only_total_tec")
-        error_channel = journal.info("AzSrgCorrections._should_use_only_total_tec")
-
-        tec_path = self.cfg['dynamic_ancillary_file_group']['tec_file']
-
-        if tec_path is None:
-            warning_channel.log(f'TEC path was not provided: {tec_path}')
-            return False
-
-        if not os.path.exists(tec_path):
-            warning_channel.log(f'TEC path provided does not exist: {tec_path}')
-            return False
-
-        if self.cfg['processing']['tec_correction']['use_total_tec_only'] is True:
-            return True
-
-        with open(tec_path, 'r') as fin:
-            tec_dict = json.load(fin)
-        # For compatibility, skip the check if `topTecNrDataFlag` or `topTecFrDataFlag`
-        # do not exist.
-        required_keys = {"topTecNrDataFlag", "topTecFrDataFlag"}
-
-        if not required_keys.issubset(tec_dict):
-            warning_channel.log(f'TopTEC Dataflag do not exist in IMAGEN TEC file: {tec_path}')
-            return False
-
-        # Start the investigation.
-        if self.cfg['processing']['tec_correction']['ignore_low_quality_topside_tec'] is True:
-            # Convert the TEC UTC times to seconds since the radar grid
-            # reference epoch so they share the same time base as self.az_vec.
-            ref_epoch = self.radar_grid_scaled.ref_epoch
-            tec_t_since_epoch = np.array(
-                [(isce3.core.DateTime(t_str) - ref_epoch).total_seconds()
-                 for t_str in tec_dict['utc']])
-
-            # Crop the topside TEC data flags to the TEC samples that fall
-            # within the azimuth time span of the (decimated) radar grid.
-            within_radar_grid = ((tec_t_since_epoch >= self.az_vec[0]) &
-                                 (tec_t_since_epoch <= self.az_vec[-1]))
-
-            top_tec_flags = np.concatenate(
-                [np.array(tec_dict['topTecNrDataFlag'])[within_radar_grid],
-                 np.array(tec_dict['topTecFrDataFlag'])[within_radar_grid]])
-
-            # A flag value of 1 marks a low-quality topside TEC sample. If any
-            # exist within the radar grid, fall back to total TEC only.
-            if np.any(top_tec_flags == 1):
-                warning_channel.log(
-                    'Low-quality topside TEC detected within the radar grid; '
-                    'using total TEC only.')
-                return True
-
-        return False
 
 
     def _compute_offset_luts(self):

--- a/share/nisar/defaults/gcov.yaml
+++ b/share/nisar/defaults/gcov.yaml
@@ -277,6 +277,13 @@ runconfig:
                 #     'algorithm_type' equal to 'area_projection'
                 area_beta_mode: auto
 
+            # TEC correction options. The apply-range/azimuth ionospheric delay
+            # flags live under the `geocode` group above.
+            tec_correction:
+                use_total_tec_only: False
+                ignore_low_quality_topside_tec: False
+                polyfit_tec_profile: False
+
             # Mechanism to specify output posting and DEM
             geocode:
 

--- a/share/nisar/defaults/gcov.yaml
+++ b/share/nisar/defaults/gcov.yaml
@@ -20,7 +20,7 @@ runconfig:
             # REQUIRED - Digital elevation model
             dem_file:
 
-            # Description of the digital elevation model (DEM) file  
+            # Description of the digital elevation model (DEM) file
             # to be included in the output product metadata
             dem_file_description:
 
@@ -153,7 +153,7 @@ runconfig:
             # field will be set to "(NOT SPECIFIED)".
             processing_center:
 
-            # Processing center. If not provided, the metadata field 
+            # Processing center. If not provided, the metadata field
             # `granuleId` will be set to "(NOT SPECIFIED)".
             partial_granule_id:
 
@@ -281,7 +281,7 @@ runconfig:
             # flags live under the `geocode` group above.
             tec_correction:
                 use_total_tec_only: False
-                ignore_invalid_topside_tec: False
+                ignore_invalid_topside_tec: True
                 polyfit_tec_profile: False
 
             # Mechanism to specify output posting and DEM
@@ -406,7 +406,7 @@ runconfig:
 
                 # Pixel spacing in the units of the output EPSG coordinate
                 # system (output_epsg).
-                # 
+                #
                 # If not specified and `output_epsg` differs from the DEM’s EPSG:
                 #   - Defaults to 0.00017966305682390427 degrees for geographic
                 # coordinate systems.

--- a/share/nisar/defaults/gcov.yaml
+++ b/share/nisar/defaults/gcov.yaml
@@ -281,7 +281,7 @@ runconfig:
             # flags live under the `geocode` group above.
             tec_correction:
                 use_total_tec_only: False
-                ignore_low_quality_topside_tec: False
+                ignore_invalid_topside_tec: False
                 polyfit_tec_profile: False
 
             # Mechanism to specify output posting and DEM

--- a/share/nisar/defaults/gslc.yaml
+++ b/share/nisar/defaults/gslc.yaml
@@ -331,6 +331,12 @@ runconfig:
                 # Boolean flag to activate/deactivate model-based solid earth tide corrections
                 solid_earth_tides_enabled: True
 
+            tec_correction:
+                apply_slant_range_correction: True
+                apply_azimuth_correction: True
+                use_total_tec: False
+                reject_lowqual_toptec: False
+
         # OPTIONAL - Group containing CEOS Analysis Ready Data (CARD) parameters
         # to populate the output product's metadata
         ceos_analysis_ready_data:

--- a/share/nisar/defaults/gslc.yaml
+++ b/share/nisar/defaults/gslc.yaml
@@ -335,7 +335,7 @@ runconfig:
                 apply_slant_range_correction: True
                 apply_azimuth_correction: True
                 use_total_tec_only: False
-                ignore_invalid_topside_tec: False
+                ignore_invalid_topside_tec: True
                 polyfit_tec_profile: False
 
         # OPTIONAL - Group containing CEOS Analysis Ready Data (CARD) parameters

--- a/share/nisar/defaults/gslc.yaml
+++ b/share/nisar/defaults/gslc.yaml
@@ -334,8 +334,9 @@ runconfig:
             tec_correction:
                 apply_slant_range_correction: True
                 apply_azimuth_correction: True
-                use_total_tec: False
-                reject_lowqual_toptec: False
+                use_total_tec_only: False
+                ignore_low_quality_topside_tec: False
+                polyfit_tec_profile: False
 
         # OPTIONAL - Group containing CEOS Analysis Ready Data (CARD) parameters
         # to populate the output product's metadata

--- a/share/nisar/defaults/gslc.yaml
+++ b/share/nisar/defaults/gslc.yaml
@@ -335,7 +335,7 @@ runconfig:
                 apply_slant_range_correction: True
                 apply_azimuth_correction: True
                 use_total_tec_only: False
-                ignore_low_quality_topside_tec: False
+                ignore_invalid_topside_tec: False
                 polyfit_tec_profile: False
 
         # OPTIONAL - Group containing CEOS Analysis Ready Data (CARD) parameters

--- a/share/nisar/defaults/insar.yaml
+++ b/share/nisar/defaults/insar.yaml
@@ -830,6 +830,13 @@ runconfig:
                 # Boolean flag to activate/deactivate model-based solid earth tide corrections
                 solid_earth_tides_enabled: True
 
+            tec_correction:
+                apply_slant_range_correction: True
+                apply_azimuth_correction: True
+                use_total_tec_only: False
+                ignore_low_quality_topside_tec: False
+                polyfit_tec_profile: False
+
             # Set of options to enable compression, choose compression level,
             # chunk size and shuffle filter
         output:

--- a/share/nisar/defaults/insar.yaml
+++ b/share/nisar/defaults/insar.yaml
@@ -834,7 +834,7 @@ runconfig:
                 apply_slant_range_correction: True
                 apply_azimuth_correction: True
                 use_total_tec_only: False
-                ignore_invalid_topside_tec: False
+                ignore_invalid_topside_tec: True
                 polyfit_tec_profile: False
 
             # Set of options to enable compression, choose compression level,

--- a/share/nisar/defaults/insar.yaml
+++ b/share/nisar/defaults/insar.yaml
@@ -834,7 +834,7 @@ runconfig:
                 apply_slant_range_correction: True
                 apply_azimuth_correction: True
                 use_total_tec_only: False
-                ignore_low_quality_topside_tec: False
+                ignore_invalid_topside_tec: False
                 polyfit_tec_profile: False
 
             # Set of options to enable compression, choose compression level,

--- a/share/nisar/schemas/gcov.yaml
+++ b/share/nisar/schemas/gcov.yaml
@@ -560,7 +560,7 @@ geocode_options:
 
 tec_correction_options:
     use_total_tec_only: bool(required=False)
-    ignore_low_quality_topside_tec: bool(required=False)
+    ignore_invalid_topside_tec: bool(required=False)
     polyfit_tec_profile: bool(required=False)
 
 ceos_analysis_ready_data_options:

--- a/share/nisar/schemas/gcov.yaml
+++ b/share/nisar/schemas/gcov.yaml
@@ -97,6 +97,9 @@ runconfig:
             # Geocode options: (e.g. output posting)
             geocode: include('geocode_options', required=False)
 
+            # TEC correction options
+            tec_correction: include('tec_correction_options', required=False)
+
             # Radar grids cube options
             radar_grid_cubes:  include('radar_grid_cubes_options', required=False)
 
@@ -554,6 +557,11 @@ geocode_options:
     # block, considering the data type and the number of bands
     # (polarizations) to process.
     max_block_size: num(min=0, required=False)
+
+tec_correction_options:
+    use_total_tec_only: bool(required=False)
+    ignore_low_quality_topside_tec: bool(required=False)
+    polyfit_tec_profile: bool(required=False)
 
 ceos_analysis_ready_data_options:
 

--- a/share/nisar/schemas/gslc.yaml
+++ b/share/nisar/schemas/gslc.yaml
@@ -443,5 +443,5 @@ tec_correction_options:
     apply_slant_range_correction: bool(required=False)
     apply_azimuth_correction: bool(required=False)
     use_total_tec_only: bool(required=False)
-    ignore_low_quality_topside_tec: bool(required=False)
+    ignore_invalid_topside_tec: bool(required=False)
     polyfit_tec_profile: bool(required=False)

--- a/share/nisar/schemas/gslc.yaml
+++ b/share/nisar/schemas/gslc.yaml
@@ -443,4 +443,5 @@ tec_correction_options:
     apply_slant_range_correction: bool(required=False)
     apply_azimuth_correction: bool(required=False)
     use_total_tec: bool(required=False)
-    reject_lowqual_tec: bool(required=False)
+    ignore_low_quality_topside_tec: bool(required=False)
+    polyfit_tec_profile: bool(required=False)

--- a/share/nisar/schemas/gslc.yaml
+++ b/share/nisar/schemas/gslc.yaml
@@ -107,6 +107,8 @@ runconfig:
 
             ampcor: include('ampcor_options', required=False)
 
+            tec_correction: include('tec_correction_options', required=False)
+
             blocksize:
                 x: int(min=100, max=100000)
                 y: int(min=100, max=10000)
@@ -436,3 +438,9 @@ output_options:
 lut_options:
     # Boolean flag to activate/deactivate model-based solid earth tide corrections
     solid_earth_tides_enabled: bool(required=False)
+
+tec_correction_options:
+    apply_slant_range_correction: bool(required=False)
+    apply_azimuth_correction: bool(required=False)
+    use_total_tec: bool(required=False)
+    reject_lowqual_tec: bool(required=False)

--- a/share/nisar/schemas/gslc.yaml
+++ b/share/nisar/schemas/gslc.yaml
@@ -442,6 +442,6 @@ lut_options:
 tec_correction_options:
     apply_slant_range_correction: bool(required=False)
     apply_azimuth_correction: bool(required=False)
-    use_total_tec: bool(required=False)
+    use_total_tec_only: bool(required=False)
     ignore_low_quality_topside_tec: bool(required=False)
     polyfit_tec_profile: bool(required=False)

--- a/share/nisar/schemas/insar.yaml
+++ b/share/nisar/schemas/insar.yaml
@@ -155,6 +155,8 @@ runconfig:
             # Options to generate model-based slant range and azimuth correction LUTs
             correction_luts: include('lut_options', required=False)
 
+            tec_correction: include('tec_correction_options', required=False)
+
         # To setup type of worker
         worker: include('worker_options', required=False)
 
@@ -1234,6 +1236,13 @@ output_options:
 lut_options:
     # Boolean flag to activate/deactivate model-based solid earth tide corrections
     solid_earth_tides_enabled: bool(required=False)
+
+tec_correction_options:
+    apply_slant_range_correction: bool(required=False)
+    apply_azimuth_correction: bool(required=False)
+    use_total_tec_only: bool(required=False)
+    ignore_low_quality_topside_tec: bool(required=False)
+    polyfit_tec_profile: bool(required=False)
 
 product_version_options:
     rifg_version: str('^\d+\.\d+\.\d+$', required=False)

--- a/share/nisar/schemas/insar.yaml
+++ b/share/nisar/schemas/insar.yaml
@@ -1241,7 +1241,7 @@ tec_correction_options:
     apply_slant_range_correction: bool(required=False)
     apply_azimuth_correction: bool(required=False)
     use_total_tec_only: bool(required=False)
-    ignore_low_quality_topside_tec: bool(required=False)
+    ignore_invalid_topside_tec: bool(required=False)
     polyfit_tec_profile: bool(required=False)
 
 product_version_options:


### PR DESCRIPTION
This PR adds several options to ionospheric TEC correction

- Add option into runconfig to use total TEC only
- Add option to turn on / off the slant range / azimuth correction individually
- Add logic to ignore topside TEC (i.e. use total TEC only) based on the data flag inside IMAGEN TEC
- Apply polynomial fitting to TEC profile to get rid of spikes
- Add the additional TEC profiles to GCOV and InSAR workflows


EDIT
09/10/2026: RANSAC-based outlier detection is implemented and being applied before polynomial fitting. Test is ongoing internally.