### PR TITLE
Improve definition of isMixedMode for RSLC

### DIFF
--- a/python/packages/nisar/mixed_mode/__init__.py
+++ b/python/packages/nisar/mixed_mode/__init__.py
@@ -1,3 +1,3 @@
 from .logic import (Band, null_band, PolChannel, PolChannelSet,
-	UnsupportedModeIntersection, find_overlapping_channel)
+	UnsupportedModeIntersection, find_overlapping_channel, check_mixed_mode)
 from .processing import get_common_band_filter

--- a/python/packages/nisar/mixed_mode/logic.py
+++ b/python/packages/nisar/mixed_mode/logic.py
@@ -256,3 +256,13 @@ def find_overlapping_channel(raw: RawBase, desired: PolChannel) -> PolChannel:
         if chan.intersection(desired).isvalid:
             return chan
     raise ValueError(f"Raw file does not contain channel intersecting {desired}.")
+
+
+def check_mixed_mode(modes: list[PolChannelSet]) -> bool:
+    """
+    Determine whether a list of modes represents a mixed-mode case.  True if any
+    mode doesn't match one of the others.
+    """
+    if len(modes) == 0:
+        return False
+    return any(mode != modes[0] for mode in modes)

--- a/python/packages/nisar/workflows/focus.py
+++ b/python/packages/nisar/workflows/focus.py
@@ -13,7 +13,7 @@ from nisar.antenna import AntennaPattern, get_calib_range_line_idx
 from nisar.noise.noise_estimation_from_raw import (
     est_noise_power_in_focus, NoiseEquivalentBackscatterProduct)
 from nisar.mixed_mode import (PolChannel, PolChannelSet, Band,
-    find_overlapping_channel)
+    find_overlapping_channel, check_mixed_mode)
 from nisar.products.readers.antenna import AntennaParser
 from nisar.products.readers.instrument import InstrumentParser
 from nisar.products.readers.Raw import (
@@ -1896,8 +1896,8 @@ def focus(runconfig, runconfig_path=""):
         is_full_frame=is_full_frame, frame_coverage=overlap,
         coverage_threshold=cfg.geometry.full_coverage_threshold_percent / 100,
         is_dithered=is_dithered, granule_id=granule_id,
-        is_mixed_mode=any(PolChannelSet.from_raw(raw) != common_mode
-            for raw in rawlist),
+        is_mixed_mode=check_mixed_mode([PolChannelSet.from_raw(raw)
+            for raw in rawlist]),
         **id_data)
     set_algorithm_metadata(cfg, slc, is_dithered)
     set_input_file_metadata(cfg, slc, runconfig_path)

--- a/tests/python/packages/nisar/mixed_mode/logic.py
+++ b/tests/python/packages/nisar/mixed_mode/logic.py
@@ -1,6 +1,6 @@
 import iscetest
 from nisar.mixed_mode import (Band, null_band, PolChannel, PolChannelSet,
-    find_overlapping_channel)
+    find_overlapping_channel, check_mixed_mode)
 from nisar.products.readers.Raw import Raw
 import numpy.testing as npt
 from pathlib import Path
@@ -176,3 +176,15 @@ def test_quasi_dual_5p5():
         PolChannel("A", "HH", L05),
         PolChannel("B", "VV", QQ5)
     ]))
+
+def test_is_mixed_mode():
+    mode = PolChannelSet([
+        PolChannel("B", "HH", L05),
+        PolChannel("B", "VV", QQ5)
+    ])
+    npt.assert_(check_mixed_mode([mode, mode]) == False)
+
+    mode_missing_h = PolChannelSet([
+        PolChannel("B", "VV", QQ5)
+    ])
+    npt.assert_(check_mixed_mode([mode, mode_missing_h]) == True)


### PR DESCRIPTION
We noticed an edge case where RSLC reports isMixedMode=True in the metadata, but the file name (determined by PCM) did not indicate a mixed mode product. It turned out PCM was correct. The test in RSLC was to check if any input mode differs from the output mode. Usually that works fine, but in cases like QD5+5 we have to re-label one of the frequency B images to frequency A so that the RSLC can correctly represent their distinct center frequencies. The fix in this PR is to just compare the input modes to each other rather than to the output mode.