### PR TITLE
RSLC missing data mask

### DIFF
--- a/python/packages/isce3/focus/__init__.py
+++ b/python/packages/isce3/focus/__init__.py
@@ -3,6 +3,7 @@ from .caltone import ToneRemover
 from .sar_duration import (get_sar_duration, get_radar_velocities,
 	predict_azimuth_envelope)
 from .valid_regions import (RadarPoint, RadarBoundingBox,
-	get_focused_sub_swaths, fill_gaps, find_bad_rangline_slices)
+	get_focused_sub_swath_polygons, get_focused_sub_swaths,
+	save_valid_data_mask, fill_gaps, find_bad_rangline_slices)
 from .calibration_luts import make_los_luts, make_cal_luts
 from .notch import Notch, FrequencyDomain

--- a/python/packages/isce3/focus/valid_regions.py
+++ b/python/packages/isce3/focus/valid_regions.py
@@ -614,7 +614,7 @@ def save_subswath_polygons_to_image(polygon_lists, grid, image, blocksize=None,
     """
     if image.dtype.kind not in "bui":
         raise ValueError("Expected integer or boolean data type for mask")
-    nbits = (1 if np.issubdtype(image.dtype, np.bool)
+    nbits = (1 if np.issubdtype(image.dtype, np.bool_)
         else 8 * image.dtype.itemsize)
     if not (0 <= bit < nbits):
         raise ValueError(f"Expected 0 <= bit < {nbits} but got {bit=}")

--- a/python/packages/isce3/focus/valid_regions.py
+++ b/python/packages/isce3/focus/valid_regions.py
@@ -513,6 +513,50 @@ def get_focused_sub_swaths(raw_bbox_lists, chirp_durations, orbit,
         threshold=allowed_range_gap)
 
 
+def save_subswath_polygons_to_image(polygon_lists, grid, image, blocksize=None):
+    m, n = grid.shape
+    if grid.shape != image.shape:
+        raise ValueError("Shape of output image must match grid shape")
+
+    # Use chunk-aligned access if image is an HDF5 dataset.
+    if blocksize is None:
+        blocksize = getattr(image, "chunks", (512,))[0]
+
+    # Allocate block workspace.  Then we'll assign full blocks at a time since
+    # access to the image may be slow (e.g., compressed HDF5 dataset).
+    image_block = np.zeros((blocksize, n), image.dtype)
+
+    dr = grid.range_pixel_spacing
+    r0, r1 = grid.slant_ranges[0], grid.slant_ranges[-1]
+
+    for i0 in range(0, m, blocksize):
+        i1 = min(i0 + blocksize, m)
+        image_block[...] = False
+        for iblock, itime in enumerate(range(i0, i1)):
+            # Scanline corresponding to a row of the radar image grid.
+            t = grid.sensing_times[itime]
+            line = shapely.LineString([(r0, t), (r1, t)])
+
+            for polygons in polygon_lists:
+                for polygon in polygons:
+                    intersection = line & polygon
+                    # Result can be empty, line, or multiline
+                    for segment in shapely.get_parts(intersection):
+                        if segment.is_empty:
+                            continue
+                        assert segment.geom_type == "LineString"
+                        r = np.array(sorted(segment.coords.xy[0]))
+                        j0, j1 = np.round((r - r0) / dr).astype(int)
+                        image_block[iblock, j0:j1] = True
+
+        source_rows = slice(0, i1 - i0)
+        dest_rows = slice(i0, i1)
+        if hasattr(image, "write_direct"):
+            image.write_direct(image_block, source_rows, dest_rows)
+        else:
+            image[dest_rows] = image_block[source_rows]
+
+
 def fill_gaps(data, swaths, value=np.complex64(0)):
     """
     Fill transmit gaps in raw data with a specified value.

--- a/python/packages/isce3/focus/valid_regions.py
+++ b/python/packages/isce3/focus/valid_regions.py
@@ -419,10 +419,10 @@ def rasterize_subswath_polygons(slc_polygon_lists, slc_grid, threshold=2):
                 j0, j1 = tmp_swaths[iswath, iobs]
 
                 # Cast to int to prevent unsigned underflow.
-                if abs(int(j0) - i1) <= threshold:
+                if abs(np.int64(j0) - i1) <= threshold:
                     # Join contiguous, previous first.
                     swaths[iswath, itime] = (i0, j1)
-                elif abs(int(i0) - j1) <= threshold:
+                elif abs(np.int64(i0) - j1) <= threshold:
                     # Join contiguous, current first.
                     swaths[iswath, itime] = (j0, i1)
                 elif (j1 - j0) > n:

--- a/python/packages/isce3/focus/valid_regions.py
+++ b/python/packages/isce3/focus/valid_regions.py
@@ -582,9 +582,11 @@ def get_focused_sub_swaths(raw_bbox_lists, chirp_durations, orbit,
         threshold=allowed_range_gap)
 
 
-def save_subswath_polygons_to_image(polygon_lists, grid, image, blocksize=None):
+def save_subswath_polygons_to_image(polygon_lists, grid, image, blocksize=None,
+                                    bit=0):
     """
-    Rasterize valid data polygons onto a per-pixel boolean mask image.
+    Rasterize valid data polygons onto a per-pixel mask image.  Each pixel will
+    be bitwise-ORed with the existing value.
 
     Parameters
     ----------
@@ -597,11 +599,25 @@ def save_subswath_polygons_to_image(polygon_lists, grid, image, blocksize=None):
         Grid for output image.
     image : array_like
         Output boolean mask, must have shape matching `grid.shape`.  May be
-        an HDF5 dataset, in which case writes are chunk-aligned.
+        an HDF5 dataset, in which case writes are chunk-aligned.  Should be
+        initialized to zero (at least in the bit position specified by `bit`).
     blocksize : int, optional
         Number of rows to rasterize and write at a time.  Defaults to the
         chunk size of `image` if it is an HDF5 dataset, otherwise 512.
+    bit : int, optional
+        The bit to set in the output mask for valid pixels.
+    
+    Returns
+    -------
+    num_valid : int
+        Total number of valid pixels in the image.
     """
+    if image.dtype.kind not in "bui":
+        raise ValueError("Expected integer or boolean data type for mask")
+    nbits = (1 if np.issubdtype(image.dtype, np.bool)
+        else 8 * image.dtype.itemsize)
+    if not (0 <= bit < nbits):
+        raise ValueError(f"Expected 0 <= bit < {nbits} but got {bit=}")
     m, n = grid.shape
     if grid.shape != image.shape:
         raise ValueError("Shape of output image must match grid shape")
@@ -632,6 +648,8 @@ def save_subswath_polygons_to_image(polygon_lists, grid, image, blocksize=None):
             feature.SetGeometry(shapely2ogr_polygon(polygon))
             layer.CreateFeature(feature)
 
+    num_valid = 0
+
     for i0 in range(0, m, blocksize):
         i1 = min(i0 + blocksize, m)
         nrows = i1 - i0
@@ -645,11 +663,20 @@ def save_subswath_polygons_to_image(polygon_lists, grid, image, blocksize=None):
         image_block = raster_ds.GetRasterBand(1).ReadAsArray().astype(
             image.dtype, copy=False)
 
+        num_valid += np.sum(image_block)
+
+        # Shift mask to selected bit and OR with existing mask data.
+        if bit > 0:
+            image_block <<= bit
         dest_rows = slice(i0, i1)
+        image_block |= image[dest_rows]
+        # Write back out.
         if hasattr(image, "write_direct"):
             image.write_direct(image_block, None, dest_rows)
         else:
             image[dest_rows] = image_block
+
+    return num_valid
 
 
 def save_valid_data_mask(raw_bbox_lists, chirp_durations, orbit,

--- a/python/packages/isce3/focus/valid_regions.py
+++ b/python/packages/isce3/focus/valid_regions.py
@@ -3,6 +3,8 @@ from .sar_duration import get_sar_duration
 from copy import deepcopy
 from dataclasses import dataclass
 from functools import reduce
+from isce3.geometry.polygons import shapely2ogr_polygon
+from osgeo import gdal, ogr, osr
 import isce3
 import numpy as np
 import shapely
@@ -514,6 +516,25 @@ def get_focused_sub_swaths(raw_bbox_lists, chirp_durations, orbit,
 
 
 def save_subswath_polygons_to_image(polygon_lists, grid, image, blocksize=None):
+    """
+    Rasterize valid data polygons onto a per-pixel boolean mask image.
+
+    Parameters
+    ----------
+    polygon_lists : list[list[shapely.Polygon]]
+        List of valid data regions for each file/observation specified in
+        image grid (x=range, y=time) coordinates, e.g., as produced by
+        `transform_polygons_raw2image`.  A pixel is marked valid if it falls
+        within any polygon from any list.
+    grid : isce3.product.RadarGridParameters
+        Grid for output image.
+    image : array_like
+        Output boolean mask, must have shape matching `grid.shape`.  May be
+        an HDF5 dataset, in which case writes are chunk-aligned.
+    blocksize : int, optional
+        Number of rows to rasterize and write at a time.  Defaults to the
+        chunk size of `image` if it is an HDF5 dataset, otherwise 512.
+    """
     m, n = grid.shape
     if grid.shape != image.shape:
         raise ValueError("Shape of output image must match grid shape")
@@ -522,39 +543,46 @@ def save_subswath_polygons_to_image(polygon_lists, grid, image, blocksize=None):
     if blocksize is None:
         blocksize = getattr(image, "chunks", (512,))[0]
 
-    # Allocate block workspace.  Then we'll assign full blocks at a time since
-    # access to the image may be slow (e.g., compressed HDF5 dataset).
-    image_block = np.zeros((blocksize, n), image.dtype)
-
     dr = grid.range_pixel_spacing
-    r0, r1 = grid.slant_ranges[0], grid.slant_ranges[-1]
+    r0 = grid.slant_ranges[0]
+    dt = 1.0 / grid.prf
+    t0 = grid.sensing_times[0]
+
+    # Build a single in-memory vector layer with all subswath polygons so we
+    # can rasterize them directly (via GDAL's scanline fill) instead of
+    # intersecting a line with every polygon for every row, which is
+    # dominated by per-call Python/GEOS overhead for large images.
+    # Assign a (meaningless) local SRS to the layer and raster below so GDAL
+    # can confirm they match instead of warning about it.
+    srs = osr.SpatialReference()
+    srs.SetLocalCS("radar image grid")
+
+    vector_ds = ogr.GetDriverByName("Memory").CreateDataSource("")
+    layer = vector_ds.CreateLayer("subswaths", srs=srs)
+    for polygons in polygon_lists:
+        for polygon in polygons:
+            feature = ogr.Feature(layer.GetLayerDefn())
+            feature.SetGeometry(shapely2ogr_polygon(polygon))
+            layer.CreateFeature(feature)
 
     for i0 in range(0, m, blocksize):
         i1 = min(i0 + blocksize, m)
-        image_block[...] = False
-        for iblock, itime in enumerate(range(i0, i1)):
-            # Scanline corresponding to a row of the radar image grid.
-            t = grid.sensing_times[itime]
-            line = shapely.LineString([(r0, t), (r1, t)])
+        nrows = i1 - i0
 
-            for polygons in polygon_lists:
-                for polygon in polygons:
-                    intersection = line & polygon
-                    # Result can be empty, line, or multiline
-                    for segment in shapely.get_parts(intersection):
-                        if segment.is_empty:
-                            continue
-                        assert segment.geom_type == "LineString"
-                        r = np.array(sorted(segment.coords.xy[0]))
-                        j0, j1 = np.round((r - r0) / dr).astype(int)
-                        image_block[iblock, j0:j1] = True
+        raster_ds = gdal.GetDriverByName("MEM").Create("", n, nrows, 1,
+            gdal.GDT_Byte)
+        raster_ds.SetSpatialRef(srs)
+        raster_ds.SetGeoTransform(
+            (r0 - dr / 2, dr, 0, t0 + i0 * dt - dt / 2, 0, dt))
+        gdal.RasterizeLayer(raster_ds, [1], layer, burn_values=[1])
+        image_block = raster_ds.GetRasterBand(1).ReadAsArray().astype(
+            image.dtype, copy=False)
 
-        source_rows = slice(0, i1 - i0)
         dest_rows = slice(i0, i1)
         if hasattr(image, "write_direct"):
-            image.write_direct(image_block, source_rows, dest_rows)
+            image.write_direct(image_block, None, dest_rows)
         else:
-            image[dest_rows] = image_block[source_rows]
+            image[dest_rows] = image_block
 
 
 def fill_gaps(data, swaths, value=np.complex64(0)):

--- a/python/packages/isce3/focus/valid_regions.py
+++ b/python/packages/isce3/focus/valid_regions.py
@@ -686,7 +686,7 @@ def save_valid_data_mask(raw_bbox_lists, chirp_durations, orbit,
                          rdr2geo_params=dict(),
                          geo2rdr_params=dict(), max_segment_length=5000,
                          convolution_mode="valid",
-                         allowed_azimuth_gap=2, blocksize=None):
+                         allowed_azimuth_gap=2, blocksize=None, bit=0):
     """
     Determine valid data regions of a focused image, considering transmit
     gaps and gaps between files (in multi-observation processing), and write
@@ -736,6 +736,13 @@ def save_valid_data_mask(raw_bbox_lists, chirp_durations, orbit,
     blocksize : int, optional
         Number of rows to rasterize and write at a time.  Defaults to the
         chunk size of `image` if it is an HDF5 dataset, otherwise 512.
+    bit : int, optional
+        The bit to set in the output mask for valid pixels.
+
+    Returns
+    -------
+    num_valid : int
+        Total number of valid pixels in the image.
     """
     slc_polygons = get_focused_sub_swath_polygons(
         raw_bbox_lists=raw_bbox_lists, chirp_durations=chirp_durations,
@@ -746,8 +753,8 @@ def save_valid_data_mask(raw_bbox_lists, chirp_durations, orbit,
         convolution_mode=convolution_mode,
         allowed_azimuth_gap=allowed_azimuth_gap)
 
-    save_subswath_polygons_to_image(slc_polygons, grid, image,
-        blocksize=blocksize)
+    return save_subswath_polygons_to_image(slc_polygons, grid, image,
+        blocksize=blocksize, bit=bit)
 
 
 def fill_gaps(data, swaths, value=np.complex64(0)):

--- a/python/packages/isce3/focus/valid_regions.py
+++ b/python/packages/isce3/focus/valid_regions.py
@@ -435,6 +435,77 @@ def rasterize_subswath_polygons(slc_polygon_lists, slc_grid, threshold=2):
     return swaths
 
 
+def get_focused_sub_swath_polygons(raw_bbox_lists, chirp_durations, orbit,
+                                   native_doppler, azres, grid,
+                                   dem=isce3.geometry.DEMInterpolator(),
+                                   image_grid_doppler=isce3.core.LUT2d(),
+                                   rdr2geo_params=dict(),
+                                   geo2rdr_params=dict(), max_segment_length=5000,
+                                   convolution_mode="valid",
+                                   allowed_azimuth_gap=2):
+    """
+    Determine valid data regions of a focused image, considering transmit
+    gaps and gaps between files (in multi-observation processing).
+
+    Parameters
+    ----------
+    raw_bbox_lists : list[list[RadarBoundingBox]]
+        Bounding boxes of all subswaths for each raw data file/observation.
+        Azimuth times should be specified in seconds relative to the orbit
+        reference epoch.
+    chirp_durations : list[float]
+        Duration of transmit chirp for each raw data file.
+    orbit : isce3.core.Orbit
+        Trajectory of radar antenna phase center.
+    native_doppler : isce3.core.LUT2d
+        Doppler centroid in Hz.  Time should be referenced to the same epoch
+        as the orbit.
+    azres : float
+        Intended azimuth resolution in meters.
+    grid : isce3.product.RadarGridParameters
+        Grid for focused image.
+    dem : isce3.geometry.DEMInterpolator, optional
+        Digital elevation model.  Defaults to 0 m above WGS84 ellipsoid.
+    image_grid_doppler : isce3.core.LUT2d, optional
+        Doppler (in Hz) associated with focused image grid geometry.
+        Defaults to zero-Doppler (NISAR convention).
+    rdr2geo_params : dict, optional
+        Parameters for rdr2geo_bracket
+    geo2rdr_params : dict, optional
+        Parameters for geo2rdr_bracket
+    max_segment_length : float, optional
+        Length scale over which subswath boundary can be considered linear,
+        in meters.
+    convolution_mode : {"valid", "full", "same"}, optional
+        How to handle boundary effects of focusing operation.  For "valid",
+        only return regions that will be fully focused.  For "full", return
+        regions with any nonzero data.  For "same", return regions that are
+        at least halfway focused.
+    allowed_azimuth_gap : int, optional
+        Amount of time (specified in pulse intervals) allowed between files
+        that is still considered contiguous.  If exceeded, the missing data
+        will be considered invalid and masked according to `convolution_mode`.
+
+    Returns
+    -------
+    slc_polygon_lists : list[list[shapely.Polygon]]
+        List of valid data regions for each file/observation specified in
+        focused radar image (x=range, y=time) coordinates.
+    """
+    raw_polygons = get_raw_sub_swath_polygons(raw_bbox_lists=raw_bbox_lists,
+        chirp_durations=chirp_durations, orbit=orbit,
+        wavelength=grid.wavelength, azres=azres, prf=grid.prf,
+        ellipsoid=dem.ellipsoid, convolution_mode=convolution_mode,
+        allowed_azimuth_gap=allowed_azimuth_gap)
+
+    return transform_polygons_raw2image(raw_polygon_lists=raw_polygons,
+        orbit=orbit, lookside=grid.lookside, native_doppler=native_doppler,
+        wavelength=grid.wavelength, dem=dem,
+        image_grid_doppler=image_grid_doppler,
+        max_segment_length=max_segment_length,
+        rdr2geo_params=rdr2geo_params, geo2rdr_params=geo2rdr_params)
+
+
 def get_focused_sub_swaths(raw_bbox_lists, chirp_durations, orbit,
                            native_doppler, azres, grid,
                            dem=isce3.geometry.DEMInterpolator(),
@@ -498,18 +569,14 @@ def get_focused_sub_swaths(raw_bbox_lists, chirp_durations, orbit,
         where nswath is the number of valid sub-swaths and npulse is the length
         of the focused image grid.
     """
-    raw_polygons = get_raw_sub_swath_polygons(raw_bbox_lists=raw_bbox_lists,
-        chirp_durations=chirp_durations, orbit=orbit,
-        wavelength=grid.wavelength, azres=azres, prf=grid.prf,
-        ellipsoid=dem.ellipsoid, convolution_mode=convolution_mode,
-        allowed_azimuth_gap=allowed_azimuth_gap)
-
-    slc_polygons = transform_polygons_raw2image(raw_polygon_lists=raw_polygons,
-        orbit=orbit, lookside=grid.lookside, native_doppler=native_doppler,
-        wavelength=grid.wavelength, dem=dem,
-        image_grid_doppler=image_grid_doppler,
+    slc_polygons = get_focused_sub_swath_polygons(
+        raw_bbox_lists=raw_bbox_lists, chirp_durations=chirp_durations,
+        orbit=orbit, native_doppler=native_doppler, azres=azres, grid=grid,
+        dem=dem, image_grid_doppler=image_grid_doppler,
+        rdr2geo_params=rdr2geo_params, geo2rdr_params=geo2rdr_params,
         max_segment_length=max_segment_length,
-        rdr2geo_params=rdr2geo_params, geo2rdr_params=geo2rdr_params)
+        convolution_mode=convolution_mode,
+        allowed_azimuth_gap=allowed_azimuth_gap)
 
     return rasterize_subswath_polygons(slc_polygons, grid,
         threshold=allowed_range_gap)
@@ -583,6 +650,77 @@ def save_subswath_polygons_to_image(polygon_lists, grid, image, blocksize=None):
             image.write_direct(image_block, None, dest_rows)
         else:
             image[dest_rows] = image_block
+
+
+def save_valid_data_mask(raw_bbox_lists, chirp_durations, orbit,
+                         native_doppler, azres, grid, image,
+                         dem=isce3.geometry.DEMInterpolator(),
+                         image_grid_doppler=isce3.core.LUT2d(),
+                         rdr2geo_params=dict(),
+                         geo2rdr_params=dict(), max_segment_length=5000,
+                         convolution_mode="valid",
+                         allowed_azimuth_gap=2, blocksize=None):
+    """
+    Determine valid data regions of a focused image, considering transmit
+    gaps and gaps between files (in multi-observation processing), and write
+    the result as a per-pixel boolean mask.
+
+    Parameters
+    ----------
+    raw_bbox_lists : list[list[RadarBoundingBox]]
+        Bounding boxes of all subswaths for each raw data file/observation.
+        Azimuth times should be specified in seconds relative to the orbit
+        reference epoch.
+    chirp_durations : list[float]
+        Duration of transmit chirp for each raw data file.
+    orbit : isce3.core.Orbit
+        Trajectory of radar antenna phase center.
+    native_doppler : isce3.core.LUT2d
+        Doppler centroid in Hz.  Time should be referenced to the same epoch
+        as the orbit.
+    azres : float
+        Intended azimuth resolution in meters.
+    grid : isce3.product.RadarGridParameters
+        Grid for focused image.
+    image : array_like
+        Output boolean mask, must have shape matching `grid.shape`.  May be
+        an HDF5 dataset, in which case writes are chunk-aligned.
+    dem : isce3.geometry.DEMInterpolator, optional
+        Digital elevation model.  Defaults to 0 m above WGS84 ellipsoid.
+    image_grid_doppler : isce3.core.LUT2d, optional
+        Doppler (in Hz) associated with focused image grid geometry.
+        Defaults to zero-Doppler (NISAR convention).
+    rdr2geo_params : dict, optional
+        Parameters for rdr2geo_bracket
+    geo2rdr_params : dict, optional
+        Parameters for geo2rdr_bracket
+    max_segment_length : float, optional
+        Length scale over which subswath boundary can be considered linear,
+        in meters.
+    convolution_mode : {"valid", "full", "same"}, optional
+        How to handle boundary effects of focusing operation.  For "valid",
+        only return regions that will be fully focused.  For "full", return
+        regions with any nonzero data.  For "same", return regions that are
+        at least halfway focused.
+    allowed_azimuth_gap : int, optional
+        Amount of time (specified in pulse intervals) allowed between files
+        that is still considered contiguous.  If exceeded, the missing data
+        will be considered invalid and masked according to `convolution_mode`.
+    blocksize : int, optional
+        Number of rows to rasterize and write at a time.  Defaults to the
+        chunk size of `image` if it is an HDF5 dataset, otherwise 512.
+    """
+    slc_polygons = get_focused_sub_swath_polygons(
+        raw_bbox_lists=raw_bbox_lists, chirp_durations=chirp_durations,
+        orbit=orbit, native_doppler=native_doppler, azres=azres, grid=grid,
+        dem=dem, image_grid_doppler=image_grid_doppler,
+        rdr2geo_params=rdr2geo_params, geo2rdr_params=geo2rdr_params,
+        max_segment_length=max_segment_length,
+        convolution_mode=convolution_mode,
+        allowed_azimuth_gap=allowed_azimuth_gap)
+
+    save_subswath_polygons_to_image(slc_polygons, grid, image,
+        blocksize=blocksize)
 
 
 def fill_gaps(data, swaths, value=np.complex64(0)):

--- a/python/packages/nisar/__init__.py
+++ b/python/packages/nisar/__init__.py
@@ -1,5 +1,6 @@
 from . import antenna
 from . import cal
+from . import focus
 from . import h5
 from . import log
 from . import mixed_mode

--- a/python/packages/nisar/focus/__init__.py
+++ b/python/packages/nisar/focus/__init__.py
@@ -1,0 +1,1 @@
+from . import valid_regions

--- a/python/packages/nisar/focus/valid_regions.py
+++ b/python/packages/nisar/focus/valid_regions.py
@@ -221,6 +221,7 @@ def get_focused_sub_swaths(rawlist, out_chan, grid, orbit, doppler, dem, azres,
     """
     min_segment_length = _get_min_segment_length(min_segment_fraction, azres,
         grid, orbit, dem.ellipsoid, _get_prf(rawlist))
+    log.info(f"Using {min_segment_length=} for valid sub swaths")
 
     raw_bbox_lists, chirp_durations = get_raw_sub_swath_bboxes(rawlist,
         out_chan, orbit, num_ignore=num_ignore,
@@ -385,6 +386,7 @@ def save_valid_data_mask(rawlist, out_chan, grid, orbit, doppler, dem, azres,
 
     min_segment_length = _get_min_segment_length(min_segment_fraction, azres,
         grid, orbit, dem.ellipsoid, _get_prf(rawlist))
+    log.info(f"Using {min_segment_length=} for valid data mask")
 
     raw_bbox_lists, chirp_durations = get_raw_sub_swath_bboxes(rawlist,
         out_chan, orbit, num_ignore=num_ignore,

--- a/python/packages/nisar/focus/valid_regions.py
+++ b/python/packages/nisar/focus/valid_regions.py
@@ -13,14 +13,14 @@ class _PolBit(enum.IntEnum):
     Bit index assigned to each polarization channel in the valid-data mask
     written by save_valid_data_mask.
     """
-    HH = 0
-    HV = 1
-    VH = 2
-    VV = 3
-    LH = 4
-    LV = 5
-    RH = 6
-    RV = 7
+    HH = 8
+    HV = 9
+    VH = 10
+    VV = 11
+    LH = 12
+    LV = 13
+    RH = 14
+    RV = 15
 
 
 class PolValidMask(enum.IntFlag):

--- a/python/packages/nisar/focus/valid_regions.py
+++ b/python/packages/nisar/focus/valid_regions.py
@@ -1,6 +1,7 @@
 #!python3
 import enum
 import logging
+from math import ceil
 import isce3
 import numpy as np
 from nisar.mixed_mode import find_overlapping_channel
@@ -261,11 +262,44 @@ def _mark_all_valid(image, bit, blocksize=None):
     return nrows * ncols
 
 
+def _get_prf(rawlist, reduction=max):
+    """
+    Get a representative pulse repetition frequency for a group of Raw files.
+
+    Parameters
+    ----------
+    rawlist : Iterable[Raw]
+        List of input raw data (NISAR L0B) files.
+    reduction : Callable[[Iterable[float]], float], optional
+        How to combine results from multiple files.  Default=max
+    
+    Returns
+    -------
+    prf : float
+        Pulse repetition frequency in Hz
+    """
+    return reduction(1.0 / np.mean(np.diff(raw.getPulseTimes()))
+        for raw in rawlist)
+
+
+def _get_min_segment_length(min_segment_fraction, azres, grid, orbit, ellipsoid,
+                            prf):
+    if not (0 < min_segment_fraction <= 1.0):
+        raise ValueError("Expected 0 < min_segment_fraction <= 1 but got "
+            f"{min_segment_fraction}")
+
+    sardur = isce3.focus.get_sar_duration(grid.sensing_mid, grid.end_range,
+        orbit, ellipsoid, azres, grid.wavelength)
+
+    min_segment_length = ceil(min_segment_fraction * sardur * prf)
+    return max(1, min_segment_length)
+
+
 def save_valid_data_mask(rawlist, out_chan, grid, orbit, doppler, dem, azres,
                          image, rdr2geo_params=dict(), geo2rdr_params=dict(),
                          ignore_failure=False, polygon_segment_length=50.0,
                          num_ignore=25, max_observation_gap=0.002,
-                         min_segment_length=2000, max_pulse_gap=1,
+                         min_segment_fraction=0.25, max_pulse_gap=1,
                          blocksize=None):
     """
     Determine fully-focused regions of the image and write the result as a
@@ -321,16 +355,18 @@ def save_valid_data_mask(rawlist, out_chan, grid, orbit, doppler, dem, azres,
         and the first pulse of the following observation for the two to be
         considered seamless.  Larger raw data gaps may result in a synthetic
         aperture being marked invalid in the RSLC.
-    min_segment_length : int, optional
+    min_segment_fraction : float, optional
+        Lower bound on the number of consecutive valid pulses, expressed as a
+        fraction of the synthetic aperture length.
         Segments with fewer than this number of consecutive valid pulses
         will not be returned.  This helps avoid unnecessary bookkeeping when
         lots of missing pulses are sprinkled throughout an observation. Must
         be >= 1 pulse.
     max_pulse_gap : int, optional
-        Segments (each of which must be at least min_segment_length pulses)
-        separated by max_pulse_gap or fewer invalid pulses will be joined
-        together.  This provides an easy way to ignore isolated gaps of a
-        single invlid pulse, for example.  Set to 0 to disable merging.
+        Segments (each lasting at least min_segment_fraction) separated by
+        max_pulse_gap or fewer invalid pulses will be joined together.  This
+        provides an easy way to ignore isolated gaps of a single invlid pulse,
+        for example.  Set to 0 to disable merging.
     blocksize : int, optional
         Number of rows to rasterize and write at a time.  Defaults to the
         chunk size of `image` if it is an HDF5 dataset, otherwise 512.
@@ -341,6 +377,9 @@ def save_valid_data_mask(rawlist, out_chan, grid, orbit, doppler, dem, azres,
         Total number of valid pixels in the image.
     """
     bit = int(_PolBit[out_chan.pol])
+
+    min_segment_length = _get_min_segment_length(min_segment_fraction, azres,
+        grid, orbit, dem.ellipsoid, _get_prf(rawlist))
 
     raw_bbox_lists, chirp_durations = get_raw_sub_swath_bboxes(rawlist,
         out_chan, orbit, num_ignore=num_ignore,

--- a/python/packages/nisar/focus/valid_regions.py
+++ b/python/packages/nisar/focus/valid_regions.py
@@ -1,0 +1,140 @@
+#!python3
+import logging
+import isce3
+from nisar.mixed_mode import find_overlapping_channel
+
+log = logging.getLogger("focus")
+
+def get_focused_sub_swaths(rawlist, out_chan, grid, orbit, doppler, dem, azres,
+                           rdr2geo_params=dict(), geo2rdr_params=dict(),
+                           ignore_failure=False, polygon_segment_length=50.0,
+                           num_ignore=25, max_observation_gap=0.002,
+                           min_segment_length=2000, max_pulse_gap=1):
+    """
+    Determine fully-focused regions of the image in a format suitable for
+    populating the validSamplesSubSwathX RSLC datasets.
+
+    Parameters
+    ----------
+    rawlist : list[nisar.products.readers.Raw.Raw]
+        List of raw data files (observations) that will be processed.
+    out_chan : nisar.mixed_mode.PolChannel
+        Desired channel to process (will be matched with available raw data
+        using mixed-mode logic).
+    grid : isce3.product.RadarGridParameters
+        Grid for focused image (zero-Doppler).
+    orbit : isce3.core.Orbit
+        Trajectory of antenna phase center.  Its time span must cover the entire
+        collection of raw data plus any reskew time offset between the native-
+        and zero-Doppler radar coordinate systems.
+    doppler : isce3.core.LUT2d
+        Doppler centroid of raw data, in Hz.
+    dem : isce3.geometry.DEMInterpolator
+        Digital elevation model.
+    azres : float
+        Processed azimuth resolution, in meters.
+    rdr2geo_params : dict
+        Parameters for rdr2geo_bracket
+    geo2rdr_params : dict
+        Parameters for geo2rdr_bracket
+    ignore_failure : bool
+        If set to True and isce3.focus.get_focused_sub_swaths fails for any
+        reason, then a mask corresponding to all-pixels-valid will be returned.
+        Otherwise an exception will be raised on failures.  This can be useful
+        for datasets where the orbit data covers all the raw data but without
+        enough extra for the reskew to the zero-Doppler image grid.
+    polygon_segment_length : float, optional
+        Length scale over which subswath boundary can be considered linear,
+        in meters.
+    num_ignore : int, optional
+        Number of pulses to ignore when calculating the valid data region at the
+        end of a fixed-PRF observation.  This is relevant when a fixed-PRF
+        observation is immediately followed by a dithered observation, as the
+        dithered pulses in the air will overlap the last few receive windows of
+        the fixed-PRF one.
+    max_observation_gap : float, optional
+        Max allowed time (in seconds) between the last pulse of one observation
+        and the first pulse of the following observation for the two to be
+        considered seamless.  Larger raw data gaps may result in a synthetic
+        aperture being marked invalid in the RSLC.
+    min_segment_length : int, optional
+        Segments with fewer than this number of consecutive valid pulses
+        will not be returned.  This helps avoid unnecessary bookkeeping when
+        lots of missing pulses are sprinkled throughout an observation. Must
+        be >= 2 pulses.
+    max_pulse_gap : int, optional
+        Segments (each of which must be at least min_segment_length pulses)
+        separated by max_pulse_gap or fewer invalid pulses will be joined
+        together.  This provides an easy way to ignore isolated gaps of a
+        single invlid pulse, for example.  Set to 0 to disable merging.
+
+    Returns
+    -------
+    swaths : numpy.ndarray[np.uint32]
+        Array of [start, stop) valid data regions, shape = (nswath, npulse, 2)
+        where nswath is the number of valid sub-swaths and npulse is the length
+        of the focused image grid.
+    """
+    # Need raw files sorted in time so we can reason about gaps between them.
+    rawlist = sorted(rawlist, key=lambda raw: raw.identification.zdStartTime)
+
+    raw_bbox_lists = []
+    chirp_durations = []
+    for raw in rawlist:
+        raw_chan = find_overlapping_channel(raw, out_chan)
+
+        freq = raw_chan.freq_id
+        bbox_lists = raw.getSubSwathBboxes(freq, epoch=orbit.reference_epoch,
+            num_ignore=num_ignore, min_segment_length=min_segment_length,
+            max_pulse_gap=max_pulse_gap)
+        raw_bbox_lists.extend(bbox_lists)
+
+        txpol = raw_chan.pol[0]
+        T = raw.getChirpParameters(freq, txpol)[3]
+        chirp_durations.extend(len(bbox_lists) * [T])
+
+    # Force azimuth continuity since Raw.getSubSwathBboxes doesn't know final
+    # PRI so there's a 1-pulse gap between observations.  Note that there
+    # should be no gap between 10-second DWP updates.
+    for i in range(len(raw_bbox_lists) - 1):
+        # Each subswath should have the same start/end time, just different
+        # ranges.
+        t_cur = raw_bbox_lists[i][0].last.time
+        t_next = raw_bbox_lists[i + 1][0].first.time
+        dt = t_next - t_cur
+        if dt <= max_observation_gap:
+            if dt > 0.0:
+                log.info(f"Merging observations separated by {dt * 1e6:.2f} us "
+                    f"at {orbit.reference_epoch + TimeDelta(t_cur)}")
+            elif dt < 0.0:
+                # The time difference should always be positive since there's at
+                # least one PRI between the end of one observation and the start
+                # of the next one.  However, as of 2026-05-04, L0B time stamps
+                # are derived from LRCLK counts using a model that's updated
+                # every downlink pass.  If the observations were downlinked on
+                # separate passes, it's conceivable that time could go backwards
+                # (though this would violate requirements).  If that happens it
+                # seems safe to assume that's a seamless transition, so just log
+                # it and proceed.
+                log.warning("Time decremented between observations.  "
+                    "Assuming seamless transition.")
+            for bbox in raw_bbox_lists[i]:
+                bbox.last.time = max(t_next, t_cur)
+        else:
+            log.warning(f"Gap between observations {dt:7f} s exceeds threshold "
+                f"for seamless observations ({max_observation_gap} s).")
+
+    try:
+        swaths = isce3.focus.get_focused_sub_swaths(raw_bbox_lists,
+            chirp_durations, orbit, doppler, azres, grid, dem=dem,
+            rdr2geo_params=rdr2geo_params, geo2rdr_params=geo2rdr_params,
+            max_segment_length=polygon_segment_length)
+    except Exception as e:
+        if ignore_failure:
+            log.error("Failed to calculate valid subswath masks!  "
+                "The entire radar grid will be assumed valid.")
+            swaths = np.zeros((1, grid.length, 2), dtype=np.uint32)
+            swaths[..., 1] = grid.width
+        else:
+            raise e
+    return swaths

--- a/python/packages/nisar/focus/valid_regions.py
+++ b/python/packages/nisar/focus/valid_regions.py
@@ -434,3 +434,20 @@ def save_valid_data_mask(rawlist, out_chan, grid, orbit, doppler, dem, azres,
         else:
             raise e
     return num_valid
+
+
+def get_valid_pulse_fraction(rawlist, out_chan, t0, t1, epoch):
+    num_valid, num_total = 0, 0
+    for raw in rawlist:
+        raw_chan = find_overlapping_channel(raw, out_chan)
+
+        _, t = raw.getPulseTimes(raw_chan.freq_id, tx=raw_chan.pol[0],
+            epoch=epoch)
+
+        pulse_mask = (t0 <= t) & (t < t1)
+        num_total += np.sum(pulse_mask)
+
+        valid_mask = raw.getValidPulses(raw_chan.freq_id, raw_chan.pol)
+        num_valid += np.sum(valid_mask & pulse_mask)
+            
+    return num_valid / num_total

--- a/python/packages/nisar/focus/valid_regions.py
+++ b/python/packages/nisar/focus/valid_regions.py
@@ -284,7 +284,7 @@ def _get_prf(rawlist, reduction=max):
     prf : float
         Pulse repetition frequency in Hz
     """
-    return reduction(1.0 / np.mean(np.diff(raw.getPulseTimes()))
+    return reduction(1.0 / np.mean(np.diff(raw.getPulseTimes()[1]))
         for raw in rawlist)
 
 

--- a/python/packages/nisar/focus/valid_regions.py
+++ b/python/packages/nisar/focus/valid_regions.py
@@ -40,7 +40,8 @@ class PolValidMask(enum.IntFlag):
 
 def get_raw_sub_swath_bboxes(rawlist, out_chan, orbit, num_ignore=25,
                              min_segment_length=2000, max_pulse_gap=1,
-                             max_observation_gap=0.002):
+                             max_observation_gap=0.002,
+                             use_rx_pulse_mask=False):
     """
     Determine bounding boxes of raw data sub-swaths for each observation,
     matched to the requested output channel, and force azimuth continuity
@@ -77,6 +78,11 @@ def get_raw_sub_swath_bboxes(rawlist, out_chan, orbit, num_ignore=25,
         and the first pulse of the following observation for the two to be
         considered seamless.  Larger raw data gaps may result in a synthetic
         aperture being marked invalid in the RSLC.
+    use_rx_pulse_mask : bool, optional
+        When True read the pulseHasValidSamples metadata to help determine
+        which pulses are valid for the receive polarization in `out_chan`.
+        Otherwise only the validSamplesSubSwath metadata will be used, which
+        is not specific to the receive polarization.
 
     Returns
     -------
@@ -96,9 +102,10 @@ def get_raw_sub_swath_bboxes(rawlist, out_chan, orbit, num_ignore=25,
         raw_chan = find_overlapping_channel(raw, out_chan)
 
         freq = raw_chan.freq_id
-        bbox_lists = raw.getSubSwathBboxes(freq, epoch=orbit.reference_epoch,
-            num_ignore=num_ignore, min_segment_length=min_segment_length,
-            max_pulse_gap=max_pulse_gap)
+        bbox_lists = raw.getSubSwathBboxes(freq, polarization=raw_chan.pol,
+            epoch=orbit.reference_epoch, num_ignore=num_ignore,
+            min_segment_length=min_segment_length, max_pulse_gap=max_pulse_gap,
+            use_rx_pulse_mask=use_rx_pulse_mask)
         raw_bbox_lists.extend(bbox_lists)
 
         txpol = raw_chan.pol[0]
@@ -338,7 +345,7 @@ def save_valid_data_mask(rawlist, out_chan, grid, orbit, doppler, dem, azres,
     raw_bbox_lists, chirp_durations = get_raw_sub_swath_bboxes(rawlist,
         out_chan, orbit, num_ignore=num_ignore,
         min_segment_length=min_segment_length, max_pulse_gap=max_pulse_gap,
-        max_observation_gap=max_observation_gap)
+        max_observation_gap=max_observation_gap, use_rx_pulse_mask=True)
 
     try:
         num_valid = isce3.focus.save_valid_data_mask(raw_bbox_lists,

--- a/python/packages/nisar/focus/valid_regions.py
+++ b/python/packages/nisar/focus/valid_regions.py
@@ -1,9 +1,112 @@
 #!python3
 import logging
 import isce3
+import numpy as np
 from nisar.mixed_mode import find_overlapping_channel
 
 log = logging.getLogger("focus")
+
+
+def get_raw_sub_swath_bboxes(rawlist, out_chan, orbit, num_ignore=25,
+                             min_segment_length=2000, max_pulse_gap=1,
+                             max_observation_gap=0.002):
+    """
+    Determine bounding boxes of raw data sub-swaths for each observation,
+    matched to the requested output channel, and force azimuth continuity
+    between observations that are seamless.
+
+    Parameters
+    ----------
+    rawlist : list[nisar.products.readers.Raw.Raw]
+        List of raw data files (observations) that will be processed.
+    out_chan : nisar.mixed_mode.PolChannel
+        Desired channel to process (will be matched with available raw data
+        using mixed-mode logic).
+    orbit : isce3.core.Orbit
+        Trajectory of antenna phase center.  Used only for its reference
+        epoch, to which raw data time stamps are converted.
+    num_ignore : int, optional
+        Number of pulses to ignore when calculating the valid data region at the
+        end of a fixed-PRF observation.  This is relevant when a fixed-PRF
+        observation is immediately followed by a dithered observation, as the
+        dithered pulses in the air will overlap the last few receive windows of
+        the fixed-PRF one.
+    min_segment_length : int, optional
+        Segments with fewer than this number of consecutive valid pulses
+        will not be returned.  This helps avoid unnecessary bookkeeping when
+        lots of missing pulses are sprinkled throughout an observation. Must
+        be >= 2 pulses.
+    max_pulse_gap : int, optional
+        Segments (each of which must be at least min_segment_length pulses)
+        separated by max_pulse_gap or fewer invalid pulses will be joined
+        together.  This provides an easy way to ignore isolated gaps of a
+        single invlid pulse, for example.  Set to 0 to disable merging.
+    max_observation_gap : float, optional
+        Max allowed time (in seconds) between the last pulse of one observation
+        and the first pulse of the following observation for the two to be
+        considered seamless.  Larger raw data gaps may result in a synthetic
+        aperture being marked invalid in the RSLC.
+
+    Returns
+    -------
+    raw_bbox_lists : list[list[isce3.focus.RadarBoundingBox]]
+        Bounding boxes of all subswaths for each raw data file/observation.
+        Azimuth times are specified in seconds relative to the orbit
+        reference epoch.
+    chirp_durations : list[float]
+        Duration of transmit chirp for each raw data file, in seconds.
+    """
+    # Need raw files sorted in time so we can reason about gaps between them.
+    rawlist = sorted(rawlist, key=lambda raw: raw.identification.zdStartTime)
+
+    raw_bbox_lists = []
+    chirp_durations = []
+    for raw in rawlist:
+        raw_chan = find_overlapping_channel(raw, out_chan)
+
+        freq = raw_chan.freq_id
+        bbox_lists = raw.getSubSwathBboxes(freq, epoch=orbit.reference_epoch,
+            num_ignore=num_ignore, min_segment_length=min_segment_length,
+            max_pulse_gap=max_pulse_gap)
+        raw_bbox_lists.extend(bbox_lists)
+
+        txpol = raw_chan.pol[0]
+        T = raw.getChirpParameters(freq, txpol)[3]
+        chirp_durations.extend(len(bbox_lists) * [T])
+
+    # Force azimuth continuity since Raw.getSubSwathBboxes doesn't know final
+    # PRI so there's a 1-pulse gap between observations.  Note that there
+    # should be no gap between 10-second DWP updates.
+    for i in range(len(raw_bbox_lists) - 1):
+        # Each subswath should have the same start/end time, just different
+        # ranges.
+        t_cur = raw_bbox_lists[i][0].last.time
+        t_next = raw_bbox_lists[i + 1][0].first.time
+        dt = t_next - t_cur
+        if dt <= max_observation_gap:
+            if dt > 0.0:
+                log.info(f"Merging observations separated by {dt * 1e6:.2f} us "
+                    f"at {orbit.reference_epoch + isce3.core.TimeDelta(t_cur)}")
+            elif dt < 0.0:
+                # The time difference should always be positive since there's at
+                # least one PRI between the end of one observation and the start
+                # of the next one.  However, as of 2026-05-04, L0B time stamps
+                # are derived from LRCLK counts using a model that's updated
+                # every downlink pass.  If the observations were downlinked on
+                # separate passes, it's conceivable that time could go backwards
+                # (though this would violate requirements).  If that happens it
+                # seems safe to assume that's a seamless transition, so just log
+                # it and proceed.
+                log.warning("Time decremented between observations.  "
+                    "Assuming seamless transition.")
+            for bbox in raw_bbox_lists[i]:
+                bbox.last.time = max(t_next, t_cur)
+        else:
+            log.warning(f"Gap between observations {dt:7f} s exceeds threshold "
+                f"for seamless observations ({max_observation_gap} s).")
+
+    return raw_bbox_lists, chirp_durations
+
 
 def get_focused_sub_swaths(rawlist, out_chan, grid, orbit, doppler, dem, azres,
                            rdr2geo_params=dict(), geo2rdr_params=dict(),
@@ -75,54 +178,10 @@ def get_focused_sub_swaths(rawlist, out_chan, grid, orbit, doppler, dem, azres,
         where nswath is the number of valid sub-swaths and npulse is the length
         of the focused image grid.
     """
-    # Need raw files sorted in time so we can reason about gaps between them.
-    rawlist = sorted(rawlist, key=lambda raw: raw.identification.zdStartTime)
-
-    raw_bbox_lists = []
-    chirp_durations = []
-    for raw in rawlist:
-        raw_chan = find_overlapping_channel(raw, out_chan)
-
-        freq = raw_chan.freq_id
-        bbox_lists = raw.getSubSwathBboxes(freq, epoch=orbit.reference_epoch,
-            num_ignore=num_ignore, min_segment_length=min_segment_length,
-            max_pulse_gap=max_pulse_gap)
-        raw_bbox_lists.extend(bbox_lists)
-
-        txpol = raw_chan.pol[0]
-        T = raw.getChirpParameters(freq, txpol)[3]
-        chirp_durations.extend(len(bbox_lists) * [T])
-
-    # Force azimuth continuity since Raw.getSubSwathBboxes doesn't know final
-    # PRI so there's a 1-pulse gap between observations.  Note that there
-    # should be no gap between 10-second DWP updates.
-    for i in range(len(raw_bbox_lists) - 1):
-        # Each subswath should have the same start/end time, just different
-        # ranges.
-        t_cur = raw_bbox_lists[i][0].last.time
-        t_next = raw_bbox_lists[i + 1][0].first.time
-        dt = t_next - t_cur
-        if dt <= max_observation_gap:
-            if dt > 0.0:
-                log.info(f"Merging observations separated by {dt * 1e6:.2f} us "
-                    f"at {orbit.reference_epoch + TimeDelta(t_cur)}")
-            elif dt < 0.0:
-                # The time difference should always be positive since there's at
-                # least one PRI between the end of one observation and the start
-                # of the next one.  However, as of 2026-05-04, L0B time stamps
-                # are derived from LRCLK counts using a model that's updated
-                # every downlink pass.  If the observations were downlinked on
-                # separate passes, it's conceivable that time could go backwards
-                # (though this would violate requirements).  If that happens it
-                # seems safe to assume that's a seamless transition, so just log
-                # it and proceed.
-                log.warning("Time decremented between observations.  "
-                    "Assuming seamless transition.")
-            for bbox in raw_bbox_lists[i]:
-                bbox.last.time = max(t_next, t_cur)
-        else:
-            log.warning(f"Gap between observations {dt:7f} s exceeds threshold "
-                f"for seamless observations ({max_observation_gap} s).")
+    raw_bbox_lists, chirp_durations = get_raw_sub_swath_bboxes(rawlist,
+        out_chan, orbit, num_ignore=num_ignore,
+        min_segment_length=min_segment_length, max_pulse_gap=max_pulse_gap,
+        max_observation_gap=max_observation_gap)
 
     try:
         swaths = isce3.focus.get_focused_sub_swaths(raw_bbox_lists,
@@ -138,3 +197,126 @@ def get_focused_sub_swaths(rawlist, out_chan, grid, orbit, doppler, dem, azres,
         else:
             raise e
     return swaths
+
+
+def _mark_all_valid(image, bit, blocksize=None):
+    """
+    Set `bit` in every pixel of `image`, writing in row blocks so the whole
+    array need not be held in memory at once.
+
+    Returns
+    -------
+    num_valid : int
+        Total number of pixels in the image.
+    """
+    nrows, ncols = image.shape
+    if blocksize is None:
+        blocksize = getattr(image, "chunks", (512,))[0]
+    mask = np.array(1 << bit, dtype=image.dtype)
+    for i0 in range(0, nrows, blocksize):
+        rows = slice(i0, min(i0 + blocksize, nrows))
+        block = image[rows] | mask
+        if hasattr(image, "write_direct"):
+            image.write_direct(block, None, rows)
+        else:
+            image[rows] = block
+    return nrows * ncols
+
+
+def save_valid_data_mask(rawlist, out_chan, grid, orbit, doppler, dem, azres,
+                         image, rdr2geo_params=dict(), geo2rdr_params=dict(),
+                         ignore_failure=False, polygon_segment_length=50.0,
+                         num_ignore=25, max_observation_gap=0.002,
+                         min_segment_length=2000, max_pulse_gap=1,
+                         blocksize=None, bit=0):
+    """
+    Determine fully-focused regions of the image and write the result as a
+    per-pixel boolean mask.
+
+    Parameters
+    ----------
+    rawlist : list[nisar.products.readers.Raw.Raw]
+        List of raw data files (observations) that will be processed.
+    out_chan : nisar.mixed_mode.PolChannel
+        Desired channel to process (will be matched with available raw data
+        using mixed-mode logic).
+    grid : isce3.product.RadarGridParameters
+        Grid for focused image (zero-Doppler).
+    orbit : isce3.core.Orbit
+        Trajectory of antenna phase center.  Its time span must cover the entire
+        collection of raw data plus any reskew time offset between the native-
+        and zero-Doppler radar coordinate systems.
+    doppler : isce3.core.LUT2d
+        Doppler centroid of raw data, in Hz.
+    dem : isce3.geometry.DEMInterpolator
+        Digital elevation model.
+    azres : float
+        Processed azimuth resolution, in meters.
+    image : array_like
+        Output boolean mask, must have shape matching `grid.shape`.  May be
+        an HDF5 dataset, in which case writes are chunk-aligned.  Should be
+        initialized to zero (at least in the bit position specified by `bit`).
+    rdr2geo_params : dict
+        Parameters for rdr2geo_bracket
+    geo2rdr_params : dict
+        Parameters for geo2rdr_bracket
+    ignore_failure : bool
+        If set to True and isce3.focus.save_valid_data_mask fails for any
+        reason, then the mask will be set to all-pixels-valid.  Otherwise an
+        exception will be raised on failures.  This can be useful for
+        datasets where the orbit data covers all the raw data but without
+        enough extra for the reskew to the zero-Doppler image grid.
+    polygon_segment_length : float, optional
+        Length scale over which subswath boundary can be considered linear,
+        in meters.
+    num_ignore : int, optional
+        Number of pulses to ignore when calculating the valid data region at the
+        end of a fixed-PRF observation.  This is relevant when a fixed-PRF
+        observation is immediately followed by a dithered observation, as the
+        dithered pulses in the air will overlap the last few receive windows of
+        the fixed-PRF one.
+    max_observation_gap : float, optional
+        Max allowed time (in seconds) between the last pulse of one observation
+        and the first pulse of the following observation for the two to be
+        considered seamless.  Larger raw data gaps may result in a synthetic
+        aperture being marked invalid in the RSLC.
+    min_segment_length : int, optional
+        Segments with fewer than this number of consecutive valid pulses
+        will not be returned.  This helps avoid unnecessary bookkeeping when
+        lots of missing pulses are sprinkled throughout an observation. Must
+        be >= 2 pulses.
+    max_pulse_gap : int, optional
+        Segments (each of which must be at least min_segment_length pulses)
+        separated by max_pulse_gap or fewer invalid pulses will be joined
+        together.  This provides an easy way to ignore isolated gaps of a
+        single invlid pulse, for example.  Set to 0 to disable merging.
+    blocksize : int, optional
+        Number of rows to rasterize and write at a time.  Defaults to the
+        chunk size of `image` if it is an HDF5 dataset, otherwise 512.
+    bit : int, optional
+        The bit to set in the output mask for valid pixels.
+
+    Returns
+    -------
+    num_valid : int
+        Total number of valid pixels in the image.
+    """
+    raw_bbox_lists, chirp_durations = get_raw_sub_swath_bboxes(rawlist,
+        out_chan, orbit, num_ignore=num_ignore,
+        min_segment_length=min_segment_length, max_pulse_gap=max_pulse_gap,
+        max_observation_gap=max_observation_gap)
+
+    try:
+        num_valid = isce3.focus.save_valid_data_mask(raw_bbox_lists,
+            chirp_durations, orbit, doppler, azres, grid, image, dem=dem,
+            rdr2geo_params=rdr2geo_params, geo2rdr_params=geo2rdr_params,
+            max_segment_length=polygon_segment_length, blocksize=blocksize,
+            bit=bit)
+    except Exception as e:
+        if ignore_failure:
+            log.error("Failed to calculate valid subswath mask!  "
+                "The entire radar grid will be assumed valid.")
+            num_valid = _mark_all_valid(image, bit, blocksize=blocksize)
+        else:
+            raise e
+    return num_valid

--- a/python/packages/nisar/focus/valid_regions.py
+++ b/python/packages/nisar/focus/valid_regions.py
@@ -67,7 +67,7 @@ def get_raw_sub_swath_bboxes(rawlist, out_chan, orbit, num_ignore=25,
         Segments with fewer than this number of consecutive valid pulses
         will not be returned.  This helps avoid unnecessary bookkeeping when
         lots of missing pulses are sprinkled throughout an observation. Must
-        be >= 2 pulses.
+        be >= 1 pulse.
     max_pulse_gap : int, optional
         Segments (each of which must be at least min_segment_length pulses)
         separated by max_pulse_gap or fewer invalid pulses will be joined
@@ -202,7 +202,7 @@ def get_focused_sub_swaths(rawlist, out_chan, grid, orbit, doppler, dem, azres,
         Segments with fewer than this number of consecutive valid pulses
         will not be returned.  This helps avoid unnecessary bookkeeping when
         lots of missing pulses are sprinkled throughout an observation. Must
-        be >= 2 pulses.
+        be >= 1 pulse.
     max_pulse_gap : int, optional
         Segments (each of which must be at least min_segment_length pulses)
         separated by max_pulse_gap or fewer invalid pulses will be joined
@@ -325,7 +325,7 @@ def save_valid_data_mask(rawlist, out_chan, grid, orbit, doppler, dem, azres,
         Segments with fewer than this number of consecutive valid pulses
         will not be returned.  This helps avoid unnecessary bookkeeping when
         lots of missing pulses are sprinkled throughout an observation. Must
-        be >= 2 pulses.
+        be >= 1 pulse.
     max_pulse_gap : int, optional
         Segments (each of which must be at least min_segment_length pulses)
         separated by max_pulse_gap or fewer invalid pulses will be joined

--- a/python/packages/nisar/focus/valid_regions.py
+++ b/python/packages/nisar/focus/valid_regions.py
@@ -1,10 +1,41 @@
 #!python3
+import enum
 import logging
 import isce3
 import numpy as np
 from nisar.mixed_mode import find_overlapping_channel
 
 log = logging.getLogger("focus")
+
+
+class _PolBit(enum.IntEnum):
+    """
+    Bit index assigned to each polarization channel in the valid-data mask
+    written by save_valid_data_mask.
+    """
+    HH = 0
+    HV = 1
+    VH = 2
+    VV = 3
+    LH = 4
+    LV = 5
+    RH = 6
+    RV = 7
+
+
+class PolValidMask(enum.IntFlag):
+    """
+    Bitmask value identifying which polarization channel(s) contributed a
+    valid pixel to the mask written by save_valid_data_mask.
+    """
+    HH = 1 << _PolBit.HH
+    HV = 1 << _PolBit.HV
+    VH = 1 << _PolBit.VH
+    VV = 1 << _PolBit.VV
+    LH = 1 << _PolBit.LH
+    LV = 1 << _PolBit.LV
+    RH = 1 << _PolBit.RH
+    RV = 1 << _PolBit.RV
 
 
 def get_raw_sub_swath_bboxes(rawlist, out_chan, orbit, num_ignore=25,
@@ -228,10 +259,12 @@ def save_valid_data_mask(rawlist, out_chan, grid, orbit, doppler, dem, azres,
                          ignore_failure=False, polygon_segment_length=50.0,
                          num_ignore=25, max_observation_gap=0.002,
                          min_segment_length=2000, max_pulse_gap=1,
-                         blocksize=None, bit=0):
+                         blocksize=None):
     """
     Determine fully-focused regions of the image and write the result as a
-    per-pixel boolean mask.
+    per-pixel boolean mask.  The bit used to mark valid pixels is chosen
+    according to `out_chan.pol` (see `PolValidMask`), so that mask images for
+    different polarization channels can be safely OR-ed into the same image.
 
     Parameters
     ----------
@@ -253,9 +286,10 @@ def save_valid_data_mask(rawlist, out_chan, grid, orbit, doppler, dem, azres,
     azres : float
         Processed azimuth resolution, in meters.
     image : array_like
-        Output boolean mask, must have shape matching `grid.shape`.  May be
-        an HDF5 dataset, in which case writes are chunk-aligned.  Should be
-        initialized to zero (at least in the bit position specified by `bit`).
+        Output mask, must have shape matching `grid.shape`.  May be an HDF5
+        dataset, in which case writes are chunk-aligned.  Should be
+        initialized to zero (at least in the bit position assigned to
+        `out_chan.pol`, see `PolValidMask`).
     rdr2geo_params : dict
         Parameters for rdr2geo_bracket
     geo2rdr_params : dict
@@ -293,14 +327,14 @@ def save_valid_data_mask(rawlist, out_chan, grid, orbit, doppler, dem, azres,
     blocksize : int, optional
         Number of rows to rasterize and write at a time.  Defaults to the
         chunk size of `image` if it is an HDF5 dataset, otherwise 512.
-    bit : int, optional
-        The bit to set in the output mask for valid pixels.
 
     Returns
     -------
     num_valid : int
         Total number of valid pixels in the image.
     """
+    bit = _PolBit[out_chan.pol]
+
     raw_bbox_lists, chirp_durations = get_raw_sub_swath_bboxes(rawlist,
         out_chan, orbit, num_ignore=num_ignore,
         min_segment_length=min_segment_length, max_pulse_gap=max_pulse_gap,

--- a/python/packages/nisar/focus/valid_regions.py
+++ b/python/packages/nisar/focus/valid_regions.py
@@ -437,6 +437,30 @@ def save_valid_data_mask(rawlist, out_chan, grid, orbit, doppler, dem, azres,
 
 
 def get_valid_pulse_fraction(rawlist, out_chan, t0, t1, epoch):
+    """
+    Compute the fraction of pulses with valid data samples in a given time
+    interval, across a group of raw data files.
+
+    Parameters
+    ----------
+    rawlist : list[nisar.products.readers.Raw.Raw]
+        List of raw data files (observations) that will be processed.
+    out_chan : nisar.mixed_mode.PolChannel
+        Desired channel to process (will be matched with available raw data
+        using mixed-mode logic).
+    t0 : float
+        Start of time interval, in seconds relative to `epoch`.
+    t1 : float
+        End of time interval (exclusive), in seconds relative to `epoch`.
+    epoch : isce3.core.DateTime
+        Time reference for `t0` and `t1`.
+
+    Returns
+    -------
+    fraction : float
+        Number of valid pulses in [t0, t1) divided by the total number of
+        pulses in [t0, t1), summed over all files in `rawlist`.
+    """
     num_valid, num_total = 0, 0
     for raw in rawlist:
         raw_chan = find_overlapping_channel(raw, out_chan)

--- a/python/packages/nisar/focus/valid_regions.py
+++ b/python/packages/nisar/focus/valid_regions.py
@@ -151,7 +151,7 @@ def get_focused_sub_swaths(rawlist, out_chan, grid, orbit, doppler, dem, azres,
                            rdr2geo_params=dict(), geo2rdr_params=dict(),
                            ignore_failure=False, polygon_segment_length=50.0,
                            num_ignore=25, max_observation_gap=0.002,
-                           min_segment_length=2000, max_pulse_gap=1):
+                           min_segment_fraction=0.25, max_pulse_gap=1):
     """
     Determine fully-focused regions of the image in a format suitable for
     populating the validSamplesSubSwathX RSLC datasets.
@@ -199,16 +199,18 @@ def get_focused_sub_swaths(rawlist, out_chan, grid, orbit, doppler, dem, azres,
         and the first pulse of the following observation for the two to be
         considered seamless.  Larger raw data gaps may result in a synthetic
         aperture being marked invalid in the RSLC.
-    min_segment_length : int, optional
+    min_segment_fraction : float, optional
+        Lower bound on the number of consecutive valid pulses, expressed as a
+        fraction of the synthetic aperture length.
         Segments with fewer than this number of consecutive valid pulses
         will not be returned.  This helps avoid unnecessary bookkeeping when
         lots of missing pulses are sprinkled throughout an observation. Must
         be >= 1 pulse.
     max_pulse_gap : int, optional
-        Segments (each of which must be at least min_segment_length pulses)
-        separated by max_pulse_gap or fewer invalid pulses will be joined
-        together.  This provides an easy way to ignore isolated gaps of a
-        single invlid pulse, for example.  Set to 0 to disable merging.
+        Segments (each lasting at least min_segment_fraction) separated by
+        max_pulse_gap or fewer invalid pulses will be joined together.  This
+        provides an easy way to ignore isolated gaps of a single invlid pulse,
+        for example.  Set to 0 to disable merging.
 
     Returns
     -------
@@ -217,6 +219,9 @@ def get_focused_sub_swaths(rawlist, out_chan, grid, orbit, doppler, dem, azres,
         where nswath is the number of valid sub-swaths and npulse is the length
         of the focused image grid.
     """
+    min_segment_length = _get_min_segment_length(min_segment_fraction, azres,
+        grid, orbit, dem.ellipsoid, _get_prf(rawlist))
+
     raw_bbox_lists, chirp_durations = get_raw_sub_swath_bboxes(rawlist,
         out_chan, orbit, num_ignore=num_ignore,
         min_segment_length=min_segment_length, max_pulse_gap=max_pulse_gap,

--- a/python/packages/nisar/focus/valid_regions.py
+++ b/python/packages/nisar/focus/valid_regions.py
@@ -290,6 +290,33 @@ def _get_prf(rawlist, reduction=max):
 
 def _get_min_segment_length(min_segment_fraction, azres, grid, orbit, ellipsoid,
                             prf):
+    """
+    Convert a minimum segment length, expressed as a fraction of the
+    synthetic aperture length, to a number of pulses.
+
+    Parameters
+    ----------
+    min_segment_fraction : float
+        Lower bound on the number of consecutive valid pulses, expressed as a
+        fraction of the synthetic aperture length.  Must be in (0, 1].
+    azres : float
+        Processed azimuth resolution, in meters.
+    grid : isce3.product.RadarGridParameters
+        Grid for focused image (zero-Doppler).  Used to estimate the
+        synthetic aperture length at midswath, end range.
+    orbit : isce3.core.Orbit
+        Trajectory of antenna phase center.
+    ellipsoid : isce3.core.Ellipsoid
+        Reference ellipsoid used to estimate the synthetic aperture length.
+    prf : float
+        Pulse repetition frequency, in Hz.
+
+    Returns
+    -------
+    min_segment_length : int
+        Lower bound on the number of consecutive valid pulses, in pulses.
+        Always >= 1.
+    """
     if not (0 < min_segment_fraction <= 1.0):
         raise ValueError("Expected 0 < min_segment_fraction <= 1 but got "
             f"{min_segment_fraction}")

--- a/python/packages/nisar/focus/valid_regions.py
+++ b/python/packages/nisar/focus/valid_regions.py
@@ -340,7 +340,7 @@ def save_valid_data_mask(rawlist, out_chan, grid, orbit, doppler, dem, azres,
     num_valid : int
         Total number of valid pixels in the image.
     """
-    bit = _PolBit[out_chan.pol]
+    bit = int(_PolBit[out_chan.pol])
 
     raw_bbox_lists, chirp_durations = get_raw_sub_swath_bboxes(rawlist,
         out_chan, orbit, num_ignore=num_ignore,

--- a/python/packages/nisar/products/readers/Raw/Raw.py
+++ b/python/packages/nisar/products/readers/Raw/Raw.py
@@ -1212,7 +1212,8 @@ def get_valid_pulse_mask(subswaths):
         least one sub-swath has a non-empty valid interval and False for
         pulses that are entirely within a transmit gap.
     """
-    return (subswaths[..., 1] - subswaths[..., 0]).sum(axis=0) > 0
+    # NOTE Avoid subtraction in case subswaths is unsigned.
+    return np.any(subswaths[..., 1] > subswaths[..., 0], axis=0)
 
 
 def find_valid_pulse_intervals(subswaths, min_segment_length=1, mask=None):

--- a/python/packages/nisar/products/readers/Raw/Raw.py
+++ b/python/packages/nisar/products/readers/Raw/Raw.py
@@ -673,8 +673,17 @@ class RawBase(Base, family='nisar.productreader.raw'):
             image.  True for rows with at least some valid data.
         """
         path_txrx = self._rawGroup(frequency, polarization)
+        name = "pulseHasValidSamples"
         with h5py.File(self.filename, 'r', libver='latest', swmr=True) as fid:
-            return fid[path_txrx]["pulseHasValidSamples"][()]
+            if name in fid[path_txrx]:
+                return fid[path_txrx][name][()]
+        # Kludge for old data that may lack this field: just return True for
+        # all pulses, which is equivalent to the old assumptions.
+        log.warning(f"L0B lacks dataset={name} so assuming all pulses valid "
+            f"for {frequency=} {polarization=}.  If possible, regenerate L0B "
+            "file with the latest software to get highest fidelity mask.")
+        _, t = self.getPulseTimes(frequency, tx=polarization[0])
+        return np.ones(len(t), bool)
 
     def getCaltone(self, frequency='A', polarization=None):
         """Get complex caltone coefficients for all channels and range lines.

--- a/python/packages/nisar/products/readers/Raw/Raw.py
+++ b/python/packages/nisar/products/readers/Raw/Raw.py
@@ -948,7 +948,7 @@ class RawBase(Base, family='nisar.productreader.raw'):
             Segments with fewer than this number of consecutive valid pulses
             will not be returned.  This helps avoid unnecessary bookkeeping when
             lots of missing pulses are sprinkled throughout an observation. Must
-            be >= 2 pulses.
+            be >= 1 pulse.
         max_pulse_gap : int, optional
             Segments (each of which must be at least min_segment_length pulses)
             separated by max_pulse_gap or fewer invalid pulses will be joined
@@ -966,10 +966,8 @@ class RawBase(Base, family='nisar.productreader.raw'):
             Bounding box in radar coordinates for each sub-swath for each
             segment of constant data window position/length.
         """
-        # Lower bound of two pulses (not one) so that we can look one pulse
-        # ahead in dithered case.
-        if min_segment_length < 2:
-            raise ValueError("Need at least two pulses per segment")
+        if min_segment_length < 1:
+            raise ValueError("Need at least one pulse per segment")
         if max_pulse_gap < 0:
             raise ValueError("max_pulse_gap must be non-negative")
         if polarization is None:
@@ -1046,10 +1044,10 @@ class RawBase(Base, family='nisar.productreader.raw'):
                 # If dithered peek ahead in case gap overlaps start or end of
                 # valid swath.  Only need to check one pulse ahead assuming
                 # dither sequence is correctly designed to avoid consecutive
-                # gaps.
-                if is_dithered:
+                # gaps.  Of course, only do this trick if the segment actually
+                # has a second pulse to check.
+                if is_dithered and ipulse1 > (ipulse0 + 1):
                     assert iswath == 0  # due to restructuring above
-                    assert ipulse0 < (nt - 1)  # since min_segment_length > 1
                     j0next = subswaths[iswath, ipulse0 + 1, 0]
                     j1next = subswaths[iswath, ipulse0 + 1, 1]
                     if j1next > j0next:

--- a/python/packages/nisar/products/readers/Raw/Raw.py
+++ b/python/packages/nisar/products/readers/Raw/Raw.py
@@ -1157,14 +1157,44 @@ class Raw(RawBase, family='nisar.productreader.raw'):
 
 def get_valid_pulse_mask(subswaths):
     """
-    TODO
+    Determine which pulses contain any valid (non-gap) echo data.
+
+    Parameters
+    ----------
+    subswaths : np.ndarray
+        Array of [start, end) valid sample indices with shape (ns, nt, 2)
+        where ns is the number of sub-swaths and nt is the number of pulse
+        times, as returned by `RawBase.getSubSwaths`.
+
+    Returns
+    -------
+    np.ndarray(bool)
+        1-D boolean array of length nt that is True for pulses where at
+        least one sub-swath has a non-empty valid interval and False for
+        pulses that are entirely within a transmit gap.
     """
     return (subswaths[..., 1] - subswaths[..., 0]).sum(axis=0) > 0
 
 
 def find_valid_pulse_intervals(subswaths, min_segment_length=1):
     """
-    TODO
+    Find runs of consecutive pulses that all contain valid echo data.
+
+    Parameters
+    ----------
+    subswaths : np.ndarray
+        Array of [start, end) valid sample indices with shape (ns, nt, 2)
+        where ns is the number of sub-swaths and nt is the number of pulse
+        times, as returned by `RawBase.getSubSwaths`.
+    min_segment_length : int, optional
+        Minimum number of consecutive valid pulses required for a run to be
+        included in the output.  Shorter runs are dropped.  Defaults to 1.
+
+    Returns
+    -------
+    list[tuple[int, int]]
+        List of (start, end) pulse index pairs, each describing a half-open
+        interval [start, end) of consecutive pulses with valid echo data.
     """
     have_echo = get_valid_pulse_mask(subswaths)
 
@@ -1186,7 +1216,27 @@ def find_valid_pulse_intervals(subswaths, min_segment_length=1):
 
 def split_segments(segments, breaks):
     """
-    TODO
+    Split segments at the given break points.
+
+    Parameters
+    ----------
+    segments : list[tuple[int, int]]
+        List of (start, end) pulse index pairs, each describing a half-open
+        interval [start, end) of pulses, as returned by
+        `find_valid_pulse_intervals`.
+    breaks : array_like[int]
+        Pulse indices at which any segment spanning that index should be
+        divided into two.  An index i strictly inside a segment (start,
+        end), i.e. start < i < end, splits it into (start, i) and (i, end).
+        Indices equal to a segment boundary or outside all segments have
+        no effect.
+
+    Returns
+    -------
+    list[tuple[int, int]]
+        Updated list of (start, end) segments, with any segments spanning a
+        break point divided accordingly.  Order matches the order of the
+        input segments.
     """
     updated_segments = []
     # NOTE It'd be more efficient to sort segments and breaks, then only
@@ -1205,7 +1255,31 @@ def split_segments(segments, breaks):
 
 def join_segments(segments, max_gap=0):
     """
-    TODO
+    Merge adjacent segments that are separated by only a small gap.
+
+    Parameters
+    ----------
+    segments : list[tuple[int, int]]
+        Sorted, non-overlapping list of (start, end) pulse index pairs, each
+        describing a half-open interval [start, end) of pulses, as returned
+        by `find_valid_pulse_intervals`.
+    max_gap : int, optional
+        Maximum number of pulses between the end of one segment and the
+        start of the next for the two segments to be merged into one.
+        Defaults to 0, meaning only directly adjacent (touching) segments
+        are merged.
+
+    Returns
+    -------
+    list[tuple[int, int]]
+        Updated list of (start, end) segments with gaps of at most max_gap
+        pulses joined together.
+
+    Raises
+    ------
+    ValueError
+        If the input segments are not sorted in increasing, non-overlapping
+        order.
     """
     if len(segments) < 2:
         return segments

--- a/python/packages/nisar/products/readers/Raw/Raw.py
+++ b/python/packages/nisar/products/readers/Raw/Raw.py
@@ -652,6 +652,30 @@ class RawBase(Base, family='nisar.productreader.raw'):
         with h5py.File(self.filename, 'r', libver='latest', swmr=True) as f:
             return f[path]["txPhase"][()]
 
+    def getValidPulses(self, frequency, polarization):
+        """Get valid pulse mask.
+
+        The mask reflects whether each pulse has any valid data samples.  The
+        result should be equivalent to reading each row of raw data and checking
+        whether all samples in the row are equal to the fill value.
+
+        Parameters
+        ----------
+        frequency : {'A', 'B'}
+            Sub-band.  Typically main science band is 'A'.
+        polarization : {'HH', 'HV', 'VH', 'VV', 'RH','RV', 'LH', 'LV'}
+            Transmit-Receive polarization.
+
+        Returns
+        -------
+        np.ndarray[bool]
+            Vector of boolean.  Length equal to number of rows in raw data
+            image.  True for rows with at least some valid data.
+        """
+        path_txrx = self._rawGroup(frequency, polarization)
+        with h5py.File(self.filename, 'r', libver='latest', swmr=True) as fid:
+            return fid[path_txrx]["pulseHasValidSamples"][()]
+
     def getCaltone(self, frequency='A', polarization=None):
         """Get complex caltone coefficients for all channels and range lines.
 

--- a/python/packages/nisar/products/readers/Raw/Raw.py
+++ b/python/packages/nisar/products/readers/Raw/Raw.py
@@ -890,7 +890,8 @@ class RawBase(Base, family='nisar.productreader.raw'):
         return swaths
 
 
-    def getSubSwathBboxes(self, frequency, polarization=None, epoch=None, num_ignore=0):
+    def getSubSwathBboxes(self, frequency, polarization=None, epoch=None,
+            num_ignore=0, min_segment_length=2000, max_pulse_gap=1):
         """
         Return the bounding box for each sub-swath.
 
@@ -909,6 +910,16 @@ class RawBase(Base, family='nisar.productreader.raw'):
             dithered-PRF one, in which case the gaps in the last few receive
             windows will have irregular spacing due to the dithered pulses in
             the air.
+        min_segment_length : int, optional
+            Segments with fewer than this number of consecutive valid pulses
+            will not be returned.  This helps avoid unnecessary bookkeeping when
+            lots of missing pulses are sprinkled throughout an observation. Must
+            be >= 2 pulses.
+        max_pulse_gap : int, optional
+            Segments (each of which must be at least min_segment_length pulses)
+            separated by max_pulse_gap or fewer invalid pulses will be joined
+            together.  This provides an easy way to ignore isolated gaps of a
+            single invlid pulse, for example.  Set to 0 to disable merging.
 
         Returns
         -------
@@ -916,6 +927,12 @@ class RawBase(Base, family='nisar.productreader.raw'):
             Bounding box in radar coordinates for each sub-swath for each
             segment of constant data window position/length.
         """
+        # Lower bound of two pulses (not one) so that we can look one pulse
+        # ahead in dithered case.
+        if min_segment_length < 2:
+            raise ValueError("Need at least two pulses per segment")
+        if max_pulse_gap < 0:
+            raise ValueError("max_pulse_gap must be non-negative")
         if polarization is None:
             polarization = self.polarizations[frequency][0]
         tx = polarization[0]
@@ -961,9 +978,10 @@ class RawBase(Base, family='nisar.productreader.raw'):
                 (1, -1, 2))
 
         # Find runs of consecutive pulses with valid echo data.
-        segments = find_valid_pulse_intervals(subswaths, min_segment_length=2000)  # TODO param
+        segments = find_valid_pulse_intervals(subswaths,
+            min_segment_length=min_segment_length)
         # Join any that are separated by just one pulse.
-        segments = join_segments(segments, max_gap=1)  # TODO param
+        segments = join_segments(segments, max_gap=max_pulse_gap)
         # Split segments at DWP change boundaries.  Then we'll have segments
         # of valid data with constant DWP.
         changes = get_dwp_change_indices(rd, wd, wl)

--- a/python/packages/nisar/products/readers/Raw/Raw.py
+++ b/python/packages/nisar/products/readers/Raw/Raw.py
@@ -960,14 +960,25 @@ class RawBase(Base, family='nisar.productreader.raw'):
             subswaths = np.vstack((min_starts, max_ends)).transpose().reshape(
                 (1, -1, 2))
 
+        # Find runs of consecutive pulses with valid echo data.
+        segments = find_valid_pulse_intervals(subswaths, min_segment_length=2000)  # TODO param
+        # Join any that are separated by just one pulse.
+        segments = join_segments(segments, max_gap=1)  # TODO param
+        # Split segments at DWP change boundaries.  Then we'll have segments
+        # of valid data with constant DWP.
         changes = get_dwp_change_indices(rd, wd, wl)
+        segments = split_segments(segments, changes)
 
         # Append first and last pulses to generate pairs of constant DWP.
-        breaks = np.hstack(([0], changes, [grid.shape[0] - 1]))
         bbox_lists = []
-        for ibreak in range(len(breaks) - 1):
-            ipulse0, ipulse1 = breaks[ibreak], breaks[ibreak + 1]
-            t0, t1 = times[ipulse0], times[ipulse1]  # one past end point
+        for ipulse0, ipulse1 in segments:
+            # Generally we want t1 equal to t0 of previous interval.  But for
+            # last interval we don't know the pulse time after the last pulse
+            # (PRI can vary within and between observations).  So last segment
+            # we'll report last pulse time and worry about mixed-mode case in
+            # higher level code.
+            ipulse1 = min(ipulse1, nt - 1)
+            t0, t1 = times[ipulse0], times[ipulse1]
             bboxes = []
             for iswath, (j0, j1) in enumerate(subswaths[:, ipulse0, :]):
                 # Exclude empty subswaths.
@@ -979,7 +990,7 @@ class RawBase(Base, family='nisar.productreader.raw'):
                 # gaps.
                 if is_dithered:
                     assert iswath == 0  # due to restructuring above
-                    assert ipulse0 < (nt - 1)  # from construction of breaks
+                    assert ipulse0 < (nt - 1)  # since min_segment_length > 1
                     j0next = subswaths[iswath, ipulse0 + 1, 0]
                     j1next = subswaths[iswath, ipulse0 + 1, 1]
                     if j1next > j0next:
@@ -1124,6 +1135,74 @@ class LegacyRaw(RawBase, family='nisar.productreader.raw'):
 class Raw(RawBase, family='nisar.productreader.raw'):
     # TODO methods for new telemetry fields.
     pass
+
+
+def get_valid_pulse_mask(subswaths):
+    """
+    TODO
+    """
+    return (subswaths[..., 1] - subswaths[..., 0]).sum(axis=0) > 0
+
+
+def find_valid_pulse_intervals(subswaths, min_segment_length=1):
+    """
+    TODO
+    """
+    have_echo = get_valid_pulse_mask(subswaths)
+
+    # Find boundaries where have_echo changes, padded so that the endpoints
+    # are considered properly.
+    x = np.zeros(len(have_echo) + 2, np.int8)
+    x[1:-1] = have_echo
+    dx = np.diff(x)
+
+    # An interval starts when we go from not having data to having data.
+    # Likewise, it ends when we go from having data to not having data.
+    starts = np.where(dx > 0)[0]
+    ends = np.where(dx < 0)[0]
+    assert len(starts) == len(ends)
+
+    return [(start, end) for (start, end) in zip(starts, ends)
+        if (end - start) >= min_segment_length]
+
+
+def split_segments(segments, breaks):
+    """
+    TODO
+    """
+    updated_segments = []
+    # NOTE It'd be more efficient to sort segments and breaks, then only
+    # iterate over relevant breaks indices in each segment.  Assume arrays
+    # are small enough we don't care about efficiency.
+    for start, end in segments:
+        for i in breaks:
+            # Don't check equality since that implies there's already a
+            # segment boundary at the desired location.
+            if start < i < end:
+                updated_segments.append((start, i))
+                start = i
+        updated_segments.append((start, end))
+    return updated_segments
+
+
+def join_segments(segments, max_gap=0):
+    """
+    TODO
+    """
+    if len(segments) < 2:
+        return segments
+    updated_segments = []
+    prev_start, prev_end = segments[0]
+    for cur_start, cur_end in segments[1:]:
+        if not (cur_start >= prev_end):
+            raise ValueError("expected sorted segments")
+        if cur_start - prev_end > max_gap:
+            updated_segments.append((prev_start, prev_end))
+            prev_start, prev_end = cur_start, cur_end
+        else:
+            prev_end = cur_end
+    updated_segments.append((prev_start, prev_end))
+    return updated_segments
 
 
 def get_dwp_change_indices(rd, wd, wl):

--- a/python/packages/nisar/products/readers/Raw/Raw.py
+++ b/python/packages/nisar/products/readers/Raw/Raw.py
@@ -915,7 +915,8 @@ class RawBase(Base, family='nisar.productreader.raw'):
 
 
     def getSubSwathBboxes(self, frequency, polarization=None, epoch=None,
-            num_ignore=0, min_segment_length=2000, max_pulse_gap=1):
+            num_ignore=0, min_segment_length=2000, max_pulse_gap=1,
+            use_rx_pulse_mask=False):
         """
         Return the bounding box for each sub-swath.
 
@@ -944,6 +945,11 @@ class RawBase(Base, family='nisar.productreader.raw'):
             separated by max_pulse_gap or fewer invalid pulses will be joined
             together.  This provides an easy way to ignore isolated gaps of a
             single invlid pulse, for example.  Set to 0 to disable merging.
+        use_rx_pulse_mask : bool, optional
+            When True read the pulseHasValidSamples metadata to help determine
+            which pulses are valid.  Otherwise only the validSamplesSubSwath
+            metadata will be used, which is not specific to the receive
+            polarization.
 
         Returns
         -------
@@ -1002,8 +1008,10 @@ class RawBase(Base, family='nisar.productreader.raw'):
                 (1, -1, 2))
 
         # Find runs of consecutive pulses with valid echo data.
+        rx_mask = (self.getValidPulses(frequency, polarization)
+            if use_rx_pulse_mask else None)
         segments = find_valid_pulse_intervals(subswaths,
-            min_segment_length=min_segment_length)
+            min_segment_length=min_segment_length, mask=rx_mask)
         # Join any that are separated by just one pulse.
         segments = join_segments(segments, max_gap=max_pulse_gap)
         # Split segments at DWP change boundaries.  Then we'll have segments
@@ -1200,7 +1208,7 @@ def get_valid_pulse_mask(subswaths):
     return (subswaths[..., 1] - subswaths[..., 0]).sum(axis=0) > 0
 
 
-def find_valid_pulse_intervals(subswaths, min_segment_length=1):
+def find_valid_pulse_intervals(subswaths, min_segment_length=1, mask=None):
     """
     Find runs of consecutive pulses that all contain valid echo data.
 
@@ -1213,6 +1221,9 @@ def find_valid_pulse_intervals(subswaths, min_segment_length=1):
     min_segment_length : int, optional
         Minimum number of consecutive valid pulses required for a run to be
         included in the output.  Shorter runs are dropped.  Defaults to 1.
+    mask : np.ndarray[bool], optional
+        Extra mask array indicating True for each valid pulse.  Will be ANDed
+        into the mask derived from the subswaths array.
 
     Returns
     -------
@@ -1221,6 +1232,8 @@ def find_valid_pulse_intervals(subswaths, min_segment_length=1):
         interval [start, end) of consecutive pulses with valid echo data.
     """
     have_echo = get_valid_pulse_mask(subswaths)
+    if mask is not None:
+        have_echo &= mask
 
     # Find boundaries where have_echo changes, padded so that the endpoints
     # are considered properly.

--- a/python/packages/nisar/products/readers/Raw/__init__.py
+++ b/python/packages/nisar/products/readers/Raw/__init__.py
@@ -7,6 +7,8 @@ from .Raw import (
     first_tx_pol_for_quad,
     opposite_linear_pol,
     caltone_frequency_from_raw,
-    range_delay_sequential_tx_from_raw
+    range_delay_sequential_tx_from_raw,
+    get_valid_pulse_mask,
+    find_valid_pulse_intervals
 )
 from .DataDecoder import complex32, DataDecoder

--- a/python/packages/nisar/products/writers/SLC.py
+++ b/python/packages/nisar/products/writers/SLC.py
@@ -14,6 +14,7 @@ from isce3.geometry import DEMInterpolator
 from isce3.product import get_radar_grid_nominal_ground_spacing
 from nisar.h5 import set_string
 from isce3.core.types import complex32
+from nisar.focus.valid_regions import PolValidMask
 from nisar.mixed_mode import PolChannelSet
 from nisar.products import descriptions
 from nisar.products.granule_id import get_polarization_code, format_datetime
@@ -526,26 +527,19 @@ class SLC(h5py.File):
         dset.attrs["units"] = np.bytes_("1")
         return dset
 
-    def create_valid_data_mask(self, frequency="A", **kw) -> h5py.Dataset:
-        log.info("Initializing storage for valid data mask for "
-            f"frequency={frequency} with HDF5 options={kw}")
-        kw.setdefault("dtype", np.uint8)
-        dset = self.swath(frequency).create_dataset("mask", **kw)
-        dset.attrs["description"] = np.bytes_("Bitwise OR of valid data mask "
-            "for each polarization.  High bit means the pixel is fully focused "
-            "(1:HH, 2:HV, 4:VH, 8:VV, 16:LH, 32:LV, 64:RH, 128:RV)")
-        dset.attrs["units"] = np.bytes_("1")
-        return dset
-
     def create_anomaly_mask(self, frequency="A", **kw) -> h5py.Dataset:
         log.info("Initializing storage for anomaly mask for "
             f"frequency={frequency} with HDF5 options={kw}")
-        kw.setdefault("dtype", np.uint8)
+        kw.setdefault("dtype", np.uint16)
         dset = self.swath(frequency).create_dataset("inputDataExceptionMask",
             **kw)
+        validity_description = ", ".join(f"{x.value}:{x.name}"
+            for x in PolValidMask)
         dset.attrs["description"] = np.bytes_("Bitwise OR of input data "
             "exception codes for each image pixel (0: no anomaly, 2: NISAR "
-            "LSAR qFSP-H1 sample slip)")
+            "LSAR qFSP-H1 sample slip).  Also includes OR of validity mask "
+            "bits, where each bit is set on for fully-focused data or off for "
+            f"partially focused or missing data ({validity_description})")
         dset.attrs["units"] = np.bytes_("1")
         return dset
 

--- a/python/packages/nisar/products/writers/SLC.py
+++ b/python/packages/nisar/products/writers/SLC.py
@@ -526,6 +526,17 @@ class SLC(h5py.File):
         dset.attrs["units"] = np.bytes_("1")
         return dset
 
+    def create_valid_data_mask(self, frequency="A", **kw) -> h5py.Dataset:
+        log.info("Initializing storage for valid data mask for "
+            f"frequency={frequency} with HDF5 options={kw}")
+        kw.setdefault("dtype", np.uint8)
+        dset = self.swath(frequency).create_dataset("mask", **kw)
+        dset.attrs["description"] = np.bytes_("Bitwise OR of valid data mask "
+            "for each polarization.  High bit means the pixel is fully focused "
+            "(1:HH, 2:HV, 4:VH, 8:VV, 16:LH, 32:LV, 64:RH, 128:RV)")
+        dset.attrs["units"] = np.bytes_("1")
+        return dset
+
     def create_anomaly_mask(self, frequency="A", **kw) -> h5py.Dataset:
         log.info("Initializing storage for anomaly mask for "
             f"frequency={frequency} with HDF5 options={kw}")

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1859,9 +1859,11 @@ def focus(runconfig, runconfig_path=""):
             log.info(f"Geting and saving valid data mask for {frequency}{pol}")
             pol_chan = [x for x in common_mode
                 if (x.freq_id == frequency and x.pol == pol)][0]
-            save_valid_data_mask(rawlist, pol_chan, og, orbit, dop[frequency],
-                dem, azres, mask, get_rdr2geo_params(cfg),
+            num_valid_pix = save_valid_data_mask(rawlist, pol_chan, og, orbit,
+                dop[frequency], dem, azres, mask, get_rdr2geo_params(cfg),
                 get_geo2rdr_params(cfg), **vars(cfg.processing.valid_data_mask))
+            frac_valid_pix = num_valid_pix / np.prod(og.shape)
+            mask.attrs[f"validPixelFraction{pol}"] = frac_valid_pix
 
     freq = next(iter(get_bands(common_mode)))
     slc.set_geolocation_grid(orbit, ogrid[freq], dop[freq],

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1586,7 +1586,8 @@ def get_output_range_spacings(rawlist: list[Raw], common_mode: PolChannelSet):
 def get_focused_sub_swaths(rawlist, out_chan, grid, orbit, doppler, dem, azres,
                            rdr2geo_params=dict(), geo2rdr_params=dict(),
                            ignore_failure=False, polygon_segment_length=50.0,
-                           num_ignore=25, max_observation_gap=0.002):
+                           num_ignore=25, max_observation_gap=0.002,
+                           min_segment_length=2000, max_pulse_gap=1):
     """
     Determine fully-focused regions of the image in a format suitable for
     populating the validSamplesSubSwathX RSLC datasets.
@@ -1634,6 +1635,16 @@ def get_focused_sub_swaths(rawlist, out_chan, grid, orbit, doppler, dem, azres,
         and the first pulse of the following observation for the two to be
         considered seamless.  Larger raw data gaps may result in a synthetic
         aperture being marked invalid in the RSLC.
+    min_segment_length : int, optional
+        Segments with fewer than this number of consecutive valid pulses
+        will not be returned.  This helps avoid unnecessary bookkeeping when
+        lots of missing pulses are sprinkled throughout an observation. Must
+        be >= 2 pulses.
+    max_pulse_gap : int, optional
+        Segments (each of which must be at least min_segment_length pulses)
+        separated by max_pulse_gap or fewer invalid pulses will be joined
+        together.  This provides an easy way to ignore isolated gaps of a
+        single invlid pulse, for example.  Set to 0 to disable merging.
 
     Returns
     -------
@@ -1652,7 +1663,8 @@ def get_focused_sub_swaths(rawlist, out_chan, grid, orbit, doppler, dem, azres,
 
         freq = raw_chan.freq_id
         bbox_lists = raw.getSubSwathBboxes(freq, epoch=orbit.reference_epoch,
-            num_ignore=num_ignore)
+            num_ignore=num_ignore, min_segment_length=min_segment_length,
+            max_pulse_gap=max_pulse_gap)
         raw_bbox_lists.extend(bbox_lists)
 
         txpol = raw_chan.pol[0]

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -39,6 +39,7 @@ from isce3.geometry import los2doppler
 from isce3.io.gdal import Raster, GDT_CFloat32
 from isce3.product import (RadarGridParameters,
     get_radar_grid_nominal_ground_spacing)
+from nisar.focus.valid_regions import get_focused_sub_swaths
 from nisar.workflows.yaml_argparse import YamlArgparse
 import nisar.workflows.helpers as helpers
 from ruamel.yaml import YAML
@@ -1583,141 +1584,6 @@ def get_output_range_spacings(rawlist: list[Raw], common_mode: PolChannelSet):
     return range_spacings
 
 
-def get_focused_sub_swaths(rawlist, out_chan, grid, orbit, doppler, dem, azres,
-                           rdr2geo_params=dict(), geo2rdr_params=dict(),
-                           ignore_failure=False, polygon_segment_length=50.0,
-                           num_ignore=25, max_observation_gap=0.002,
-                           min_segment_length=2000, max_pulse_gap=1):
-    """
-    Determine fully-focused regions of the image in a format suitable for
-    populating the validSamplesSubSwathX RSLC datasets.
-
-    Parameters
-    ----------
-    rawlist : list[Raw]
-        List of raw data files (observations) that will be processed.
-    out_chan : PolChannel
-        Desired channel to process (will be matched with available raw data
-        using mixed-mode logic).
-    grid : RadarGridParameters
-        Grid for focused image (zero-Doppler).
-    orbit : Orbit
-        Trajectory of antenna phase center.  Its time span must cover the entire
-        collection of raw data plus any reskew time offset between the native-
-        and zero-Doppler radar coordinate systems.
-    doppler : LUT2d
-        Doppler centroid of raw data, in Hz.
-    dem : DEMInterpolator
-        Digital elevation model.
-    azres : float
-        Processed azimuth resolution, in meters.
-    rdr2geo_params : dict
-        Parameters for rdr2geo_bracket
-    geo2rdr_params : dict
-        Parameters for geo2rdr_bracket
-    ignore_failure : bool
-        If set to True and isce3.focus.get_focused_sub_swaths fails for any
-        reason, then a mask corresponding to all-pixels-valid will be returned.
-        Otherwise an exception will be raised on failures.  This can be useful
-        for datasets where the orbit data covers all the raw data but without
-        enough extra for the reskew to the zero-Doppler image grid.
-    polygon_segment_length : float, optional
-        Length scale over which subswath boundary can be considered linear,
-        in meters.
-    num_ignore : int, optional
-        Number of pulses to ignore when calculating the valid data region at the
-        end of a fixed-PRF observation.  This is relevant when a fixed-PRF
-        observation is immediately followed by a dithered observation, as the
-        dithered pulses in the air will overlap the last few receive windows of
-        the fixed-PRF one.
-    max_observation_gap : float, optional
-        Max allowed time (in seconds) between the last pulse of one observation
-        and the first pulse of the following observation for the two to be
-        considered seamless.  Larger raw data gaps may result in a synthetic
-        aperture being marked invalid in the RSLC.
-    min_segment_length : int, optional
-        Segments with fewer than this number of consecutive valid pulses
-        will not be returned.  This helps avoid unnecessary bookkeeping when
-        lots of missing pulses are sprinkled throughout an observation. Must
-        be >= 2 pulses.
-    max_pulse_gap : int, optional
-        Segments (each of which must be at least min_segment_length pulses)
-        separated by max_pulse_gap or fewer invalid pulses will be joined
-        together.  This provides an easy way to ignore isolated gaps of a
-        single invlid pulse, for example.  Set to 0 to disable merging.
-
-    Returns
-    -------
-    swaths : numpy.ndarray[np.uint32]
-        Array of [start, stop) valid data regions, shape = (nswath, npulse, 2)
-        where nswath is the number of valid sub-swaths and npulse is the length
-        of the focused image grid.
-    """
-    # Need raw files sorted in time so we can reason about gaps between them.
-    rawlist = sorted(rawlist, key=lambda raw: raw.identification.zdStartTime)
-
-    raw_bbox_lists = []
-    chirp_durations = []
-    for raw in rawlist:
-        raw_chan = find_overlapping_channel(raw, out_chan)
-
-        freq = raw_chan.freq_id
-        bbox_lists = raw.getSubSwathBboxes(freq, epoch=orbit.reference_epoch,
-            num_ignore=num_ignore, min_segment_length=min_segment_length,
-            max_pulse_gap=max_pulse_gap)
-        raw_bbox_lists.extend(bbox_lists)
-
-        txpol = raw_chan.pol[0]
-        T = raw.getChirpParameters(freq, txpol)[3]
-        chirp_durations.extend(len(bbox_lists) * [T])
-
-    # Force azimuth continuity since Raw.getSubSwathBboxes doesn't know final
-    # PRI so there's a 1-pulse gap between observations.  Note that there
-    # should be no gap between 10-second DWP updates.
-    for i in range(len(raw_bbox_lists) - 1):
-        # Each subswath should have the same start/end time, just different
-        # ranges.
-        t_cur = raw_bbox_lists[i][0].last.time
-        t_next = raw_bbox_lists[i + 1][0].first.time
-        dt = t_next - t_cur
-        if dt <= max_observation_gap:
-            if dt > 0.0:
-                log.info(f"Merging observations separated by {dt * 1e6:.2f} us "
-                    f"at {orbit.reference_epoch + TimeDelta(t_cur)}")
-            elif dt < 0.0:
-                # The time difference should always be positive since there's at
-                # least one PRI between the end of one observation and the start
-                # of the next one.  However, as of 2026-05-04, L0B time stamps
-                # are derived from LRCLK counts using a model that's updated
-                # every downlink pass.  If the observations were downlinked on
-                # separate passes, it's conceivable that time could go backwards
-                # (though this would violate requirements).  If that happens it
-                # seems safe to assume that's a seamless transition, so just log
-                # it and proceed.
-                log.warning("Time decremented between observations.  "
-                    "Assuming seamless transition.")
-            for bbox in raw_bbox_lists[i]:
-                bbox.last.time = max(t_next, t_cur)
-        else:
-            log.warning(f"Gap between observations {dt:7f} s exceeds threshold "
-                f"for seamless observations ({max_observation_gap} s).")
-
-    try:
-        swaths = isce3.focus.get_focused_sub_swaths(raw_bbox_lists,
-            chirp_durations, orbit, doppler, azres, grid, dem=dem,
-            rdr2geo_params=rdr2geo_params, geo2rdr_params=geo2rdr_params,
-            max_segment_length=polygon_segment_length)
-    except Exception as e:
-        if ignore_failure:
-            log.error("Failed to calculate valid subswath masks!  "
-                "The entire radar grid will be assumed valid.")
-            swaths = np.zeros((1, grid.length, 2), dtype=np.uint32)
-            swaths[..., 1] = grid.width
-        else:
-            raise e
-    return swaths
-
-
 def get_caltone_algorithm(cfg, fc, fs, n, is_dithered):
     """Helper for configuring caltone removal.
 
@@ -2397,7 +2263,7 @@ def configure_logging():
     sh.setFormatter(fmt)
     log.addHandler(sh)
     for friend in ("Raw", "SLCWriter", "nisar.antenna.pattern", "rslc_cal",
-                   "isce3.focus.notch"):
+                   "isce3.focus.notch", "isce3.signal.rfi"):
         l = logging.getLogger(friend)
         l.setLevel(log_level)
         l.addHandler(sh)

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -39,7 +39,8 @@ from isce3.geometry import los2doppler
 from isce3.io.gdal import Raster, GDT_CFloat32
 from isce3.product import (RadarGridParameters,
     get_radar_grid_nominal_ground_spacing)
-from nisar.focus.valid_regions import get_focused_sub_swaths
+from nisar.focus.valid_regions import (get_focused_sub_swaths,
+    save_valid_data_mask)
 from nisar.workflows.yaml_argparse import YamlArgparse
 import nisar.workflows.helpers as helpers
 from ruamel.yaml import YAML
@@ -1842,15 +1843,25 @@ def focus(runconfig, runconfig_path=""):
         # Set anomaly mask. Need to do some geometry.
         opts = get_dataset_creation_options(cfg, og.shape)
         del opts["dtype"]
-        mask = slc.create_anomaly_mask(frequency, shape=og.shape, **opts)
+        qfsp_mask = slc.create_anomaly_mask(frequency, shape=og.shape, **opts)
         if instparser is not None:
             log.info(f"Writing inputDataExceptionMask for frequency{frequency}")
-            nisar.cal.qfsp_slip.write_anomaly_mask(anomaly_code, mask,
+            nisar.cal.qfsp_slip.write_anomaly_mask(anomaly_code, qfsp_mask,
                 og.sensing_times, og.slant_ranges, tn_lut, rn_lut, el_lut,
                 instparser)
         else:
             log.warning("Internal calibration (INT_CAL) file was not provided "
                 "so unable to populate inputDataExceptionMask")
+
+        # Set missing/valid data mask.
+        mask = slc.create_valid_data_mask(frequency, shape=og.shape, **opts)
+        for pol in pols:
+            log.info(f"Geting and saving valid data mask for {frequency}{pol}")
+            pol_chan = [x for x in common_mode
+                if (x.freq_id == frequency and x.pol == pol)][0]
+            save_valid_data_mask(rawlist, pol_chan, og, orbit, dop[frequency],
+                dem, azres, mask, get_rdr2geo_params(cfg),
+                get_geo2rdr_params(cfg), **vars(cfg.processing.valid_data_mask))
 
     freq = next(iter(get_bands(common_mode)))
     slc.set_geolocation_grid(orbit, ogrid[freq], dop[freq],

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1862,9 +1862,10 @@ def focus(runconfig, runconfig_path=""):
                 dop[frequency], dem, azres, mask, get_rdr2geo_params(cfg),
                 get_geo2rdr_params(cfg), **vars(cfg.processing.valid_data_mask))
             frac_valid_pix = num_valid_pix / np.prod(og.shape)
-            mask.attrs[f"validPixelFraction{pol}"] = frac_valid_pix
-            mask.attrs[f"validPulseFraction{pol}"] = get_valid_pulse_fraction(
-                rawlist, pol_chan, proc_begin, proc_end, og.ref_epoch)
+            mask.attrs[f"maskValidPixelFraction{pol}"] = frac_valid_pix
+            rawfrac = get_valid_pulse_fraction(rawlist, pol_chan, proc_begin,
+                proc_end, og.ref_epoch)
+            mask.attrs[f"rawValidPulseFraction{pol}"] = rawfrac
 
     freq = next(iter(get_bands(common_mode)))
     slc.set_geolocation_grid(orbit, ogrid[freq], dop[freq],

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1843,18 +1843,17 @@ def focus(runconfig, runconfig_path=""):
         # Set anomaly mask. Need to do some geometry.
         opts = get_dataset_creation_options(cfg, og.shape)
         del opts["dtype"]
-        qfsp_mask = slc.create_anomaly_mask(frequency, shape=og.shape, **opts)
+        mask = slc.create_anomaly_mask(frequency, shape=og.shape, **opts)
         if instparser is not None:
             log.info(f"Writing inputDataExceptionMask for frequency{frequency}")
-            nisar.cal.qfsp_slip.write_anomaly_mask(anomaly_code, qfsp_mask,
+            nisar.cal.qfsp_slip.write_anomaly_mask(anomaly_code, mask,
                 og.sensing_times, og.slant_ranges, tn_lut, rn_lut, el_lut,
                 instparser)
         else:
             log.warning("Internal calibration (INT_CAL) file was not provided "
                 "so unable to populate inputDataExceptionMask")
 
-        # Set missing/valid data mask.
-        mask = slc.create_valid_data_mask(frequency, shape=og.shape, **opts)
+        # Set missing/valid data mask (same dataset).
         for pol in pols:
             log.info(f"Geting and saving valid data mask for {frequency}{pol}")
             pol_chan = [x for x in common_mode

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -1855,7 +1855,7 @@ def focus(runconfig, runconfig_path=""):
 
         # Set missing/valid data mask (same dataset).
         for pol in pols:
-            log.info(f"Geting and saving valid data mask for {frequency}{pol}")
+            log.info(f"Getting and saving valid data mask for {frequency}{pol}")
             pol_chan = [x for x in common_mode
                 if (x.freq_id == frequency and x.pol == pol)][0]
             num_valid_pix = save_valid_data_mask(rawlist, pol_chan, og, orbit,

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -40,7 +40,7 @@ from isce3.io.gdal import Raster, GDT_CFloat32
 from isce3.product import (RadarGridParameters,
     get_radar_grid_nominal_ground_spacing)
 from nisar.focus.valid_regions import (get_focused_sub_swaths,
-    save_valid_data_mask)
+    save_valid_data_mask, get_valid_pulse_fraction)
 from nisar.workflows.yaml_argparse import YamlArgparse
 import nisar.workflows.helpers as helpers
 from ruamel.yaml import YAML
@@ -1863,6 +1863,8 @@ def focus(runconfig, runconfig_path=""):
                 get_geo2rdr_params(cfg), **vars(cfg.processing.valid_data_mask))
             frac_valid_pix = num_valid_pix / np.prod(og.shape)
             mask.attrs[f"validPixelFraction{pol}"] = frac_valid_pix
+            mask.attrs[f"validPulseFraction{pol}"] = get_valid_pulse_fraction(
+                rawlist, pol_chan, proc_begin, proc_end, og.ref_epoch)
 
     freq = next(iter(get_bands(common_mode)))
     slc.set_geolocation_grid(orbit, ogrid[freq], dop[freq],

--- a/share/nisar/defaults/focus.yaml
+++ b/share/nisar/defaults/focus.yaml
@@ -508,6 +508,19 @@ runconfig:
                 # RSLC.
                 max_observation_gap: 0.002
 
+                # Data segments with fewer than this number of consecutive valid
+                # pulses will be excluded from the valid data mask.  This helps
+                # avoid unnecessary bookkeeping when lots of missing pulses are
+                # sprinkled throughout an observation. Must be >= 2 pulses.
+                min_segment_length: 2000
+
+                # Data segments (each of which must be at least
+                # min_segment_length pulses) separated by max_pulse_gap or fewer
+                # invalid pulses will be joined together.  This provides an easy
+                # way to ignore isolated gaps of a single invlid pulse, for
+                # example.  Set to 0 to disable merging.
+                max_pulse_gap: 1
+
             caltone:
                 # If "azimuth_mean", subtract the azimuth mean from the raw
                 # data, which is useful when the caltone is nearly constant in

--- a/share/nisar/defaults/focus.yaml
+++ b/share/nisar/defaults/focus.yaml
@@ -511,7 +511,7 @@ runconfig:
                 # Data segments with fewer than this number of consecutive valid
                 # pulses will be excluded from the valid data mask.  This helps
                 # avoid unnecessary bookkeeping when lots of missing pulses are
-                # sprinkled throughout an observation. Must be >= 2 pulses.
+                # sprinkled throughout an observation. Must be >= 1 pulse.
                 min_segment_length: 2000
 
                 # Data segments (each of which must be at least

--- a/share/nisar/defaults/focus.yaml
+++ b/share/nisar/defaults/focus.yaml
@@ -508,17 +508,18 @@ runconfig:
                 # RSLC.
                 max_observation_gap: 0.002
 
-                # Data segments with fewer than this number of consecutive valid
+                # Data segments with less than this amount of consecutive valid
                 # pulses will be excluded from the valid data mask.  This helps
                 # avoid unnecessary bookkeeping when lots of missing pulses are
-                # sprinkled throughout an observation. Must be >= 1 pulse.
-                min_segment_length: 2000
+                # sprinkled throughout an observation.  Expressed as a fraction
+                # of the synthetic aperture length, values in (0, 1]
+                min_segment_fraction: 0.25
 
-                # Data segments (each of which must be at least
-                # min_segment_length pulses) separated by max_pulse_gap or fewer
-                # invalid pulses will be joined together.  This provides an easy
-                # way to ignore isolated gaps of a single invlid pulse, for
-                # example.  Set to 0 to disable merging.
+                # Data segments (each lasting at least min_segment_fraction)
+                # separated by max_pulse_gap or fewer invalid pulses will be
+                # joined together.  This provides an easy way to ignore isolated
+                # gaps of a single invlid pulse, for example.  Set to 0 to
+                # disable merging.
                 max_pulse_gap: 1
 
             caltone:

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -316,17 +316,18 @@ mask_options:
   # RSLC.
   max_observation_gap: num(min=0, required=False)
 
-  # Data segments with fewer than this number of consecutive valid
+  # Data segments with less than this amount of consecutive valid
   # pulses will be excluded from the valid data mask.  This helps
   # avoid unnecessary bookkeeping when lots of missing pulses are
-  # sprinkled throughout an observation. Must be >= 1 pulse.
-  min_segment_length: int(min=1, required=False)
+  # sprinkled throughout an observation.  Expressed as a fraction
+  # of the synthetic aperture length, values in (0, 1]
+  min_segment_fraction: num(min=0, max=1, required=False)
 
-  # Data segments (each of which must be at least
-  # min_segment_length pulses) separated by max_pulse_gap or fewer
-  # invalid pulses will be joined together.  This provides an easy
-  # way to ignore isolated gaps of a single invlid pulse, for
-  # example.  Set to 0 to disable merging.
+  # Data segments (each lasting at least min_segment_fraction)
+  # separated by max_pulse_gap or fewer invalid pulses will be
+  # joined together.  This provides an easy way to ignore isolated
+  # gaps of a single invlid pulse, for example.  Set to 0 to
+  # disable merging.
   max_pulse_gap: int(min=0, required=False)
 
 caltone_options:

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -316,6 +316,19 @@ mask_options:
   # RSLC.
   max_observation_gap: num(min=0, required=False)
 
+  # Data segments with fewer than this number of consecutive valid
+  # pulses will be excluded from the valid data mask.  This helps
+  # avoid unnecessary bookkeeping when lots of missing pulses are
+  # sprinkled throughout an observation. Must be >= 2 pulses.
+  min_segment_length: int(min=2, required=False)
+
+  # Data segments (each of which must be at least
+  # min_segment_length pulses) separated by max_pulse_gap or fewer
+  # invalid pulses will be joined together.  This provides an easy
+  # way to ignore isolated gaps of a single invlid pulse, for
+  # example.  Set to 0 to disable merging.
+  max_pulse_gap: int(min=0, required=False)
+
 caltone_options:
   frequency: num(min=0, required=False)
   algorithm: enum('wavelet', 'azimuth_mean', 'auto', 'disabled', required=False)

--- a/share/nisar/schemas/focus.yaml
+++ b/share/nisar/schemas/focus.yaml
@@ -319,8 +319,8 @@ mask_options:
   # Data segments with fewer than this number of consecutive valid
   # pulses will be excluded from the valid data mask.  This helps
   # avoid unnecessary bookkeeping when lots of missing pulses are
-  # sprinkled throughout an observation. Must be >= 2 pulses.
-  min_segment_length: int(min=2, required=False)
+  # sprinkled throughout an observation. Must be >= 1 pulse.
+  min_segment_length: int(min=1, required=False)
 
   # Data segments (each of which must be at least
   # min_segment_length pulses) separated by max_pulse_gap or fewer

--- a/tests/python/packages/isce3/focus/valid_regions.py
+++ b/tests/python/packages/isce3/focus/valid_regions.py
@@ -65,3 +65,15 @@ def test_valid_regions():
     # This means we don't expect an exact match.
     matching_fraction = np.sum(mask == expected) / np.prod(mask.shape)
     npt.assert_(matching_fraction > 0.99)
+
+    # Same check, but via save_valid_data_mask, which rasterizes the valid
+    # data polygons directly into a full-resolution mask instead of going
+    # through per-pulse start/stop indices.
+    full_mask = np.zeros(grid.shape, dtype=bool)
+    isce3.focus.save_valid_data_mask(raw_bbox_lists, chirp_durations, orbit,
+        doppler, azres, grid, full_mask, dem=dem,
+        rdr2geo_params=rdr2geo_params, geo2rdr_params=geo2rdr_params)
+
+    mask2 = full_mask[::looks_azimuth, ::looks_range][:mask.shape[0], :mask.shape[1]]
+    matching_fraction = np.sum(mask2 == expected) / np.prod(mask2.shape)
+    npt.assert_(matching_fraction > 0.99)


### PR DESCRIPTION
This is work in progress for improving the RSLC valid data mask. Currently, the RSLC mask only considers the transmit gaps and the range location of the swath (which may change every 10 s). We want it to also reflect missing data, typically echoes that were recorded on board but were lost in the downlink. Here's the contents of `validSamplesSubSwath1` for a missing data case using this branch as of today (green is start, red is stop):

<img width="727" height="735" alt="image" src="https://github.com/user-attachments/assets/0b840468-2bb1-4f65-9751-23241cd6ff25" />

Based on today's discussion the code needs substantial changes, but I thought it'd be helpful to open PR so it could be added to the delivery milestone, if nothing else. The core problem is that the existing metadata is not polarization-specific, so it can't represent polarization-specific missing data masks. Here are the changes we discussed:

- [ ] L0B should change how it populates its `validSamplesSubSwath1`. If the gap metadata is missing for one RX polarization but not the other, then it should be populated with the valid one.
- [ ] L0B should add new RX polarization specific 1D datasets called `pulseHasValidSamples` that report missing pulses. That saves users the trouble of reading the whole image and checking whether all the samples are fill_value in each row.
- [ ] RSLC `validSamplesSubSwath1` should basically just reflect the TX gaps and range timing as it currently does.
- [ ] RSLC should add new polarization-specific mask images to report missing data.